### PR TITLE
End to end tests should capture docker logs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,7 @@ on: push
 jobs:
   build:
     name: Build and test
+    if: startsWith(github.ref, 'refs/heads/')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,7 @@ on: push
 jobs:
   build:
     name: Build and test
+    if: github.ref == ''
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,6 @@ on: push
 jobs:
   build:
     name: Build and test
-    if: github.ref == null
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ on: push
 jobs:
   build:
     name: Build and test
-    if: github.ref == ''
+    if: github.ref == null
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,3 +19,7 @@ jobs:
           java-version: '8.0.212'
       - name: Build and test
         run: ./gradlew build
+      - name: Display uname
+        run: uname -a
+      - name: End to End tests
+        run: ./gradlew endtoendTest --tests *LocalWorkflowTest*

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: '8.0.212'
       - name: Build and test
         run: ./gradlew build
-      - name: Display uname
-        run: uname -a
       - name: End to End tests
-        run: ./gradlew endtoendTest --tests *LocalWorkflowTest*
+        run: |
+          uname -a
+          ./gradlew endtoendTest --tests *LocalWorkflowTest*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@
 #
 name: Release
 
-on: create
+on:
+  push: tags
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,7 @@
 #
 name: Release
 
-on:
-  push: tags
+on: create
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
           java-version: '8.0.212'
       - name: Build and test
         run: ./gradlew build -PserverImageName=docker.pkg.github.com/$GITHUB_REPOSITORY/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
+      - name: End to End tests
+        run: |
+          uname -a
+          ./gradlew endtoendTest --tests *LocalWorkflowTest*
       #
       # GITHUB_TOKEN cannot currently be used for pushing docker images, so we
       # have to use a hard-coded secret instead.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   publish:
     name: Test and publish
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1

--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -10,6 +10,7 @@ import io.titandata.util.CommandExecutor
 import java.net.InetAddress
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.slf4j.LoggerFactory
 
 /**
  * Utility class for managing docker containers for integration tests. There are two types of
@@ -35,6 +36,11 @@ class DockerUtil(
     fun url(path: String): String {
         return "http://localhost:$port/v1/$path"
     }
+
+    companion object {
+        val log = LoggerFactory.getLogger(CommandExecutor::class.java)
+    }
+
 
     fun startTitan(entryPoint: String, daemon: Boolean): String {
         val args = mutableListOf("docker", "run", "--privileged", "--pid=host", "--network=host",
@@ -75,7 +81,14 @@ class DockerUtil(
         var tried = 1
         while (testGet() != 200) {
             if (tried++ == retries) {
-                throw Exception("Timed out waiting for server to start")
+                val process = executor.start("docker", "logs", "$identity-launch")
+                log.error(process.inputStream.bufferedReader().readText())
+                val stderr = process.errorStream.bufferedReader().readText()
+                try {
+                    throw Exception("Timed out waiting for server to start: " + stderr)
+                } finally {
+                    process.destroy()
+                }
             }
             Thread.sleep(timeout)
         }

--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -41,7 +41,6 @@ class DockerUtil(
         val log = LoggerFactory.getLogger(CommandExecutor::class.java)
     }
 
-
     fun startTitan(entryPoint: String, daemon: Boolean): String {
         val args = mutableListOf("docker", "run", "--privileged", "--pid=host", "--network=host",
                 "-v", "/var/lib:/var/lib", "-v", "/run/docker:/run/docker")


### PR DESCRIPTION
## Issues Addressed

Fixes #14 

## Proposed Changes

This adds some code to capture docker errors while running end to end tests. It also updates the actions to run endtoend tests on push and release. For now, we only are running the LocalWorkflowTest (hence not closing #13) as I'll need to do some community AWS work to set up a S3 bucket for the S3 tests. The docker logs aren't perfect - we don't get a splicing of both stdout and stderr together, but it's enough to make forward progress.

## Testing

Ran new actions on my fork, verified that end to end tests worked.