### PR TITLE
titan-server should not log sensitive information

### DIFF
--- a/server/src/integration-test/kotlin/io/titandata/RemotesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RemotesApiTest.kt
@@ -26,6 +26,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
+import io.mockk.mockk
 import io.mockk.verify
 import io.titandata.remote.engine.EngineRemoteProvider
 import io.titandata.storage.zfs.ZfsStorageProvider
@@ -101,6 +102,8 @@ class RemotesApiTest : StringSpec() {
         }
 
         "create remote succeeds" {
+            every { executor.start(*anyVararg()) } returns mockk()
+            every { executor.exec(any<Process>(), any()) } returns ""
             every { executor.exec(*anyVararg()) } returns "-"
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/repo/remotes") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -110,7 +113,7 @@ class RemotesApiTest : StringSpec() {
                 response.content shouldBe "{\"provider\":\"nop\",\"name\":\"a\"}"
 
                 verify {
-                    executor.exec("zfs", "set",
+                    executor.start("zfs", "set",
                             "io.titan-data:remotes=[{\"provider\":\"nop\",\"name\":\"a\"}]",
                             "test/repo/repo")
                 }
@@ -118,6 +121,8 @@ class RemotesApiTest : StringSpec() {
         }
 
         "add remote succeeds" {
+            every { executor.start(*anyVararg()) } returns mockk()
+            every { executor.exec(any<Process>(), any()) } returns ""
             every { executor.exec(*anyVararg()) } returns "[{\"provider\":\"nop\",\"name\":\"a\"}]"
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/repo/remotes") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -127,7 +132,7 @@ class RemotesApiTest : StringSpec() {
                 response.status() shouldBe HttpStatusCode.Created
 
                 verify {
-                    executor.exec("zfs", "set",
+                    executor.start("zfs", "set",
                             "io.titan-data:remotes=[{\"provider\":\"nop\",\"name\":\"a\"}," +
                                     "{\"provider\":\"engine\",\"name\":\"bar\",\"address\":\"a\"," +
                                     "\"username\":\"u\",\"password\":\"p\"}]",
@@ -157,6 +162,8 @@ class RemotesApiTest : StringSpec() {
         }
 
         "update remote succeeds" {
+            every { executor.start(*anyVararg()) } returns mockk()
+            every { executor.exec(any<Process>(), any()) } returns ""
             every { executor.exec(*anyVararg()) } returns
                     "[{\"provider\":\"nop\",\"name\":\"foo\"}," +
                     "{\"provider\":\"engine\",\"name\":\"bar\",\"address\":\"a\"," +
@@ -170,7 +177,7 @@ class RemotesApiTest : StringSpec() {
                 response.content shouldBe "{\"provider\":\"engine\",\"name\":\"bar\",\"address\":\"b\"," +
                         "\"username\":\"u\",\"password\":\"p\"}"
                 verify {
-                    executor.exec("zfs", "set",
+                    executor.start("zfs", "set",
                             "io.titan-data:remotes=[{\"provider\":\"nop\",\"name\":\"foo\"}," +
                                     "{\"provider\":\"engine\",\"name\":\"bar\",\"address\":\"b\"," +
                                     "\"username\":\"u\",\"password\":\"p\"}]",
@@ -180,6 +187,8 @@ class RemotesApiTest : StringSpec() {
         }
 
         "rename remote succeeds" {
+            every { executor.start(*anyVararg()) } returns mockk()
+            every { executor.exec(any<Process>(), any()) } returns ""
             every { executor.exec(*anyVararg()) } returns
                     "[{\"provider\":\"nop\",\"name\":\"foo\"}," +
                     "{\"provider\":\"engine\",\"name\":\"bar\",\"address\":\"a\"," +
@@ -191,7 +200,7 @@ class RemotesApiTest : StringSpec() {
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 verify {
-                    executor.exec("zfs", "set",
+                    executor.start("zfs", "set",
                             "io.titan-data:remotes=[{\"provider\":\"nop\",\"name\":\"foo\"}," +
                                     "{\"provider\":\"engine\",\"name\":\"baz\",\"address\":\"b\"," +
                                     "\"username\":\"u\",\"password\":\"p\"}]",
@@ -215,6 +224,8 @@ class RemotesApiTest : StringSpec() {
         }
 
         "delete remote succeeds" {
+            every { executor.start(*anyVararg()) } returns mockk()
+            every { executor.exec(any<Process>(), any()) } returns ""
             every { executor.exec(*anyVararg()) } returns
                     "[{\"provider\":\"nop\",\"name\":\"foo\"}," +
                     "{\"provider\":\"engine\",\"name\":\"bar\",\"address\":\"a\"," +
@@ -223,7 +234,7 @@ class RemotesApiTest : StringSpec() {
                 response.status() shouldBe HttpStatusCode.NoContent
 
                 verify {
-                    executor.exec("zfs", "set",
+                    executor.start("zfs", "set",
                             "io.titan-data:remotes=[{\"provider\":\"nop\",\"name\":\"foo\"}]",
                             "test/repo/repo")
                 }

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsOperationManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsOperationManager.kt
@@ -48,8 +48,7 @@ class ZfsOperationManager(val provider: ZfsStorageProvider) {
         val id = data.operation.id
         provider.cloneCommit(repo, guid, commit, id)
         val json = provider.gson.toJson(data)
-        provider.executor.exec("zfs", "set", "$OPERATION_PROP=$json",
-                "$poolName/repo/$repo/$id")
+        provider.secureZfsSet(OPERATION_PROP, json, "$poolName/repo/$repo/$id")
     }
 
     /**
@@ -142,7 +141,7 @@ class ZfsOperationManager(val provider: ZfsStorageProvider) {
         op.operation.state = state
         val json = provider.gson.toJson(op)
 
-        provider.executor.exec("zfs", "set", "$OPERATION_PROP=$json", "$poolName/repo/$repo/$id")
+        provider.secureZfsSet(OPERATION_PROP, json, "$poolName/repo/$repo/$id")
     }
 
     /**

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsRepositoryManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsRepositoryManager.kt
@@ -213,7 +213,7 @@ class ZfsRepositoryManager(val provider: ZfsStorageProvider) {
         provider.validateRepositoryName(repo)
         try {
             val json = provider.gson.toJson(remotes)
-            provider.executor.exec("zfs", "set", "$REMOTES_PROP=$json", "$poolName/repo/$repo")
+            provider.secureZfsSet(REMOTES_PROP, json, "$poolName/repo/$repo")
         } catch (e: CommandException) {
             provider.checkNoSuchRepository(e, repo)
             throw e

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -242,6 +242,18 @@ class ZfsStorageProvider(
         }
     }
 
+    /**
+     * This is a helper function that is used for "zfs set" operations that can contain sensitive information
+     * (such as credentials in remotes or remote parameters). We apply a large hammer here and just blank out
+     * the whole value. If this proves problematic, then we can implement a more fine-grained scheme that pulls in
+     * more of the remote-specific context to only blank out sensitive fields.
+     */
+    fun secureZfsSet(property: String, value: String, target: String): String {
+        val process = executor.start("zfs", "set", "$property=$value", target)
+        val argString = "zfs, set, $property=*****, $target"
+        return executor.exec(process, argString)
+    }
+
     /*
      * The remainder of this class simply redirects methods to the appropriate helper class. They
      * are all annotated as synchronized as a simple (if incomplete) guard to prevent concurrent

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
@@ -19,6 +19,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
+import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
 import io.titandata.exception.CommandException
@@ -294,14 +295,15 @@ class ZfsRepositoryTest : StringSpec() {
         }
 
         "update remotes succeeds" {
+            every { executor.start(*anyVararg()) } returns mockk()
+            every { executor.exec(any<Process>(), any()) } returns ""
             every { executor.exec(*anyVararg()) } returns ""
             provider.updateRemotes("repo", listOf(NopRemote(name = "foo")))
-            verifySequence {
-                executor.exec("zfs", "set",
+            verify {
+                executor.start("zfs", "set",
                         "io.titan-data:remotes=[{\"provider\":\"nop\",\"name\":\"foo\"}]",
                         "test/repo/repo")
             }
-            confirmVerified()
         }
     }
 }


### PR DESCRIPTION
## Issues Addressed

Fixes #10 

## Proposed Changes

The only place we have sensitive information is in remote configuration, and the only place those are logged is when we run "zfs set". This change creates a wrapper method to safely set properties by obscuring the values. I considered more complex changes that would involve different JSON serialization contexts, etc, but decided it was overkill for what we need right now.

## Testing

`gradle build endtoendTest`

Also looked at the logs during the end to end tests and made sure we were obscuring values, such as:

```
2019-09-23 23:09:09.731 [DefaultDispatcher-worker-5] ERROR io.titandata.util.CommandExecutor - Exit 1: zfs set io.titan-data:remotes=***** test/repo/foo
```