### PR TITLE
update ZFS to 0.8.2

### DIFF
--- a/server/src/scripts/zfs.sh
+++ b/server/src/scripts/zfs.sh
@@ -10,7 +10,7 @@ min_zfs_version=0.8
 # Return the tag in the ZFS repository we should be using to build ZFS binaries.
 #
 function get_zfs_build_version() {
-  echo "0.8.1"
+  echo "0.8.2"
 }
 
 #


### PR DESCRIPTION
## Issues Addressed

Fixes #18 

## Proposed Changes

This started off pretty easily, but in the process I learned that I whiffed on some of the ZFS version checks. I need to use the newest ZFS userland with older kernels, not vice versa. And we don't want to use just any compatible module off of the titan-data volume, otherwise we won't use the latest ZFS version we shipped. So I modified it to make a more exact match.

## Testing

Build and endtoend test. Verified that ZFS 0.8.2 is running on titan-server. Ran through a variety of different ZFS versions, running on the system, installed on titan-data, etc.
