### PR TITLE
S3 provider doesn't work with MFA credentials

### DIFF
--- a/client/src/main/kotlin/io/titandata/models/S3Parameters.kt
+++ b/client/src/main/kotlin/io/titandata/models/S3Parameters.kt
@@ -8,5 +8,6 @@ data class S3Parameters(
     override var provider: String = "s3",
     var accessKey: String? = null,
     var secretKey: String? = null,
+    var sessionToken: String? = null,
     var region: String? = null
 ) : RemoteParameters()

--- a/client/src/main/kotlin/io/titandata/serialization/remote/S3RemoteUtil.kt
+++ b/client/src/main/kotlin/io/titandata/serialization/remote/S3RemoteUtil.kt
@@ -9,6 +9,7 @@ import io.titandata.models.RemoteParameters
 import io.titandata.models.S3Parameters
 import io.titandata.models.S3Remote
 import io.titandata.serialization.RemoteUtilProvider
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain
 import java.net.URI
@@ -102,6 +103,7 @@ class S3RemoteUtil : RemoteUtilProvider() {
 
         var accessKey = remote.accessKey
         var secretKey = remote.secretKey
+        var sessionToken:String? = null
         if (accessKey == null || secretKey == null) {
             val creds = DefaultCredentialsProvider.create().resolveCredentials()
             if (creds == null) {
@@ -112,6 +114,10 @@ class S3RemoteUtil : RemoteUtilProvider() {
             if (accessKey == null || secretKey == null) {
                 throw IllegalArgumentException("Unable to determine AWS credentials")
             }
+
+            if (creds is AwsSessionCredentials) {
+                sessionToken = creds.sessionToken()
+            }
         }
 
         var region = remote.region
@@ -119,6 +125,6 @@ class S3RemoteUtil : RemoteUtilProvider() {
             region = DefaultAwsRegionProviderChain().region?.id()
         }
 
-        return S3Parameters(accessKey = accessKey, secretKey = secretKey, region = region)
+        return S3Parameters(accessKey = accessKey, secretKey = secretKey, region = region, sessionToken = sessionToken)
     }
 }

--- a/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
@@ -4,8 +4,10 @@
 
 package io.titandata.remote.s3
 
+import com.amazonaws.auth.AWSSessionCredentials
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.auth.BasicSessionCredentials
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.AmazonS3Exception
@@ -48,7 +50,10 @@ class S3RemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() {
         val region = params.region ?: remote.region
             ?: throw IllegalArgumentException("missing region")
 
-        val creds = BasicAWSCredentials(accessKey, secretKey)
+        val creds = when(params.sessionToken) {
+            null -> BasicAWSCredentials(accessKey, secretKey)
+            else -> BasicSessionCredentials(accessKey, secretKey, params.sessionToken)
+        }
         val provider = AWSStaticCredentialsProvider(creds)
 
         return AmazonS3ClientBuilder.standard().withCredentials(provider).withRegion(region).build()!!

--- a/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
@@ -4,7 +4,6 @@
 
 package io.titandata.remote.s3
 
-import com.amazonaws.auth.AWSSessionCredentials
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.auth.BasicSessionCredentials
@@ -50,7 +49,7 @@ class S3RemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() {
         val region = params.region ?: remote.region
             ?: throw IllegalArgumentException("missing region")
 
-        val creds = when(params.sessionToken) {
+        val creds = when (params.sessionToken) {
             null -> BasicAWSCredentials(accessKey, secretKey)
             else -> BasicSessionCredentials(accessKey, secretKey, params.sessionToken)
         }

--- a/server/src/test/kotlin/io/titandata/serialization/S3RemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/serialization/S3RemoteTest.kt
@@ -209,7 +209,6 @@ class S3RemoteTest : StringSpec() {
                 params.secretKey shouldBe "secretKey"
                 params.sessionToken shouldBe "sessionToken"
                 params.region shouldBe "us-west-2"
-
             }
         }
     }

--- a/server/src/test/kotlin/io/titandata/serialization/S3RemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/serialization/S3RemoteTest.kt
@@ -5,6 +5,7 @@
 package io.titandata.serialization
 
 import com.google.gson.GsonBuilder
+import io.kotlintest.extensions.system.withEnvironment
 import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
@@ -192,6 +193,24 @@ class S3RemoteTest : StringSpec() {
             params.accessKey shouldBe "ACCESS"
             params.secretKey shouldBe "SECRET"
             params.region shouldBe "REGION"
+        }
+
+        "getting credentials from environment succeeds" {
+            withEnvironment(mapOf("AWS_ACCESS_KEY_ID" to "accessKey", "AWS_SECRET_ACCESS_KEY" to "secretKey",
+                    "AWS_REGION" to "us-west-2", "AWS_SESSION_TOKEN" to "sessionToken")) {
+                System.getenv("AWS_ACCESS_KEY_ID") shouldBe "accessKey"
+                System.getenv("AWS_SECRET_ACCESS_KEY") shouldBe "secretKey"
+                System.getenv("AWS_REGION") shouldBe "us-west-2"
+                System.getenv("AWS_SESSION_TOKEN") shouldBe "sessionToken"
+                val params = remoteUtil.getParameters(S3Remote(name = "name", bucket = "bucket", path = "path"))
+                params.shouldBeInstanceOf<S3Parameters>()
+                params as S3Parameters
+                params.accessKey shouldBe "accessKey"
+                params.secretKey shouldBe "secretKey"
+                params.sessionToken shouldBe "sessionToken"
+                params.region shouldBe "us-west-2"
+
+            }
         }
     }
 }

--- a/server/src/test/kotlin/io/titandata/serialization/SshRemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/serialization/SshRemoteTest.kt
@@ -7,7 +7,6 @@ package io.titandata.serialization
 import com.google.gson.GsonBuilder
 import io.kotlintest.TestCase
 import io.kotlintest.TestResult
-import io.kotlintest.extensions.system.withEnvironment
 import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow

--- a/server/src/test/kotlin/io/titandata/serialization/SshRemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/serialization/SshRemoteTest.kt
@@ -7,6 +7,7 @@ package io.titandata.serialization
 import com.google.gson.GsonBuilder
 import io.kotlintest.TestCase
 import io.kotlintest.TestResult
+import io.kotlintest.extensions.system.withEnvironment
 import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow


### PR DESCRIPTION
## Issues Addressed

Fixes #30 

## Proposed Changes

This fix will fetch the session token from the client and pass that to the server. Why you have to check the instance type of the object returned I don't know, but that's apparently the interface.

## Testing

After getting credentials from `aws sts get-session-token` and setting environment variables, with current titan:

```
$ titan clone s3://titan-data-demo/hello-world/postgres hello-world
Clone failed.
The AWS Access Key Id you provided does not exist in our records. (Service: Amazon S3; Status Code: 403; Error Code: InvalidAccessKeyId; Request ID: AE9AE0C236B7E357; S3 Extended Request ID: uKxN8c7SyScgymGk4i3BhzY9LMRcxCNJb4UFn9UeX3BVgRrCVXXGxNzd+vSXr0zwMAF7uXwFPyc=)
hello-world removed
```

With fix in place:

```
$ java -jar ./target/titan-0.3.1-jar-with-dependencies.jar clone s3://titan-data-demo/hello-world/postgres hello-world
Creating repository hello-world
Creating docker volume hello-world/v0 with path /var/lib/postgresql/data
Running controlled container hello-world
PULL 0f53a6a4-90ff-4f8c-843a-a6cce36f4f4f from origin RUNNING
Pulling 0f53a6a4-90ff-4f8c-843a-a6cce36f4f4f from 'origin'
Downloading archive for /var/lib/postgresql/data
null
Extracting archive for /var/lib/postgresql/data
null
PULL 0f53a6a4-90ff-4f8c-843a-a6cce36f4f4f from origin COMPLETE
Stopping container hello-world
Checkout 0f53a6a4-90ff-4f8c-843a-a6cce36f4f4f
Starting container hello-world
0f53a6a4-90ff-4f8c-843a-a6cce36f4f4f checked out
```