### PR TITLE
provide size information for commits

### DIFF
--- a/client/src/main/kotlin/io/titandata/client/apis/CommitsApi.kt
+++ b/client/src/main/kotlin/io/titandata/client/apis/CommitsApi.kt
@@ -12,6 +12,7 @@ import io.titandata.client.infrastructure.ResponseType
 import io.titandata.client.infrastructure.ServerException
 import io.titandata.client.infrastructure.Success
 import io.titandata.models.Commit
+import io.titandata.models.CommitStatus
 
 class CommitsApi(basePath: String = "http://localhost:5001") : ApiClient(basePath) {
 
@@ -103,6 +104,30 @@ class CommitsApi(basePath: String = "http://localhost:5001") : ApiClient(basePat
 
         return when (response.responseType) {
             ResponseType.Success -> (response as Success<*>).data as Commit
+            ResponseType.ClientError -> throw ClientException.fromResponse(gson, response)
+            ResponseType.ServerError -> throw ServerException.fromResponse(gson, response)
+            else -> throw NotImplementedError(response.responseType.toString())
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun getCommitStatus(repositoryName: String, commitId: String) : CommitStatus {
+        val localVariableBody: Any? = null
+        val localVariableQuery: Map<String,List<String>> = mapOf()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        val localVariableConfig = RequestConfig(
+                RequestMethod.GET,
+                "/v1/repositories/{repositoryName}/commits/{commitId}/status".replace("{" + "repositoryName" + "}", "$repositoryName").replace("{" + "commitId" + "}", "$commitId"),
+                query = localVariableQuery,
+                headers = localVariableHeaders
+        )
+        val response = request<CommitStatus>(
+                localVariableConfig,
+                localVariableBody
+        )
+
+        return when (response.responseType) {
+            ResponseType.Success -> (response as Success<*>).data as CommitStatus
             ResponseType.ClientError -> throw ClientException.fromResponse(gson, response)
             ResponseType.ServerError -> throw ServerException.fromResponse(gson, response)
             else -> throw NotImplementedError(response.responseType.toString())

--- a/client/src/main/kotlin/io/titandata/models/CommitStatus.kt
+++ b/client/src/main/kotlin/io/titandata/models/CommitStatus.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.models
+
+data class CommitStatus(
+    var logicalSize: Long,
+    var actualSize: Long,
+    var uniqueSize: Long
+)

--- a/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
@@ -170,6 +170,13 @@ class LocalWorkflowTest : EndToEndTest() {
             exception.code shouldBe "NoSuchObjectException"
         }
 
+        "get commit status succeeds" {
+            val status = commitApi.getCommitStatus("foo", "id")
+            status.logicalSize shouldNotBe 0
+            status.actualSize shouldNotBe 0
+            status.uniqueSize shouldBe 0
+        }
+
         "commit shows up in list" {
             val commits = commitApi.listCommits("foo")
             commits.size shouldBe 1

--- a/server/src/main/kotlin/io/titandata/apis/CommitsApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/CommitsApi.kt
@@ -50,6 +50,14 @@ fun Route.CommitsApi(providers: ProviderModule) {
         }
     }
 
+    route("/v1/repositories/{repositoryName}/commits/{commitId}/status") {
+        get {
+            val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
+            val commit = call.parameters["commitId"] ?: throw IllegalArgumentException("missing commit id parameter")
+            call.respond(providers.storage.getCommitStatus(repo, commit))
+        }
+    }
+
     route("/v1/repositories/{repositoryName}/commits/{commitId}/checkout") {
         post {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")

--- a/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
@@ -5,6 +5,7 @@
 package io.titandata.storage
 
 import io.titandata.models.Commit
+import io.titandata.models.CommitStatus
 import io.titandata.models.Operation
 import io.titandata.models.Remote
 import io.titandata.models.Repository
@@ -23,6 +24,7 @@ interface StorageProvider {
 
     fun createCommit(repo: String, commit: Commit): Commit
     fun getCommit(repo: String, id: String): Commit
+    fun getCommitStatus(repo: String, id: String): CommitStatus
     fun listCommits(repo: String): List<Commit>
     fun deleteCommit(repo: String, commit: String)
     fun checkoutCommit(repo: String, commit: String)

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -12,6 +12,7 @@ import io.titandata.exception.InvalidStateException
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Commit
+import io.titandata.models.CommitStatus
 import io.titandata.models.Operation
 import io.titandata.models.Remote
 import io.titandata.models.Repository
@@ -312,6 +313,11 @@ class ZfsStorageProvider(
     @Synchronized
     override fun getCommit(repo: String, id: String): Commit {
         return commitManager.getCommit(repo, id)
+    }
+
+    @Synchronized
+    override fun getCommitStatus(repo: String, id: String): CommitStatus {
+        return commitManager.getCommitStatus(repo, id)
     }
 
     @Synchronized


### PR DESCRIPTION
## Issues Addressed

Fixes #26 

## Proposed Changes

This adds a new "/status" endpoint to the commit API that returns a sum of the ZFS sizes for all the descendent snapshots of the commit. I used a separate endpoint because (a) this information is more expensive to calculate and (b) the commit structure is serialized in various forms and shouldn't really container "dynamic" information like sizes. I chose note to include a per-volume breakdown for now until someone tells us it would be useful.

## Testing

./gradle build endtoendTest