### PR TITLE
turn on compression

### DIFF
--- a/server/src/scripts/zfs.sh
+++ b/server/src/scripts/zfs.sh
@@ -155,7 +155,7 @@ function create_pool() {
   local mountpoint=$3
   local cachefile=$4
   zpool create -m $mountpoint -o cachefile=$cachefile $pool $data
-  zfs create -o mountpoint=none $pool/repo
+  zfs create -o mountpoint=none -o compression=lz4 $pool/repo
   zfs create -o mountpoint=none $pool/deathrow
 }
 


### PR DESCRIPTION
## Issues Addressed

Fixes #42 

## Proposed Changes

This fix turns on lz4 compression for all repositories. While we could add the capbility to turn this on for existing installations, given the current number of users it seems overkill to add that level of complexity. So this will only affect new installations.

## Testing

Build & end to end tests. Verified that compression is set:

```
zfs list -o name,compression
NAME            COMPRESS
titan                off
titan/deathrow       off
titan/repo           lz4
```