### PR TITLE
switch to dockerhub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           java-version: '8.0.212'
       - name: Build and test
-        run: ./gradlew build -PserverImageName=docker.pkg.github.com/$GITHUB_REPOSITORY/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
+        run: ./gradlew build -PserverImageName=titandata/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
       - name: End to End tests
         run: |
           uname -a
@@ -32,8 +32,8 @@ jobs:
       #
       - name: Publish docker image
         run: |
-          docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }} docker.pkg.github.com
-          ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=docker.pkg.github.com/$GITHUB_REPOSITORY/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
+          docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+          ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=titandata/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
       - name: Publish client jar
         run: >
           ./gradlew :client:publish -PmavenUrl=https://maven.pkg.github.com/$GITHUB_REPOSITORY


### PR DESCRIPTION
## Proposed Changes

Github private docker package registry is giving "unknown blob" errors, even though it worked when pushing to 'eschrock/titan-server'. Rather than debug this whole thing now, let's switch back to dockerhub and keep using the image path we were using before.

