### PR TITLE
Publish artifacts through Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,6 @@ jobs:
           api_key: $GITHUB_TOKEN
           file: client/build/libs/titan-client-$TRAVIS_TAG.jar
           draft: true
+          name: $TRAVIS_TAG
           on:
             tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,29 +19,31 @@ branches:
 
 jobs:
   include:
-    - stage: compile
-      name: "Compile"
-      install: skip
-      script:
-        - ./gradlew compileKotlin compileJava
-    - stage: check
-      name: "Style Checks"
-      install: skip
-      script:
-        - ./gradlew style
-    - name: "Unit Tests"
-      install: skip
-      script:
-        - ./gradlew test
-    - name: "Integration Tests"
-      install: skip
-      script:
-        - ./gradlew integrationTest
+#    - stage: compile
+#      name: "Compile"
+#      install: skip
+#      script:
+#        - ./gradlew compileKotlin compileJava
+#    - stage: check
+#      name: "Style Checks"
+#      install: skip
+#      script:
+#        - ./gradlew style
+#    - name: "Unit Tests"
+#      install: skip
+#      script:
+#        - ./gradlew test
+#    - name: "Integration Tests"
+#      install: skip
+#      script:
+#        - ./gradlew integrationTest
     - stage: publish
+      if: tag IS present
       name: "Publish Docker Image"
+      install:
+        - ./gradlew assemble -PserverImageName=$DOCKER_IMAGE -PtitanVersion=$TRAVIS_TAG
       before_deploy:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - ./gradlew shadowJar buildDockerServer -PserverImageName=$DOCKER_IMAGE
       deploy:
-        provider: script
-        script: ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=$DOCKER_IMAGE
+        - provider: script
+          script: ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=$DOCKER_IMAGE -PtitanVersion=$TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,29 +19,29 @@ branches:
 
 jobs:
   include:
-#    - stage: compile
-#      name: "Compile"
-#      install: skip
-#      script:
-#        - ./gradlew compileKotlin compileJava
-#    - stage: check
-#      name: "Style Checks"
-#      install: skip
-#      script:
-#        - ./gradlew style
-#    - name: "Unit Tests"
-#      install: skip
-#      script:
-#        - ./gradlew test
-#    - name: "Integration Tests"
-#      install: skip
-#      script:
-#        - ./gradlew integrationTest
+    - stage: compile
+      name: "Compile"
+      install: skip
+      script:
+        - ./gradlew compileKotlin compileJava
+    - stage: check
+      name: "Style Checks"
+      install: skip
+      script:
+        - ./gradlew style
+    - name: "Unit Tests"
+      install: skip
+      script:
+        - ./gradlew test
+    - name: "Integration Tests"
+      install: skip
+      script:
+        - ./gradlew integrationTest
     - stage: publish
+      name: "Publish Docker Image"
+      before_deploy:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - ./gradlew shadowJar buildDockerServer -PserverImageName=$DOCKER_IMAGE
       deploy:
         provider: script
-        name: "Publish Docker Image"
-        before_deploy:
-          - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          - ./gradlew shadowJar buildDockerServer -PserverImageName=$DOCKER_IMAGE
         script: ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=$DOCKER_IMAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-branches:
-  only:
-    - feature/publish
+#branches:
+#  only:
+#    - feature/publish
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,5 @@ jobs:
       deploy:
         - provider: script
           script: ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=$DOCKER_IMAGE -PtitanVersion=$TRAVIS_TAG
+          on:
+            tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,25 +15,33 @@ cache:
 
 branches:
   only:
-    - master
+    - feature/publish
 
 jobs:
   include:
-    - stage: compile
-      name: "Compile"
-      install: skip
-      script:
-        - ./gradlew compileKotlin compileJava
-    - stage: check
-      name: "Style Checks"
-      install: skip
-      script:
-        - ./gradlew style
-    - name: "Unit Tests"
-      install: skip
-      script:
-        - ./gradlew test
-    - name: "Integration Tests"
-      install: skip
-      script:
-        - ./gradlew integrationTest
+#    - stage: compile
+#      name: "Compile"
+#      install: skip
+#      script:
+#        - ./gradlew compileKotlin compileJava
+#    - stage: check
+#      name: "Style Checks"
+#      install: skip
+#      script:
+#        - ./gradlew style
+#    - name: "Unit Tests"
+#      install: skip
+#      script:
+#        - ./gradlew test
+#    - name: "Integration Tests"
+#      install: skip
+#      script:
+#        - ./gradlew integrationTest
+    - stage: publish
+      deploy:
+        provider: script
+        name: "Publish Docker Image"
+        before_deploy:
+          - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          - ./gradlew shadowJar buildDockerServer -PserverImageName=$DOCKER_IMAGE
+        script: ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=$DOCKER_IMAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,33 +13,29 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-#branches:
-#  only:
-#    - feature/publish
-
 jobs:
   include:
-#    - stage: compile
-#      name: "Compile"
-#      install: skip
-#      script:
-#        - ./gradlew compileKotlin compileJava
-#    - stage: check
-#      name: "Style Checks"
-#      install: skip
-#      script:
-#        - ./gradlew style
-#    - name: "Unit Tests"
-#      install: skip
-#      script:
-#        - ./gradlew test
-#    - name: "Integration Tests"
-#      install: skip
-#      script:
-#        - ./gradlew integrationTest
+    - stage: compile
+      name: "Compile"
+      install: skip
+      script:
+        - ./gradlew compileKotlin compileJava
+    - stage: check
+      name: "Style Checks"
+      install: skip
+      script:
+        - ./gradlew style
+    - name: "Unit Tests"
+      install: skip
+      script:
+        - ./gradlew test
+    - name: "Integration Tests"
+      install: skip
+      script:
+        - ./gradlew integrationTest
     - stage: publish
       if: tag IS present
-      name: "Publish Docker Image"
+      name: "Publish Artifacts"
       install:
         - ./gradlew assemble -PserverImageName=$DOCKER_IMAGE -PtitanVersion=$TRAVIS_TAG
       before_deploy:
@@ -47,5 +43,11 @@ jobs:
       deploy:
         - provider: script
           script: ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=$DOCKER_IMAGE -PtitanVersion=$TRAVIS_TAG
+          on:
+            tags: true
+        - provider: releases
+          api_key: $GITHUB_TOKEN
+          file: client/build/libs/titan-client-$TRAVIS_TAG.jar
+          draft: true
           on:
             tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,12 @@ jobs:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       deploy:
         - provider: script
+          skip_cleanup: true
           script: ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=$DOCKER_IMAGE -PtitanVersion=$TRAVIS_TAG
           on:
             tags: true
         - provider: releases
+          skip_cleanup: true
           api_key: $GITHUB_TOKEN
           file: client/build/libs/titan-client-$TRAVIS_TAG.jar
           draft: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,10 @@ plugins {
     id("com.github.ben-manes.versions") version("0.22.0")
 }
 
-val titanVersion by extra("0.3.2")
+val titanVersion by extra(when(project.hasProperty("titanVersion")) {
+    true -> project.property("titanVersion")
+    false -> "latest"
+})
 
 tasks.register("check")
 

--- a/server/gradle/docker.gradle.kts
+++ b/server/gradle/docker.gradle.kts
@@ -1,7 +1,12 @@
+val imageName = when(project.hasProperty("serverImageName")) {
+    true -> project.property("serverImageName")
+    false -> "titandata/titan"
+}
+
 var buildDockerServer = tasks.register<Exec>("buildDockerServer") {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Build docker server image"
-    commandLine("docker", "build", "--no-cache", "-t", "delphix/titan:latest", "-f", "${project.projectDir}/docker/server.Dockerfile", "${project.projectDir}")
+    commandLine("docker", "build", "--no-cache", "-t", "$imageName:latest", "-f", "${project.projectDir}/docker/server.Dockerfile", "${project.projectDir}")
     mustRunAfter(tasks.named("shadowJar"))
 }
 
@@ -9,28 +14,28 @@ var buildDockerServer = tasks.register<Exec>("buildDockerServer") {
 tasks.register<Exec>("rebuildDockerServer") {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Build docker server image"
-    commandLine("docker", "build", "-t", "delphix/titan:latest", "-f", "${project.projectDir}/docker/server.Dockerfile", "${project.projectDir}")
+    commandLine("docker", "build", "-t", "$imageName:latest", "-f", "${project.projectDir}/docker/server.Dockerfile", "${project.projectDir}")
     mustRunAfter(tasks.named("shadowJar"))
 }
 
 var tagDockerServer = tasks.register<Exec>("tagDockerServer") {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Tag docker server image with current version"
-    commandLine("docker", "tag", "delphix/titan:latest", "delphix/titan:${project.version}")
+    commandLine("docker", "tag", "$imageName:latest", "$imageName:${project.version}")
     mustRunAfter(tasks.named("buildDockerServer"))
 }
 
 var tagLocalDockerServer = tasks.register<Exec>("tagLocalDockerServer") {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Tag docker server image with current version"
-    commandLine("docker", "tag", "delphix/titan:latest", "titan:latest")
+    commandLine("docker", "tag", "$imageName:latest", "titan:latest")
     mustRunAfter(tasks.named("buildDockerServer"))
 }
 
 var buildSshServer = tasks.register<Exec>("buildSshTestServer") {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Build SSH endtoend server image"
-    commandLine("docker", "build", "-t", "delphix/sshtest:latest", "-f", "${project.projectDir}/docker/sshtest.Dockerfile", "${project.projectDir}")
+    commandLine("docker", "build", "-t", "sshtest:latest", "-f", "${project.projectDir}/docker/sshtest.Dockerfile", "${project.projectDir}")
 }
 
 tasks.named("assemble").configure {
@@ -46,14 +51,14 @@ tasks.named("endtoendTest").configure {
 var publishDockerVersion = tasks.register<Exec>("publishDockerVersion") {
     group = "Publishing"
     description = "Publish versioned docker server image to docker hub"
-    commandLine("docker", "push", "delphix/titan:${project.version}")
+    commandLine("docker", "push", "$imageName:${project.version}")
     mustRunAfter(tasks.named("tagDockerServer"))
 }
 
 var publishDockerLatest = tasks.register<Exec>("publishDockerLatest") {
     group = "Publishing"
     description = "Publish latest docker server image to docker hub"
-    commandLine("docker", "push", "delphix/titan:latest")
+    commandLine("docker", "push", "$imageName:latest")
     mustRunAfter(tasks.named("publishDockerVersion"))
 }
 

--- a/server/src/endtoend-test/kotlin/com/delphix/titan/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/com/delphix/titan/DockerUtil.kt
@@ -154,7 +154,7 @@ class DockerUtil(
 
     fun startSsh() {
         executor.exec("docker", "run", "-p", "$sshPort:22", "-d", "--name", "$identity-ssh",
-                "delphix/sshtest:latest")
+                "sshtest:latest")
     }
 
     fun testSsh(): Boolean {

--- a/server/src/scripts-test/test-util.sh
+++ b/server/src/scripts-test/test-util.sh
@@ -9,7 +9,7 @@ util_script=/test/src/scripts/util.sh
    source $util_script
    [ $IDENTITY = "titan" ]
    [ $PORT = "5001" ]
-   [ $IMAGE = "delphix/titan:latest" ]
+   [ $IMAGE = "titan:latest" ]
 }
 
 @test "user overrides propagated correctly" {
@@ -18,11 +18,11 @@ util_script=/test/src/scripts/util.sh
 
    export TITAN_IDENTITY=test
    export TITAN_PORT=6001
-   export TITAN_IMAGE=delphix/titan:test
+   export TITAN_IMAGE=titandata/titan:test
    source $util_script
    [ $IDENTITY = "test" ]
    [ $PORT = "6001" ]
-   [ $IMAGE = "delphix/titan:test" ]
+   [ $IMAGE = "titandata/titan:test" ]
 }
 
 @test "derived variables set correctly" {

--- a/server/src/scripts/util.sh
+++ b/server/src/scripts/util.sh
@@ -11,7 +11,7 @@
 #
 IDENTITY=${TITAN_IDENTITY:-titan}
 PORT=${TITAN_PORT:-5001}
-IMAGE=${TITAN_IMAGE:-delphix/titan:latest}
+IMAGE=${TITAN_IMAGE:-titan:latest}
 
 echo "=== User configuration ==="
 echo "IDENTITY = $IDENTITY"


### PR DESCRIPTION
## Proposed Changes

This adds support for publishing artifacts via the Travis job:

- titan-client library for use by the CLI (as GitHub release)
- titandata/titan docker image

This requires configuring the job with dockerhub and github credentials. We can explore GitHub packages when they become generally available to see if we can simplify this.

## Testing

Ran many jobs on my fork of the repo.