### PR TITLE
endtoend tests for S3 and SSH

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,7 @@ jobs:
       - name: End to End tests
         run: |
           uname -a
-          ./gradlew endtoendTest --tests *LocalWorkflowTest*
+          ./gradlew endtoendTest --tests *LocalWorkflowTest* --tests *S3WorkflowTest* --tests *SshWorkflowTest* -Ps3.location=${{ secrets.S3_TEST_LOCATION }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,3 +27,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,3 +24,6 @@ jobs:
         run: |
           uname -a
           ./gradlew endtoendTest --tests *LocalWorkflowTest*
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
       #
       # GITHUB_TOKEN cannot currently be used for pushing docker images, so we
       # have to use a hard-coded secret instead.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,10 @@ jobs:
       - name: End to End tests
         run: |
           uname -a
-          ./gradlew endtoendTest --tests *LocalWorkflowTest*
+          ./gradlew endtoendTest --tests *LocalWorkflowTest* --tests *S3WorkflowTest* --tests *SshWorkflowTest* -Ps3.location=${{ secrets.S3_TEST_LOCATION }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       #
       # GITHUB_TOKEN cannot currently be used for pushing docker images, so we
       # have to use a hard-coded secret instead.

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
     testCompile("com.squareup.okhttp3:okhttp:3.14.2")
     testCompile("io.ktor:ktor-server-test-host:$ktorVersion")
-    testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.0")
+    testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
     testImplementation("io.mockk:mockk:1.9.3")
     testImplementation("org.apache.commons:commons-text:1.7")
 }


### PR DESCRIPTION
## Issues Addressed

Fixes #13 

## Proposed Changes

This adds support for running all of our endtoend tests, including the S3 and SSH tests. It relies on the new S3 test bucket that was added to the community infrastructure. Ideally, I shouldn't have to specifically include tests, they should just be skipped if the config isn't present. But kotlintest SkipTestException is not working as I'd expect (bug filed), so for now I explicitly call out the ones I want. This way we skip running the engine endtoend tests.

## Testing

Ran on my fork.