### PR TITLE
endpoint for reporting repository status

### DIFF
--- a/client/src/main/kotlin/io/titandata/client/apis/RepositoriesApi.kt
+++ b/client/src/main/kotlin/io/titandata/client/apis/RepositoriesApi.kt
@@ -12,6 +12,7 @@ import io.titandata.client.infrastructure.ResponseType
 import io.titandata.client.infrastructure.ServerException
 import io.titandata.client.infrastructure.Success
 import io.titandata.models.Repository
+import io.titandata.models.RepositoryStatus
 
 class RepositoriesApi(basePath: String = "http://localhost:5001") : ApiClient(basePath) {
 
@@ -80,6 +81,30 @@ class RepositoriesApi(basePath: String = "http://localhost:5001") : ApiClient(ba
 
         return when (response.responseType) {
             ResponseType.Success -> (response as Success<*>).data as Repository
+            ResponseType.ClientError -> throw ClientException.fromResponse(gson, response)
+            ResponseType.ServerError -> throw ServerException.fromResponse(gson, response)
+            else -> throw NotImplementedError(response.responseType.toString())
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun getRepositoryStatus(repositoryName: String) : RepositoryStatus {
+        val localVariableBody: Any? = null
+        val localVariableQuery: Map<String,List<String>> = mapOf()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        val localVariableConfig = RequestConfig(
+                RequestMethod.GET,
+                "/v1/repositories/{repositoryName}/status".replace("{" + "repositoryName" + "}", "$repositoryName"),
+                query = localVariableQuery,
+                headers = localVariableHeaders
+        )
+        val response = request<RepositoryStatus>(
+                localVariableConfig,
+                localVariableBody
+        )
+
+        return when (response.responseType) {
+            ResponseType.Success -> (response as Success<*>).data as RepositoryStatus
             ResponseType.ClientError -> throw ClientException.fromResponse(gson, response)
             ResponseType.ServerError -> throw ServerException.fromResponse(gson, response)
             else -> throw NotImplementedError(response.responseType.toString())

--- a/client/src/main/kotlin/io/titandata/models/RepositoryStatus.kt
+++ b/client/src/main/kotlin/io/titandata/models/RepositoryStatus.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.models
+
+data class RepositoryStatus(
+    var logicalSize: Long,
+    var actualSize: Long,
+    var checkedOutFrom: String?,
+    var lastCommit: String?,
+    var volumeStatus: List<RepositoryVolumeStatus>
+)

--- a/client/src/main/kotlin/io/titandata/models/RepositoryVolumeStatus.kt
+++ b/client/src/main/kotlin/io/titandata/models/RepositoryVolumeStatus.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.models
+
+data class RepositoryVolumeStatus(
+    var logicalSize: Long,
+    var actualSize: Long,
+    var name: String,
+    var properties: Map<String, Any>
+)

--- a/client/src/main/kotlin/io/titandata/models/RepositoryVolumeStatus.kt
+++ b/client/src/main/kotlin/io/titandata/models/RepositoryVolumeStatus.kt
@@ -5,8 +5,8 @@
 package io.titandata.models
 
 data class RepositoryVolumeStatus(
+    var name: String,
     var logicalSize: Long,
     var actualSize: Long,
-    var name: String,
     var properties: Map<String, Any>
 )

--- a/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
@@ -177,6 +177,18 @@ class LocalWorkflowTest : EndToEndTest() {
             status.uniqueSize shouldBe 0
         }
 
+        "get repository status succeeds" {
+            val status = repoApi.getRepositoryStatus("foo")
+            status.checkedOutFrom shouldBe null
+            status.lastCommit shouldBe "id"
+            status.logicalSize shouldNotBe 0
+            status.actualSize shouldNotBe 0
+            status.volumeStatus.size shouldBe 1
+            status.volumeStatus[0].name shouldBe "vol"
+            status.volumeStatus[0].actualSize shouldNotBe 0
+            status.volumeStatus[0].logicalSize shouldNotBe 0
+        }
+
         "commit shows up in list" {
             val commits = commitApi.listCommits("foo")
             commits.size shouldBe 1
@@ -202,6 +214,12 @@ class LocalWorkflowTest : EndToEndTest() {
             volumeApi.mountVolume(VolumeMountRequest(name = "foo/vol"))
             val result = dockerUtil.readFile("foo/vol", "testfile")
             result shouldBe "Hello\n"
+        }
+
+        "get repository status indicates source commit" {
+            val status = repoApi.getRepositoryStatus("foo")
+            status.checkedOutFrom shouldBe "id"
+            status.lastCommit shouldBe "id"
         }
 
         "add remote succeeds" {

--- a/server/src/main/kotlin/io/titandata/apis/RepositoriesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/RepositoriesApi.kt
@@ -48,4 +48,11 @@ fun Route.RepositoriesApi(providers: ProviderModule) {
             call.respond(HttpStatusCode.NoContent)
         }
     }
+
+    route("/v1/repositories/{repositoryName}/status") {
+        get {
+            val name = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repositoryName parameter")
+            call.respond(providers.storage.getRepositoryStatus(name))
+        }
+    }
 }

--- a/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
@@ -9,6 +9,7 @@ import io.titandata.models.CommitStatus
 import io.titandata.models.Operation
 import io.titandata.models.Remote
 import io.titandata.models.Repository
+import io.titandata.models.RepositoryStatus
 import io.titandata.models.Volume
 
 interface StorageProvider {
@@ -16,6 +17,7 @@ interface StorageProvider {
     fun createRepository(repo: Repository)
     fun listRepositories(): List<Repository>
     fun getRepository(name: String): Repository
+    fun getRepositoryStatus(name: String): RepositoryStatus
     fun updateRepository(name: String, repo: Repository)
     fun deleteRepository(name: String)
 

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsRepositoryManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsRepositoryManager.kt
@@ -9,6 +9,8 @@ import io.titandata.exception.CommandException
 import io.titandata.exception.InvalidStateException
 import io.titandata.models.Remote
 import io.titandata.models.Repository
+import io.titandata.models.RepositoryStatus
+import io.titandata.models.RepositoryVolumeStatus
 
 /**
  * All repositories are placed under the "<pool>/repo" dataset. This is done to provide additional
@@ -137,6 +139,77 @@ class ZfsRepositoryManager(val provider: ZfsStorageProvider) {
             provider.checkNoSuchRepository(e, name)
             throw e
         }
+    }
+
+    /**
+     * Get the status of a repository. This fetches a few additional pieces of information about
+     * the repository:
+     *
+     *      logicalSize     Equivalent to 'logicalUsed'. This includes the size of any and all snapshots.
+     *
+     *      actutalSize     Equivalent to 'used'. Includes the size of any and all snapshots.
+     *
+     *      checkedOutFrom  If this is a clone, then this is the commit portion of the clone origin.
+     *
+     *      lastCommit      Last committed change. This may or may not be the same as the last commit on the current
+     *                      head filesystem, so we need to list all commits and fetch the latest one across the
+     *                      entire repository.
+     *
+     *      volumeStatus    Status for each volume. This reports status for the current head of each volume, including:
+     *
+     *                      logicalSize     Equivalent to 'logicalrefererenced'. This is only the referenced data
+     *                                      because it doesn't include snapshots (which maake no sense fo the
+     *                                      current head filesystem.
+     *
+     *                      actualSize      Equivalent to 'referenced'. Like 'logicalSize', we exclude snapshots.
+     *
+     *                      properties      The client-controlled properties of the volume. This includes, for example,
+     *                                      the path of the volume within the container.
+     */
+    fun getRepositoryStatus(name: String): RepositoryStatus {
+        provider.validateRepositoryName(name)
+        val commits = provider.commitManager.listCommits(name)
+        val latest = commits.getOrNull(0)?.id
+        val guid = provider.getActive(name)
+
+        val fields = provider.executor.exec("zfs", "list", "-pHo", "origin,logicalused,used",
+                "$poolName/repo/$name/$guid").lines().get(0).split("\t")
+        val origin = fields[0]
+        val logicalSize = fields[1].toLong()
+        val actualSize = fields[2].toLong()
+
+        val checkedOutFrom = when (origin) {
+            "-" -> null
+            else -> origin.substringAfter("@")
+        }
+
+        val volumes = mutableListOf<RepositoryVolumeStatus>()
+        val volumeOutput = provider.executor.exec("zfs", "list", "-d", "1", "-pHo",
+                "name,logicalreferenced,referenced,$METADATA_PROP")
+        val regex = "^$poolName/repo/$name/[^/\t]+\t([^\t]+)\t([^\t]+)\t(.*)$".toRegex()
+        for (line in volumeOutput.lines()) {
+            val result = regex.find(line)
+            if (result != null) {
+                val volumeName = result.groupValues.get(1)
+                val volumeLogical = result.groupValues.get(2).toLong()
+                val volumeActual = result.groupValues.get(3).toLong()
+                val metadataString = result.groupValues.get(4)
+                volumes.add(RepositoryVolumeStatus(
+                        name = volumeName,
+                        logicalSize = volumeLogical,
+                        actualSize = volumeActual,
+                        properties = provider.parseMetadata(metadataString)
+                ))
+            }
+        }
+
+        return RepositoryStatus(
+                logicalSize = logicalSize,
+                actualSize = actualSize,
+                checkedOutFrom = checkedOutFrom,
+                lastCommit = latest,
+                volumeStatus = volumes
+        )
     }
 
     /**

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -16,6 +16,7 @@ import io.titandata.models.CommitStatus
 import io.titandata.models.Operation
 import io.titandata.models.Remote
 import io.titandata.models.Repository
+import io.titandata.models.RepositoryStatus
 import io.titandata.models.Volume
 import io.titandata.serialization.ModelTypeAdapters
 import io.titandata.storage.OperationData
@@ -279,6 +280,11 @@ class ZfsStorageProvider(
     @Synchronized
     override fun getRepository(name: String): Repository {
         return repositoryManager.getRepository(name)
+    }
+
+    @Synchronized
+    override fun getRepositoryStatus(name: String): RepositoryStatus {
+        return repositoryManager.getRepositoryStatus(name)
     }
 
     @Synchronized

--- a/server/src/test/kotlin/io/titandata/serialization/S3RemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/serialization/S3RemoteTest.kt
@@ -5,6 +5,7 @@
 package io.titandata.serialization
 
 import com.google.gson.GsonBuilder
+import io.kotlintest.extensions.system.OverrideMode
 import io.kotlintest.extensions.system.withEnvironment
 import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
@@ -197,7 +198,7 @@ class S3RemoteTest : StringSpec() {
 
         "getting credentials from environment succeeds" {
             withEnvironment(mapOf("AWS_ACCESS_KEY_ID" to "accessKey", "AWS_SECRET_ACCESS_KEY" to "secretKey",
-                    "AWS_REGION" to "us-west-2", "AWS_SESSION_TOKEN" to "sessionToken")) {
+                    "AWS_REGION" to "us-west-2", "AWS_SESSION_TOKEN" to "sessionToken"), OverrideMode.SetOrOverride) {
                 System.getenv("AWS_ACCESS_KEY_ID") shouldBe "accessKey"
                 System.getenv("AWS_SECRET_ACCESS_KEY") shouldBe "secretKey"
                 System.getenv("AWS_REGION") shouldBe "us-west-2"

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
@@ -155,6 +155,10 @@ class ZfsRepositoryTest : StringSpec() {
             }
         }
 
+        "get repository status succeeds" {
+            provider.getRepositoryStatus("foo")
+        }
+
         "update fails with invalid name" {
             val repo = Repository(name = "not/a/name", properties = mapOf("a" to "b"))
             shouldThrow<IllegalArgumentException> {

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
@@ -156,7 +156,35 @@ class ZfsRepositoryTest : StringSpec() {
         }
 
         "get repository status succeeds" {
-            provider.getRepositoryStatus("foo")
+            every { executor.exec("zfs", "list", "-Ho", "name,defer_destroy,io.titan-data:metadata", "-t", "snapshot",
+                    "-d", "2", "test/repo/foo") } returns "test/repo/foo/guid@hash\toff\t{}\n"
+            every { executor.exec("zfs", "list", "-Ho", "io.titan-data:metadata",
+                    "test/repo/foo/guid@hash") } returns "{\"a\":\"b\"}\n"
+            every { executor.exec("zfs", "list", "-Hpo", "io.titan-data:active",
+                    "test/repo/foo") } returns "guid"
+            every { executor.exec("zfs", "list", "-pHo", "logicalused,used", "test/repo/foo/guid") } returns "40\t20\n"
+            every { executor.exec("zfs", "list", "-Ho", "origin", "-r", "test/repo/foo/guid") } returns
+                    "test/repo/foo/guidtwo/v0@sourcehash\n"
+            every { executor.exec("zfs", "list", "-d", "1",
+                    "-pHo", "name,logicalreferenced,referenced,io.titan-data:metadata", "test/repo/foo/guid") } returns arrayOf(
+                    "test/repo/foo/guid\t4\t6\t{}",
+                    "test/repo/foo/guid/v0\t5\t10\t{\"path\":\"/var/a\"}",
+                    "test/repo/foo/guid/v1\t8\t16\t{\"path\":\"/var/b\"}"
+            ).joinToString("\n")
+            val status = provider.getRepositoryStatus("foo")
+            status.checkedOutFrom shouldBe "sourcehash"
+            status.lastCommit shouldBe "hash"
+            status.logicalSize shouldBe 40L
+            status.actualSize shouldBe 20L
+            status.volumeStatus.size shouldBe 2
+            status.volumeStatus[0].name shouldBe "v0"
+            status.volumeStatus[0].logicalSize shouldBe 5
+            status.volumeStatus[0].actualSize shouldBe 10
+            status.volumeStatus[0].properties["path"] shouldBe "/var/a"
+            status.volumeStatus[1].name shouldBe "v1"
+            status.volumeStatus[1].logicalSize shouldBe 8
+            status.volumeStatus[1].actualSize shouldBe 16
+            status.volumeStatus[1].properties["path"] shouldBe "/var/b"
         }
 
         "update fails with invalid name" {


### PR DESCRIPTION
## Issues Addressed

Fixes #21 

## Proposed Changes

This adds a new `repository/<name>/status` endpoint that will return information about the repository that can't be retrieved through other means. This includes the current size information as well as the source of the commit it was cloned from. It also provides a few pieces of information for convenience, like the last commit, to simplify the client.

## Testing

Unit, integration, and endtoend tests.