### PR TITLE
sort commits in descending order prior to returning

### DIFF
--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsCommitManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsCommitManager.kt
@@ -10,6 +10,7 @@ import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Commit
 import io.titandata.models.CommitStatus
 import java.time.Instant
+import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
 /**
@@ -173,7 +174,11 @@ class ZfsCommitManager(val provider: ZfsStorageProvider) {
                     }
                 }
             }
-            return commits
+
+            // We always return commits in descending order so that the client doesn't have to
+            return commits.sortedByDescending { OffsetDateTime.parse(it.properties.get(timestampProperty)?.toString()
+                    ?: DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochSecond(0)),
+                    DateTimeFormatter.ISO_DATE_TIME) }
         } catch (e: CommandException) {
             provider.checkNoSuchRepository(e, repo)
             throw e

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsCommitTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsCommitTest.kt
@@ -278,6 +278,17 @@ class ZfsCommitTest : StringSpec() {
             result[0].properties["c"] shouldBe "d"
         }
 
+        "list commits sorts in reverse timestamp order" {
+            every { executor.exec(*anyVararg()) } returns arrayOf(
+                    "test/repo/foo/guid1@hash1\toff\t{\"timestamp\":\"2019-10-08T15:10:54Z\"}",
+                    "test/repo/foo/guid2@hash2\toff\t{\"timestamp\":\"2019-10-08T15:20:54Z\"}"
+            ).joinToString("\n")
+            val result = provider.listCommits("foo")
+            result.size shouldBe 2
+            result[0].id shouldBe "hash2"
+            result[1].id shouldBe "hash1"
+        }
+
         "list commits throws exception for non-existent repo" {
             every { executor.exec(*anyVararg()) } throws CommandException("", 1, "does not exist")
             shouldThrow<NoSuchObjectException> {


### PR DESCRIPTION
## Issues Addressed

Fixes #29 

## Proposed Changes

Right now, we return commits in whatever order ZFS feels fit to give them to us. Instead, sort the resulting list by descending timestamp. This will work even if you pull down an older commit - it will appear in the correct chronological order. Fixing it in the list function will automatically fix it in other places where it appears (CLI log sorting, repo status latest commit, etc).

## Testing

Build & endtoend test
