### PR TITLE
Fix titan version when publishing client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
             tags: true
         - provider: script
           skip_cleanup: true
-          script: ./gradlew :client:publish
+          script: ./gradlew :client:publish -PtitanVersion=$TRAVIS_TAG
           on:
             tags: true
         - provider: releases


### PR DESCRIPTION
## Proposed Changes

There was a typo in the travis configuration that wasn't setting the `titanVersion` variable properly when publishing the client.
