### PR TITLE
refactor provider package hierarchy

### DIFF
--- a/client/src/main/kotlin/io/titandata/remote/engine/EngineParameters.kt
+++ b/client/src/main/kotlin/io/titandata/remote/engine/EngineParameters.kt
@@ -2,7 +2,9 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.models
+package io.titandata.remote.engine
+
+import io.titandata.models.RemoteParameters
 
 data class EngineParameters(
     override var provider: String = "engine",

--- a/client/src/main/kotlin/io/titandata/remote/engine/EngineRemote.kt
+++ b/client/src/main/kotlin/io/titandata/remote/engine/EngineRemote.kt
@@ -2,7 +2,9 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.models
+package io.titandata.remote.engine
+
+import io.titandata.models.Remote
 
 data class EngineRemote(
     override var provider: String = "engine",

--- a/client/src/main/kotlin/io/titandata/remote/engine/EngineRemoteUtil.kt
+++ b/client/src/main/kotlin/io/titandata/remote/engine/EngineRemoteUtil.kt
@@ -2,19 +2,11 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.serialization.remote
+package io.titandata.remote.engine
 
-import io.titandata.models.EngineParameters
-import io.titandata.models.EngineRemote
-import io.titandata.models.NopRemote
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.models.S3Parameters
-import io.titandata.models.SshParameters
-import io.titandata.models.SshRemote
-import io.titandata.serialization.RemoteUtil
 import io.titandata.serialization.RemoteUtilProvider
-import java.io.File
 import java.net.URI
 
 /**

--- a/client/src/main/kotlin/io/titandata/remote/nop/NopParameters.kt
+++ b/client/src/main/kotlin/io/titandata/remote/nop/NopParameters.kt
@@ -2,7 +2,9 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.models
+package io.titandata.remote.nop
+
+import io.titandata.models.RemoteParameters
 
 data class NopParameters(
     override var provider: String = "nop",

--- a/client/src/main/kotlin/io/titandata/remote/nop/NopRemote.kt
+++ b/client/src/main/kotlin/io/titandata/remote/nop/NopRemote.kt
@@ -2,7 +2,9 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.models
+package io.titandata.remote.nop
+
+import io.titandata.models.Remote
 
 data class NopRemote(
     override var provider: String = "nop",

--- a/client/src/main/kotlin/io/titandata/remote/nop/NopRemoteUtil.kt
+++ b/client/src/main/kotlin/io/titandata/remote/nop/NopRemoteUtil.kt
@@ -2,14 +2,10 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.serialization.remote
+package io.titandata.remote.nop
 
-import io.titandata.models.NopParameters
-import io.titandata.models.NopRemote
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.models.SshRemote
-import io.titandata.serialization.RemoteUtil
 import io.titandata.serialization.RemoteUtilProvider
 import java.net.URI
 

--- a/client/src/main/kotlin/io/titandata/remote/s3/S3Parameters.kt
+++ b/client/src/main/kotlin/io/titandata/remote/s3/S3Parameters.kt
@@ -2,7 +2,9 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.models
+package io.titandata.remote.s3
+
+import io.titandata.models.RemoteParameters
 
 data class S3Parameters(
     override var provider: String = "s3",

--- a/client/src/main/kotlin/io/titandata/remote/s3/S3Remote.kt
+++ b/client/src/main/kotlin/io/titandata/remote/s3/S3Remote.kt
@@ -2,7 +2,9 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.models
+package io.titandata.remote.s3
+
+import io.titandata.models.Remote
 
 data class S3Remote(
     override var provider: String = "s3",

--- a/client/src/main/kotlin/io/titandata/remote/s3/S3RemoteUtil.kt
+++ b/client/src/main/kotlin/io/titandata/remote/s3/S3RemoteUtil.kt
@@ -2,12 +2,10 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.serialization.remote
+package io.titandata.remote.s3
 
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.models.S3Parameters
-import io.titandata.models.S3Remote
 import io.titandata.serialization.RemoteUtilProvider
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider

--- a/client/src/main/kotlin/io/titandata/remote/ssh/SshParameters.kt
+++ b/client/src/main/kotlin/io/titandata/remote/ssh/SshParameters.kt
@@ -2,7 +2,9 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.models
+package io.titandata.remote.ssh
+
+import io.titandata.models.RemoteParameters
 
 data class SshParameters(
     override var provider: String = "ssh",

--- a/client/src/main/kotlin/io/titandata/remote/ssh/SshRemote.kt
+++ b/client/src/main/kotlin/io/titandata/remote/ssh/SshRemote.kt
@@ -2,7 +2,9 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.models
+package io.titandata.remote.ssh
+
+import io.titandata.models.Remote
 
 data class SshRemote(
     override var provider: String = "ssh",

--- a/client/src/main/kotlin/io/titandata/remote/ssh/SshRemoteUtil.kt
+++ b/client/src/main/kotlin/io/titandata/remote/ssh/SshRemoteUtil.kt
@@ -2,13 +2,10 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.serialization.remote
+package io.titandata.remote.ssh
 
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.models.SshParameters
-import io.titandata.models.SshRemote
-import io.titandata.serialization.RemoteUtil
 import io.titandata.serialization.RemoteUtilProvider
 import java.io.File
 import java.net.URI

--- a/client/src/main/kotlin/io/titandata/serialization/ModelTypeAdapters.kt
+++ b/client/src/main/kotlin/io/titandata/serialization/ModelTypeAdapters.kt
@@ -4,16 +4,16 @@
 
 package io.titandata.serialization
 
-import io.titandata.models.EngineRemote
-import io.titandata.models.EngineParameters
-import io.titandata.models.NopRemote
-import io.titandata.models.NopParameters
+import io.titandata.remote.engine.EngineRemote
+import io.titandata.remote.engine.EngineParameters
+import io.titandata.remote.nop.NopRemote
+import io.titandata.remote.nop.NopParameters
 import io.titandata.models.RemoteParameters
 import io.titandata.models.Remote
-import io.titandata.models.S3Parameters
-import io.titandata.models.S3Remote
-import io.titandata.models.SshRemote
-import io.titandata.models.SshParameters
+import io.titandata.remote.s3.S3Parameters
+import io.titandata.remote.s3.S3Remote
+import io.titandata.remote.ssh.SshRemote
+import io.titandata.remote.ssh.SshParameters
 import com.google.gson.GsonBuilder
 
 class ModelTypeAdapters {

--- a/client/src/main/kotlin/io/titandata/serialization/RemoteUtil.kt
+++ b/client/src/main/kotlin/io/titandata/serialization/RemoteUtil.kt
@@ -6,10 +6,10 @@ package io.titandata.serialization
 
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.serialization.remote.EngineRemoteUtil
-import io.titandata.serialization.remote.NopRemoteUtil
-import io.titandata.serialization.remote.S3RemoteUtil
-import io.titandata.serialization.remote.SshRemoteUtil
+import io.titandata.remote.engine.EngineRemoteUtil
+import io.titandata.remote.nop.NopRemoteUtil
+import io.titandata.remote.s3.S3RemoteUtil
+import io.titandata.remote.ssh.SshRemoteUtil
 import java.net.URI
 import java.net.URISyntaxException
 

--- a/client/src/main/kotlin/io/titandata/serialization/RemoteUtilProvider.kt
+++ b/client/src/main/kotlin/io/titandata/serialization/RemoteUtilProvider.kt
@@ -6,7 +6,6 @@ package io.titandata.serialization
 
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.models.SshRemote
 import java.net.URI
 
 abstract class RemoteUtilProvider {

--- a/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
@@ -11,14 +11,14 @@ import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
 import io.titandata.client.infrastructure.ClientException
 import io.titandata.models.Commit
-import io.titandata.models.NopParameters
-import io.titandata.models.NopRemote
 import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Repository
 import io.titandata.models.VolumeCreateRequest
 import io.titandata.models.VolumeMountRequest
 import io.titandata.models.VolumeRequest
+import io.titandata.remote.nop.NopParameters
+import io.titandata.remote.nop.NopRemote
 import java.time.Duration
 import kotlinx.coroutines.time.delay
 

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/engine/EngineWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/engine/EngineWorkflowTest.kt
@@ -2,7 +2,7 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata
+package io.titandata.remote.engine
 
 import com.delphix.sdk.Delphix
 import com.delphix.sdk.Http
@@ -11,16 +11,14 @@ import io.kotlintest.SkipTestException
 import io.kotlintest.Spec
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
+import io.titandata.EndToEndTest
 import io.titandata.client.infrastructure.ClientException
 import io.titandata.models.Commit
-import io.titandata.models.EngineParameters
-import io.titandata.models.EngineRemote
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Repository
 import io.titandata.models.VolumeCreateRequest
 import io.titandata.models.VolumeMountRequest
 import io.titandata.models.VolumeRequest
-import io.titandata.remote.engine.EngineRemoteProvider
 import io.titandata.serialization.RemoteUtil
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/s3/S3WorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/s3/S3WorkflowTest.kt
@@ -2,7 +2,7 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata
+package io.titandata.remote.s3
 
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.regions.DefaultAwsRegionProviderChain
@@ -16,16 +16,15 @@ import io.kotlintest.Spec
 import io.kotlintest.TestCaseOrder
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
+import io.titandata.EndToEndTest
+import io.titandata.ProviderModule
 import io.titandata.client.infrastructure.ClientException
 import io.titandata.client.infrastructure.ServerException
 import io.titandata.models.Commit
 import io.titandata.models.Repository
-import io.titandata.models.S3Parameters
-import io.titandata.models.S3Remote
 import io.titandata.models.VolumeCreateRequest
 import io.titandata.models.VolumeMountRequest
 import io.titandata.models.VolumeRequest
-import io.titandata.remote.s3.S3RemoteProvider
 import io.titandata.util.GuidGenerator
 import java.io.ByteArrayInputStream
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
@@ -2,18 +2,17 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata
+package io.titandata.remote.ssh
 
 import io.kotlintest.Spec
 import io.kotlintest.TestCaseOrder
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
+import io.titandata.EndToEndTest
 import io.titandata.client.infrastructure.ClientException
 import io.titandata.client.infrastructure.ServerException
 import io.titandata.models.Commit
 import io.titandata.models.Repository
-import io.titandata.models.SshParameters
-import io.titandata.models.SshRemote
 import io.titandata.models.VolumeCreateRequest
 import io.titandata.models.VolumeMountRequest
 import io.titandata.models.VolumeRequest

--- a/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
@@ -29,8 +29,8 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
 import io.titandata.models.Error
-import io.titandata.models.NopParameters
 import io.titandata.models.Operation
+import io.titandata.remote.nop.NopParameters
 import io.titandata.serialization.ModelTypeAdapters
 import io.titandata.storage.OperationData
 import io.titandata.storage.zfs.ZfsStorageProvider

--- a/server/src/main/kotlin/io/titandata/remote/engine/EngineRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/engine/EngineRemoteProvider.kt
@@ -22,8 +22,6 @@ import io.titandata.exception.InvalidStateException
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.RemoteException
 import io.titandata.models.Commit
-import io.titandata.models.EngineParameters
-import io.titandata.models.EngineRemote
 import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote

--- a/server/src/main/kotlin/io/titandata/remote/nop/NopRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/nop/NopRemoteProvider.kt
@@ -5,7 +5,6 @@
 package io.titandata.remote.nop
 
 import io.titandata.models.Commit
-import io.titandata.models.NopParameters
 import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote

--- a/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
@@ -21,8 +21,6 @@ import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.models.S3Parameters
-import io.titandata.models.S3Remote
 import io.titandata.operation.OperationExecutor
 import io.titandata.remote.BaseRemoteProvider
 import io.titandata.serialization.ModelTypeAdapters

--- a/server/src/main/kotlin/io/titandata/remote/ssh/SshRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/ssh/SshRemoteProvider.kt
@@ -13,8 +13,6 @@ import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.models.SshParameters
-import io.titandata.models.SshRemote
 import io.titandata.operation.OperationExecutor
 import io.titandata.remote.BaseRemoteProvider
 import io.titandata.serialization.ModelTypeAdapters

--- a/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
@@ -24,12 +24,12 @@ import io.titandata.ProviderModule
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Commit
-import io.titandata.models.EngineParameters
-import io.titandata.models.NopParameters
-import io.titandata.models.NopRemote
 import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Repository
+import io.titandata.remote.engine.EngineParameters
+import io.titandata.remote.nop.NopParameters
+import io.titandata.remote.nop.NopRemote
 import io.titandata.remote.nop.NopRemoteProvider
 import io.titandata.storage.OperationData
 import io.titandata.storage.zfs.ZfsStorageProvider

--- a/server/src/test/kotlin/io/titandata/remote/engine/EngineRemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/engine/EngineRemoteTest.kt
@@ -2,7 +2,7 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.serialization
+package io.titandata.remote.engine
 
 import com.google.gson.GsonBuilder
 import io.kotlintest.TestCase
@@ -17,11 +17,10 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
-import io.titandata.models.EngineParameters
-import io.titandata.models.EngineRemote
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.serialization.remote.EngineRemoteUtil
+import io.titandata.serialization.ModelTypeAdapters
+import io.titandata.serialization.RemoteUtil
 import java.io.Console
 
 class EngineRemoteTest : StringSpec() {

--- a/server/src/test/kotlin/io/titandata/remote/nop/NopRemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/nop/NopRemoteTest.kt
@@ -2,7 +2,7 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.serialization
+package io.titandata.remote.nop
 
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParseException
@@ -10,10 +10,10 @@ import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
-import io.titandata.models.NopParameters
-import io.titandata.models.NopRemote
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
+import io.titandata.serialization.ModelTypeAdapters
+import io.titandata.serialization.RemoteUtil
 
 class NopRemoteTest : StringSpec() {
 

--- a/server/src/test/kotlin/io/titandata/remote/s3/S3RemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/s3/S3RemoteTest.kt
@@ -2,7 +2,7 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.serialization
+package io.titandata.remote.s3
 
 import com.google.gson.GsonBuilder
 import io.kotlintest.extensions.system.OverrideMode
@@ -13,8 +13,8 @@ import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.models.S3Parameters
-import io.titandata.models.S3Remote
+import io.titandata.serialization.ModelTypeAdapters
+import io.titandata.serialization.RemoteUtil
 
 class S3RemoteTest : StringSpec() {
 

--- a/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
@@ -28,8 +28,6 @@ import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Commit
 import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
-import io.titandata.models.SshParameters
-import io.titandata.models.SshRemote
 import io.titandata.models.Volume
 import io.titandata.operation.OperationExecutor
 import io.titandata.storage.zfs.ZfsStorageProvider

--- a/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteTest.kt
@@ -2,7 +2,7 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.serialization
+package io.titandata.remote.ssh
 
 import com.google.gson.GsonBuilder
 import io.kotlintest.TestCase
@@ -19,9 +19,8 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.models.SshParameters
-import io.titandata.models.SshRemote
-import io.titandata.serialization.remote.SshRemoteUtil
+import io.titandata.serialization.ModelTypeAdapters
+import io.titandata.serialization.RemoteUtil
 import java.io.Console
 import org.junit.rules.TemporaryFolder
 

--- a/server/src/test/kotlin/io/titandata/serialization/SerializationTest.kt
+++ b/server/src/test/kotlin/io/titandata/serialization/SerializationTest.kt
@@ -11,10 +11,10 @@ import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
-import io.titandata.models.EngineRemote
-import io.titandata.models.NopRemote
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
+import io.titandata.remote.engine.EngineRemote
+import io.titandata.remote.nop.NopRemote
 
 class SerializationTest : StringSpec() {
 

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsOperationTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsOperationTest.kt
@@ -22,8 +22,8 @@ import io.mockk.verify
 import io.titandata.exception.CommandException
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.models.Commit
-import io.titandata.models.NopParameters
 import io.titandata.models.Operation
+import io.titandata.remote.nop.NopParameters
 import io.titandata.storage.OperationData
 import io.titandata.util.CommandExecutor
 import io.titandata.util.GuidGenerator

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
@@ -26,9 +26,9 @@ import io.titandata.exception.CommandException
 import io.titandata.exception.InvalidStateException
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
-import io.titandata.models.EngineRemote
-import io.titandata.models.NopRemote
 import io.titandata.models.Repository
+import io.titandata.remote.engine.EngineRemote
+import io.titandata.remote.nop.NopRemote
 import io.titandata.util.CommandExecutor
 import io.titandata.util.GuidGenerator
 

--- a/server/src/test/kotlin/io/titandata/sync/RsyncExecutorTest.kt
+++ b/server/src/test/kotlin/io/titandata/sync/RsyncExecutorTest.kt
@@ -23,9 +23,9 @@ import io.titandata.ProviderModule
 import io.titandata.exception.CommandException
 import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
-import io.titandata.models.SshParameters
-import io.titandata.models.SshRemote
 import io.titandata.operation.OperationExecutor
+import io.titandata.remote.ssh.SshParameters
+import io.titandata.remote.ssh.SshRemote
 import io.titandata.util.CommandExecutor
 import java.io.ByteArrayInputStream
 import java.io.InputStream


### PR DESCRIPTION
## Proposed Changes

This places all the code for a remote provider under a single `io.titandata.remote.<name>` package namespace. The code is still scattered across multiple places, hence not declaring success at fixing #24, but it's a start.

## Testing

Build and end2end tests