### PR TITLE
Feature/s3 client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ jobs:
           script: ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=$DOCKER_IMAGE -PtitanVersion=$TRAVIS_TAG
           on:
             tags: true
+        - provider :script
+          skip_cleanup: true
+          script: ./gradlew :client:publish
         - provider: releases
           skip_cleanup: true
           api_key: $GITHUB_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
           script: ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=$DOCKER_IMAGE -PtitanVersion=$TRAVIS_TAG
           on:
             tags: true
-        - provider :script
+        - provider: script
           skip_cleanup: true
           script: ./gradlew :client:publish
         - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ jobs:
         - provider: script
           skip_cleanup: true
           script: ./gradlew :client:publish
+          on:
+            tags: true
         - provider: releases
           skip_cleanup: true
           api_key: $GITHUB_TOKEN

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -47,8 +47,6 @@ publishing {
     }
 }
 
-val openapiVersion = "v4.0.2"
-
 dependencies {
     compile(kotlin("stdlib"))
     compile("com.squareup.okhttp3:okhttp:3.14.2")

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -4,9 +4,14 @@ plugins {
 }
 
 val titanVersion: String by rootProject.extra
+val mavenBucket = when(project.hasProperty("mavenBucket")) {
+    true -> project.property("mavenBucket")
+    false -> "titan-data-maven-tmp"
+}
 
 group = "io.titan-data.client"
 version = titanVersion
+
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -28,6 +33,16 @@ publishing {
             artifactId = "titan-client"
 
             from(components["java"])
+        }
+    }
+
+    repositories {
+        maven {
+            name = "titan"
+            url = uri("s3://$mavenBucket")
+            authentication {
+                create<AwsImAuthentication>("awsIm")
+            }
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

The previous process relied exclusively on publishing JARs to GitHub releases. This is not easily consumable by Maven, Gradle, and other build tools. Instead, we should publish to S3, with a proper maven structure and pom.xml dependency file.

## Testing

Built by hand and through travis.
