### PR TITLE
publish maven artifacts to S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           java-version: '8.0.212'
       - name: Build and test
-        run: ./gradlew build -PserverImageName=eschrock/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
+        run: ./gradlew build -PserverImageName=titandata/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
       - name: End to End tests
         run: |
           uname -a
@@ -33,7 +33,7 @@ jobs:
       - name: Publish docker image
         run: |
           docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
-          ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=eschrock/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
+          ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=titandata/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
       - name: Publish client jar
         run: >
           ./gradlew :client:publish -PmavenBucket=${{ secrets.MAVEN_BUCKET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,14 @@ jobs:
       - name: Publish docker image
         run: |
           docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
-          ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=titandata/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
+          ./gradlew publishDockerVersion publishDockerLatest -PserverImageName=eschrock/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
       - name: Publish client jar
         run: >
-          ./gradlew :client:publish -PmavenUrl=https://maven.pkg.github.com/$GITHUB_REPOSITORY
-          -PmavenUser=x-access-token -PmavenPassword=${{ secrets.GITHUB_TOKEN }}
+          ./gradlew :client:publish -PmavenBucket=${{ secrets.MAVEN_BUCKET }}
           -PtitanVersion=${GITHUB_REF#refs/tags/}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Create release
         run: ./.github/scripts/draft-release.sh
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           java-version: '8.0.212'
       - name: Build and test
-        run: ./gradlew build -PserverImageName=titandata/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
+        run: ./gradlew build -PserverImageName=eschrock/titan -PtitanVersion=${GITHUB_REF#refs/tags/}
       - name: End to End tests
         run: |
           uname -a

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -4,17 +4,9 @@ plugins {
 }
 
 val titanVersion: String by rootProject.extra
-val mavenUrl = when(project.hasProperty("mavenUrl")) {
-    true -> project.property("mavenUrl")
-    false -> "https://maven.pkg.github.com/titan-data"
-}
-val mavenUser = when(project.hasProperty("mavenUser")) {
-    true -> project.property("mavenUser").toString()
-    false -> null
-}
-val mavenPassword = when(project.hasProperty("mavenPassword")) {
-    true -> project.property("mavenPassword").toString()
-    false -> null
+val mavenBucket = when(project.hasProperty("mavenBucket")) {
+    true -> project.property("mavenBucket")
+    false -> "titan-data-maven"
 }
 
 group = "io.titandata"
@@ -47,10 +39,9 @@ publishing {
     repositories {
         maven {
             name = "titan"
-            url = uri("$mavenUrl")
-            credentials {
-                username = mavenUser
-                password = mavenPassword
+            url = uri("s3://$mavenBucket")
+            authentication {
+                create<AwsImAuthentication>("awsIm")
             }
         }
     }


### PR DESCRIPTION
## Proposed Changes

Turns out that accessing the github package registry maven repository requires github credentials, which makes using anything within it quiet annoying. This switches us back to publishing to S3 until public read access is enabled for the github package registry.

## Testing

Pushed a tag to my fork and observed the artifacts built & published.
