### PR TITLE
Update group ID

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -9,7 +9,7 @@ val mavenBucket = when(project.hasProperty("mavenBucket")) {
     false -> "titan-data-maven-tmp"
 }
 
-group = "io.titan-data.client"
+group = "io.titandata"
 version = titanVersion
 
 
@@ -29,7 +29,7 @@ val jar by tasks.getting(Jar::class) {
 publishing {
     publications {
         create<MavenPublication>("maven") {
-            groupId = "io.titan-data"
+            groupId = "io.titandata"
             artifactId = "titan-client"
 
             from(components["java"])

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 val titanVersion: String by rootProject.extra
-group = "io.titan-data"
+group = "io.titandata"
 version = titanVersion
 
 repositories {


### PR DESCRIPTION
## Proposed Changes

The previous changes had the group ID as "io.titan-data", which is invalid. This changes it to "io.titandata". Derek has also been hitting some issues with S3 and multiple commits, so this push adds an end2end test for that.

## Testing

Derek tested ability to pull in published pom files. I ran the S3Workflow end2end tests.