### PR TITLE
add s3web provider

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,7 @@ jobs:
       - name: End to End tests
         run: |
           uname -a
-          ./gradlew endtoendTest --tests *LocalWorkflowTest* --tests *S3WorkflowTest* --tests *SshWorkflowTest* -Ps3.location=${{ secrets.S3_TEST_LOCATION }}
+          ./gradlew endtoendTest --tests *Local* --tests *S3* --tests *Ssh* -Ps3.location=${{ secrets.S3_TEST_LOCATION }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: End to End tests
         run: |
           uname -a
-          ./gradlew endtoendTest --tests *LocalWorkflowTest* --tests *S3WorkflowTest* --tests *SshWorkflowTest* -Ps3.location=${{ secrets.S3_TEST_LOCATION }}
+          ./gradlew endtoendTest --tests *Local* --tests *S3* --tests *Ssh* -Ps3.location=${{ secrets.S3_TEST_LOCATION }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -50,6 +50,6 @@ publishing {
 dependencies {
     compile(kotlin("stdlib"))
     compile("com.squareup.okhttp3:okhttp:3.14.2")
-    compile("com.google.code.gson:gson:2.8.5")
-    compile("software.amazon.awssdk:auth:2.7.33")
+    compile("com.google.code.gson:gson:2.8.6")
+    compile("software.amazon.awssdk:auth:2.9.18")
 }

--- a/client/src/main/kotlin/io/titandata/client/infrastructure/Errors.kt
+++ b/client/src/main/kotlin/io/titandata/client/infrastructure/Errors.kt
@@ -22,9 +22,8 @@ fun getError(gson: Gson, body: String?) : Error? {
      * Docker volume errors are a bit strange in that they just return success but include
      * a "Err" field. Try to pull it out here.
      */
-    val parser = JsonParser()
     try {
-        val element = parser.parse(body)
+        val element = JsonParser.parseString(body)
         val obj = element.asJsonObject
         if (obj != null && obj.has("Err") && obj.get("Err").asString != "") {
             return Error(message = obj.get("Err").asString)

--- a/client/src/main/kotlin/io/titandata/remote/s3web/S3WebParameters.kt
+++ b/client/src/main/kotlin/io/titandata/remote/s3web/S3WebParameters.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.remote.s3web
+
+import io.titandata.models.RemoteParameters
+
+data class S3WebParameters(
+    override var provider: String = "s3web"
+) : RemoteParameters()

--- a/client/src/main/kotlin/io/titandata/remote/s3web/S3WebRemote.kt
+++ b/client/src/main/kotlin/io/titandata/remote/s3web/S3WebRemote.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.remote.s3web
+
+import io.titandata.models.Remote
+
+data class S3WebRemote(
+    override var provider: String = "s3web",
+    override var name: String,
+    var url: String
+) : Remote()

--- a/client/src/main/kotlin/io/titandata/remote/s3web/S3WebRemoteUtil.kt
+++ b/client/src/main/kotlin/io/titandata/remote/s3web/S3WebRemoteUtil.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.remote.s3web
+
+import io.titandata.models.Remote
+import io.titandata.models.RemoteParameters
+import io.titandata.serialization.RemoteUtilProvider
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain
+import java.net.URI
+
+/**
+ * The URI syntax for S3 web remotes is to basically replace the "s3web" portion with "http".
+ *
+ *      s3://host[/path]
+ *
+ * Currently, we always use HTTP to access the resources, though a parameter could be provided to use HTTPS instead
+ * if needed.
+ */
+class S3WebRemoteUtil : RemoteUtilProvider() {
+
+    override fun parseUri(uri: URI, name: String, properties: Map<String, String>): Remote {
+        val (username, password, host, port, path) = getConnectionInfo(uri)
+
+        if (username != null) {
+            throw IllegalArgumentException("Username cannot be specified for S3 remote")
+        }
+
+        if (password != null) {
+            throw IllegalArgumentException("Password cannot be specified for S3 remote")
+        }
+
+        if (host == null) {
+            throw IllegalArgumentException("Missing bucket in S3 remote")
+        }
+        for (p in properties.keys) {
+            when {
+                else -> throw IllegalArgumentException("Invalid remote property '$p'")
+            }
+        }
+
+        var url = "http://$host"
+        if (port != null) {
+            url += ":$port"
+        }
+        if (path != null) {
+            url += "$path"
+        }
+
+        return S3WebRemote(name = name, url = url)
+    }
+
+    override fun toUri(remote: Remote): Pair<String, Map<String, String>> {
+        remote as S3WebRemote
+
+        return Pair(remote.url.replace("http", "s3web"), mapOf())
+    }
+
+    override fun getParameters(remote: Remote): RemoteParameters {
+        return S3WebParameters()
+    }
+}

--- a/client/src/main/kotlin/io/titandata/serialization/ModelTypeAdapters.kt
+++ b/client/src/main/kotlin/io/titandata/serialization/ModelTypeAdapters.kt
@@ -15,6 +15,8 @@ import io.titandata.remote.s3.S3Remote
 import io.titandata.remote.ssh.SshRemote
 import io.titandata.remote.ssh.SshParameters
 import com.google.gson.GsonBuilder
+import io.titandata.remote.s3web.S3WebParameters
+import io.titandata.remote.s3web.S3WebRemote
 
 class ModelTypeAdapters {
     companion object {
@@ -23,12 +25,14 @@ class ModelTypeAdapters {
                 .registerSubtype(EngineRemote::class.java, "engine")
                 .registerSubtype(SshRemote::class.java, "ssh")
                 .registerSubtype(S3Remote::class.java, "s3")
+                .registerSubtype(S3WebRemote::class.java, "s3web")
 
         private val request = RuntimeTypeAdapterFactory.of(RemoteParameters::class.java, "provider", true)
                 .registerSubtype(NopParameters::class.java, "nop")
                 .registerSubtype(EngineParameters::class.java, "engine")
                 .registerSubtype(SshParameters::class.java, "ssh")
                 .registerSubtype(S3Parameters::class.java, "s3")
+                .registerSubtype(S3WebParameters::class.java, "s3web")
 
         fun configure(builder: GsonBuilder) : GsonBuilder {
             return builder.registerTypeAdapterFactory(remote)

--- a/client/src/main/kotlin/io/titandata/serialization/RemoteUtil.kt
+++ b/client/src/main/kotlin/io/titandata/serialization/RemoteUtil.kt
@@ -9,6 +9,7 @@ import io.titandata.models.RemoteParameters
 import io.titandata.remote.engine.EngineRemoteUtil
 import io.titandata.remote.nop.NopRemoteUtil
 import io.titandata.remote.s3.S3RemoteUtil
+import io.titandata.remote.s3web.S3WebRemoteUtil
 import io.titandata.remote.ssh.SshRemoteUtil
 import java.net.URI
 import java.net.URISyntaxException
@@ -19,7 +20,8 @@ class RemoteUtil {
         "nop" to NopRemoteUtil(),
         "ssh" to SshRemoteUtil(),
         "engine" to EngineRemoteUtil(),
-        "s3" to S3RemoteUtil()
+        "s3" to S3RemoteUtil(),
+        "s3web" to S3WebRemoteUtil()
     )
 
     fun parseUri(uriString: String, name: String, properties: Map<String, String>) : Remote {

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -20,5 +20,5 @@ dependencies {
     compile(kotlin("stdlib"))
     compile(kotlin("reflect"))
     compile("org.json:json:20190722")
-    compile("com.squareup.okhttp3:okhttp:3.14.2")
+    compile("com.squareup.okhttp3:okhttp:4.2.2")
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/Http.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/Http.kt
@@ -5,6 +5,8 @@
 package com.delphix.sdk
 
 import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import java.io.IOException
 import java.util.concurrent.TimeUnit
@@ -30,7 +32,7 @@ class Http(
             throw IOException("Unexpected Code: $response")
         }
         checkCookie(response)
-        return response.body()!!
+        return response.body!!
     }
 
     private fun validateResponse(response: JSONObject) {
@@ -57,8 +59,8 @@ class Http(
     }
 
     fun setSession() {
-        val json = MediaType.parse("application/json; charset=utf-8")
-        val requestBody = RequestBody.create(json, JSONObject(requestSessions()).toString());
+        val json = "application/json; charset=utf-8".toMediaTypeOrNull()
+        val requestBody = JSONObject(requestSessions()).toString().toRequestBody(json)
         val request = Request.Builder()
                 .url("$engineAddress$sessionResource")
                 .post(requestBody)
@@ -83,8 +85,8 @@ class Http(
 
     fun handlePost(url: String, data: Map<String, Any?>): JSONObject {
         if (debug) println(url)
-        val json = MediaType.parse("application/json; charset=utf-8")
-        val requestBody = RequestBody.create(json, JSONObject(data).toString());
+        val json = "application/json; charset=utf-8".toMediaTypeOrNull()
+        val requestBody = JSONObject(data).toString().toRequestBody(json)
         val request = Request.Builder()
                 .url("$engineAddress$url")
                 .addHeader("Cookie","JSESSIONID=$JSESSIONID")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
     maven("https://dl.bintray.com/kotlin/kotlinx")
 }
 
-val ktorVersion = "1.2.3"
+val ktorVersion = "1.2.5"
 
 dependencies {
     compile(project(":client"))
@@ -27,17 +27,17 @@ dependencies {
     compile("io.ktor:ktor-server-cio:$ktorVersion")
     compile("io.ktor:ktor-gson:$ktorVersion")
     compile("ch.qos.logback:logback-classic:1.2.3")
-    compile("com.google.code.gson:gson:2.8.5")
+    compile("com.google.code.gson:gson:2.8.6")
+    compile("com.squareup.okhttp3:okhttp:4.2.2")
 
     // S3 Provider dependencies
-    compile("com.amazonaws:aws-java-sdk-s3:1.11.622")
+    compile("com.amazonaws:aws-java-sdk-s3:1.11.650")
     compile("javax.xml.bind:jaxb-api:2.3.1")
 
-    testCompile("com.squareup.okhttp3:okhttp:3.14.2")
     testCompile("io.ktor:ktor-server-test-host:$ktorVersion")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
     testImplementation("io.mockk:mockk:1.9.3")
-    testImplementation("org.apache.commons:commons-text:1.7")
+    testImplementation("org.apache.commons:commons-text:1.8")
 }
 
 jacoco {
@@ -50,6 +50,11 @@ application {
 
 tasks.withType<ShadowJar> {
     archiveFileName.set("titan-server.jar")
+}
+
+tasks.register("rebuild") {
+    group = LifecycleBasePlugin.BUILD_GROUP
+    description = "Fast rebuild of docker image"
 }
 
 tasks.register("publish") {

--- a/server/gradle/docker.gradle.kts
+++ b/server/gradle/docker.gradle.kts
@@ -11,7 +11,7 @@ var buildDockerServer = tasks.register<Exec>("buildDockerServer") {
 }
 
 // Convenience function that doesn't do --no-cache for quick rebuilds (at risk of potentially stale data
-tasks.register<Exec>("rebuildDockerServer") {
+var rebuildDockerServer = tasks.register<Exec>("rebuildDockerServer") {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Build docker server image"
     commandLine("docker", "build", "-t", "$imageName:latest", "-f", "${project.projectDir}/docker/server.Dockerfile", "${project.projectDir}")
@@ -41,6 +41,12 @@ var buildSshServer = tasks.register<Exec>("buildSshTestServer") {
 tasks.named("assemble").configure {
     dependsOn(buildDockerServer)
     dependsOn(tagDockerServer)
+    dependsOn(tagLocalDockerServer)
+}
+
+tasks.named("rebuild").configure {
+    dependsOn(tasks.named("shadowJar"))
+    dependsOn(rebuildDockerServer)
     dependsOn(tagLocalDockerServer)
 }
 

--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -70,7 +70,7 @@ class DockerUtil(
         try {
             val request = Request.Builder().url(url("repositories")).build()
             val response = OkHttpClient().newCall(request).execute()
-            return response.code()
+            return response.code
         } catch (e: Exception) {
             return 500
         }

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/s3web/S3WebWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/s3web/S3WebWorkflowTest.kt
@@ -118,7 +118,7 @@ class S3WebWorkflowTest : EndToEndTest() {
 
                 val webRemote = getS3WebRemote()
                 val webProvider = S3WebRemoteProvider(ProviderModule("test"))
-                val body = webProvider.getFile(webRemote, "id").string()
+                val body = webProvider.getFile(webRemote, "id").body!!.string()
                 body shouldBe "Hello, world!"
 
                 s3.deleteObject(bucket, key)
@@ -204,7 +204,7 @@ class S3WebWorkflowTest : EndToEndTest() {
             val exception = shouldThrow<ClientException> {
                 operationApi.push("foo", "web", "id2", S3Parameters())
             }
-            exception.code shouldBe "IllegalStateException"
+            exception.code shouldBe "IllegalArgumentException"
         }
 
         "push second commit succeeds" {

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/s3web/S3WebWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/s3web/S3WebWorkflowTest.kt
@@ -1,0 +1,268 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.remote.s3web
+
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.regions.DefaultAwsRegionProviderChain
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.model.DeleteObjectsRequest
+import com.amazonaws.services.s3.model.ListObjectsRequest
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.PutObjectRequest
+import io.kotlintest.SkipTestException
+import io.kotlintest.Spec
+import io.kotlintest.TestCaseOrder
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.titandata.EndToEndTest
+import io.titandata.ProviderModule
+import io.titandata.client.infrastructure.ClientException
+import io.titandata.models.Commit
+import io.titandata.models.Repository
+import io.titandata.models.VolumeCreateRequest
+import io.titandata.models.VolumeMountRequest
+import io.titandata.models.VolumeRequest
+import io.titandata.remote.s3.S3Parameters
+import io.titandata.remote.s3.S3Remote
+import io.titandata.remote.s3.S3RemoteProvider
+import io.titandata.util.GuidGenerator
+import java.io.ByteArrayInputStream
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+
+class S3WebWorkflowTest : EndToEndTest() {
+
+    private val guid = GuidGenerator().get()
+
+    fun clearBucket() {
+        val remote = getS3Remote()
+        try {
+            val s3 = AmazonS3ClientBuilder.standard().build()
+
+            val request = ListObjectsRequest()
+                    .withBucketName(remote.bucket)
+                    .withPrefix(remote.path)
+            var objects = s3.listObjects(request)
+            while (true) {
+                val keys = objects.objectSummaries.map { it.key }
+                if (keys.size != 0) {
+                    s3.deleteObjects(DeleteObjectsRequest(remote.bucket).withKeys(*keys.toTypedArray()))
+                }
+                if (objects.isTruncated()) {
+                    objects = s3.listNextBatchOfObjects(objects)
+                } else {
+                    break
+                }
+            }
+        } catch (e: Throwable) {
+            // Ignore
+        }
+    }
+
+    override fun beforeSpec(spec: Spec) {
+        dockerUtil.stopServer()
+        dockerUtil.startServer()
+        dockerUtil.waitForServer()
+        clearBucket()
+    }
+
+    override fun afterSpec(spec: Spec) {
+        dockerUtil.stopServer(ignoreExceptions = false)
+        clearBucket()
+    }
+
+    override fun testCaseOrder() = TestCaseOrder.Sequential
+
+    private fun getLocation(): Pair<String, String> {
+        val location = System.getProperty("s3.location")
+                ?: throw SkipTestException("'s3.location' must be specified with -P")
+        val bucket = location.substringBefore("/")
+        val path = when {
+            location.contains("/") -> location.substringAfter("/")
+            else -> ""
+        }
+        return Pair(bucket, "$path/$guid")
+    }
+
+    private fun getS3Remote(): S3Remote {
+        val (bucket, path) = getLocation()
+        val creds = DefaultCredentialsProvider.create().resolveCredentials()
+                ?: throw SkipTestException("Unable to determine AWS credentials")
+        val region = DefaultAwsRegionProviderChain().region
+
+        return S3Remote(name = "origin", bucket = bucket, path = path, accessKey = creds.accessKeyId(),
+                secretKey = creds.secretAccessKey(), region = region)
+    }
+
+    private fun getS3WebRemote(): S3WebRemote {
+        val (bucket, path) = getLocation()
+
+        return S3WebRemote(name = "web", url = "http://$bucket.s3.amazonaws.com/$path")
+    }
+
+    init {
+
+        "creating and accessing S3 object succeeds" {
+            val remote = getS3Remote()
+            val provider = S3RemoteProvider(ProviderModule("test"))
+
+            val s3 = provider.getClient(remote, S3Parameters())
+            try {
+                val (bucket, key) = provider.getPath(remote, "id")
+                val metadata = ObjectMetadata()
+                metadata.userMetadata = mapOf("test" to "test")
+                val input = ByteArrayInputStream("Hello, world!".toByteArray())
+                val request = PutObjectRequest(bucket, key, input, metadata)
+                s3.putObject(request)
+
+                val webRemote = getS3WebRemote()
+                val webProvider = S3WebRemoteProvider(ProviderModule("test"))
+                val body = webProvider.getFile(webRemote, "id").string()
+                body shouldBe "Hello, world!"
+
+                s3.deleteObject(bucket, key)
+            } catch (e: AmazonServiceException) {
+                throw SkipTestException("S3 operation failed: ${e.message}")
+            }
+        }
+
+        "create new repository succeeds" {
+            val repo = Repository(
+                    name = "foo",
+                    properties = mapOf()
+            )
+            val newRepo = repoApi.createRepository(repo)
+            newRepo.name shouldBe "foo"
+        }
+
+        "create volume succeeds" {
+            val repo = VolumeCreateRequest(
+                    name = "foo/vol",
+                    opts = mapOf()
+            )
+            val response = volumeApi.createVolume(repo)
+            response.err shouldBe ""
+        }
+
+        "mount volume succeeds" {
+            val response = volumeApi.mountVolume(VolumeMountRequest(name = "foo/vol", ID = "id"))
+            response.mountpoint shouldBe "/var/lib/test/mnt/foo/vol"
+        }
+
+        "create and write volume file succeeds" {
+            dockerUtil.writeFile("foo/vol", "testfile", "Hello")
+            val result = dockerUtil.readFile("foo/vol", "testfile")
+            result shouldBe "Hello\n"
+        }
+
+        "create commit succeeds" {
+            val commit = commitApi.createCommit("foo", Commit(id = "id", properties = mapOf("a" to "b")))
+            commit.id shouldBe "id"
+            commit.properties["a"] shouldBe "b"
+        }
+
+        "add s3 remote succeeds" {
+            val remote = getS3Remote()
+            remoteApi.createRemote("foo", remote)
+        }
+
+        "add s3 web remote succeeds" {
+            val remote = getS3WebRemote()
+            remoteApi.createRemote("foo", remote)
+        }
+
+        "list remote commits returns an empty list" {
+            val result = remoteApi.listRemoteCommits("foo", "web", S3WebParameters())
+            result.size shouldBe 0
+        }
+
+        "push commit succeeds" {
+            val op = operationApi.push("foo", "origin", "id", S3Parameters())
+            waitForOperation(op.id)
+        }
+
+        "list remote commits returns pushed commit" {
+            val commits = remoteApi.listRemoteCommits("foo", "web", S3WebParameters())
+            commits.size shouldBe 1
+            commits[0].id shouldBe "id"
+            commits[0].properties["a"] shouldBe "b"
+        }
+
+        "push of same commit fails" {
+            val exception = shouldThrow<ClientException> {
+                operationApi.push("foo", "origin", "id", S3Parameters())
+            }
+            exception.code shouldBe "ObjectExistsException"
+        }
+
+        "create second commit succeeds" {
+            commitApi.createCommit("foo", Commit(id = "id2", properties = mapOf()))
+        }
+
+        "push to web fails" {
+            val exception = shouldThrow<ClientException> {
+                operationApi.push("foo", "web", "id2", S3Parameters())
+            }
+            exception.code shouldBe "IllegalStateException"
+        }
+
+        "push second commit succeeds" {
+            val op = operationApi.push("foo", "origin", "id2", S3Parameters())
+            waitForOperation(op.id)
+        }
+
+        "list remote commits records two commits" {
+            val commits = remoteApi.listRemoteCommits("foo", "web", S3WebParameters())
+            commits.size shouldBe 2
+            commits[0].id shouldBe "id2"
+            commits[1].id shouldBe "id"
+        }
+
+        "delete local commits succeeds" {
+            commitApi.deleteCommit("foo", "id")
+            commitApi.deleteCommit("foo", "id2")
+        }
+
+        "list local commits is empty" {
+            val result = commitApi.listCommits("foo")
+            result.size shouldBe 0
+        }
+
+        "write new local value succeeds" {
+            dockerUtil.writeFile("foo/vol", "testfile", "Goodbye")
+            val result = dockerUtil.readFile("foo/vol", "testfile")
+            result shouldBe "Goodbye\n"
+        }
+
+        "pull original commit succeeds" {
+            val op = operationApi.pull("foo", "web", "id", S3WebParameters())
+            waitForOperation(op.id)
+        }
+
+        "checkout commit succeeds" {
+            volumeApi.unmountVolume(VolumeMountRequest(name = "foo/vol"))
+            commitApi.checkoutCommit("foo", "id")
+            volumeApi.mountVolume(VolumeMountRequest(name = "foo/vol"))
+        }
+
+        "original file contents are present" {
+            val result = dockerUtil.readFile("foo/vol", "testfile")
+            result shouldBe "Hello\n"
+        }
+
+        "remove remote succeeds" {
+            remoteApi.deleteRemote("foo", "origin")
+            remoteApi.deleteRemote("foo", "web")
+        }
+
+        "delete volume succeeds" {
+            volumeApi.unmountVolume(VolumeMountRequest(name = "foo/vol"))
+            volumeApi.removeVolume(VolumeRequest(name = "foo/vol"))
+        }
+
+        "delete repository succeeds" {
+            repoApi.deleteRepository("foo")
+        }
+    }
+}

--- a/server/src/main/kotlin/io/titandata/Application.kt
+++ b/server/src/main/kotlin/io/titandata/Application.kt
@@ -42,6 +42,7 @@ import io.titandata.remote.RemoteProvider
 import io.titandata.remote.engine.EngineRemoteProvider
 import io.titandata.remote.nop.NopRemoteProvider
 import io.titandata.remote.s3.S3RemoteProvider
+import io.titandata.remote.s3web.S3WebRemoteProvider
 import io.titandata.remote.ssh.SshRemoteProvider
 import io.titandata.serialization.ModelTypeAdapters
 import io.titandata.storage.StorageProvider
@@ -72,6 +73,7 @@ class ProviderModule(val pool: String) {
     private val sshRemoteProvider = SshRemoteProvider(this)
     private val operationProvider = OperationProvider(this)
     private val s3Provider = S3RemoteProvider(this)
+    private val s3WebProvider = S3WebRemoteProvider(this)
 
     val gson = ModelTypeAdapters.configure(GsonBuilder()).create()
     val commandExecutor = CommandExecutor()
@@ -99,6 +101,7 @@ class ProviderModule(val pool: String) {
             "engine" -> engineRemoteProvider
             "ssh" -> sshRemoteProvider
             "s3" -> s3Provider
+            "s3web" -> s3WebProvider
             else -> throw IllegalArgumentException("unknown remote provider '$type'")
         }
     }

--- a/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
@@ -211,15 +211,13 @@ class S3RemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() {
 
                         val archive = "$scratch/${vol.name}.tar.gz"
                         val obj = s3.getObject(bucket, "$key/${vol.name}.tar.gz")
-                        val stream = obj.objectContent
-                        val outputStream = File(archive).outputStream()
                         // TODO - progress monitoring
-                        try {
-                            stream.copyTo(outputStream)
-                            operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
-                        } finally {
-                            outputStream.close()
+                        obj.objectContent.use { input ->
+                            File(archive).outputStream().use { output ->
+                                input.copyTo(output)
+                            }
                         }
+                        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
 
                         operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
                                 message = "Extracting archive for $desc"))

--- a/server/src/main/kotlin/io/titandata/remote/s3web/S3WebRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3web/S3WebRemoteProvider.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.remote.s3web
+
+import com.google.gson.GsonBuilder
+import io.titandata.ProviderModule
+import io.titandata.exception.NoSuchObjectException
+import io.titandata.models.Commit
+import io.titandata.models.Operation
+import io.titandata.models.ProgressEntry
+import io.titandata.models.Remote
+import io.titandata.models.RemoteParameters
+import io.titandata.operation.OperationExecutor
+import io.titandata.remote.BaseRemoteProvider
+import io.titandata.serialization.ModelTypeAdapters
+import java.io.File
+import java.io.IOException
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.ResponseBody
+
+/**
+ * The S3 provider is a very simple provider for reading commits created by the S3 provider. It's primary purpose is to
+ * make public demo data available without requiring people to have some kind of AWS credentials. It should not be
+ * used as a general purpose remote. The URL can be any URL to the S3 bucket, even behind CloudFront, such as:
+ *
+ *      s3web://demo.titan-data.io/hello-world/postgres
+ *
+ * The main thing is that it expects to find the same layout as the S3 provider generates, including a "titan" file
+ * at the root of the repository that has all the commit metadata.
+ */
+class S3WebRemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() {
+
+    private val gson = ModelTypeAdapters.configure(GsonBuilder()).create()
+    private val client = OkHttpClient()
+
+    fun getFile(remote: Remote, path: String): ResponseBody {
+        remote as S3WebRemote
+        val request = Request.Builder().url("${remote.url}/$path").build()
+        val response = client.newCall(request).execute()
+
+        if (!response.isSuccessful) {
+            throw IOException("failed to get ${remote.url}/$path, error code ${response.code}")
+        }
+
+        return response.body!!
+    }
+
+    private fun getAllCommits(remote: Remote): List<Commit> {
+        val body = getFile(remote, "titan").string()
+        val ret = mutableListOf<Commit>()
+
+        for (line in body.split("\n")) {
+            if (line != "") {
+                ret.add(gson.fromJson(line, Commit::class.java))
+            }
+        }
+
+        return ret
+    }
+
+    override fun listCommits(remote: Remote, params: RemoteParameters): List<Commit> {
+        return getAllCommits(remote)
+    }
+
+    override fun getCommit(remote: Remote, commitId: String, params: RemoteParameters): Commit {
+        val commits = getAllCommits(remote)
+        val commit = commits.find { it.id == commitId }
+
+        return commit
+                ?: throw NoSuchObjectException("no such commit $commitId in remote '${remote.name}'")
+    }
+
+    // TODO refactor this into manageable chunks
+    override fun runOperation(operation: OperationExecutor) {
+        if (operation.operation.type == Operation.Type.PUSH) {
+            throw IllegalStateException("push operations are not supported for s3web provider")
+        }
+
+        val repo = operation.repo
+        val operationId = operation.operation.id
+        val remote = operation.remote as S3WebRemote
+
+        val scratch = providers.storage.createOperationScratch(repo, operationId)
+        try {
+            val base = providers.storage.mountOperationVolumes(repo, operationId)
+            try {
+                for (vol in providers.storage.listVolumes(repo)) {
+                    val desc = vol.properties?.get("path")?.toString() ?: vol.name
+
+                    operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
+                            message = "Downloading archive for $desc"))
+
+                    val src = getFile(remote, "${vol.name}.tar.gz")
+                    val archive = "$scratch/${vol.name}.tar.gz"
+                    val archiveFile = File(archive)
+                    src.byteStream().use { input ->
+                        archiveFile.outputStream().use { output ->
+                            input.copyTo(output)
+                        }
+                    }
+
+                    operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
+
+                    operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
+                            message = "Extracting archive for $desc"))
+                    val args = arrayOf("tar", "xzf", archive)
+                    val process = ProcessBuilder()
+                            .directory(File("$base/${vol.name}"))
+                            .command(*args)
+                            .start()
+                    providers.commandExecutor.exec(process, args.joinToString())
+                    operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
+                }
+            } finally {
+                providers.storage.unmountOperationVolumes(repo, operationId)
+            }
+        } finally {
+            providers.storage.destroyOperationScratch(repo, operationId)
+        }
+        // TODO cleanup on failure
+    }
+}

--- a/server/src/main/kotlin/io/titandata/remote/s3web/S3WebRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3web/S3WebRemoteProvider.kt
@@ -20,7 +20,6 @@ import java.io.IOException
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.ResponseBody
 
 /**
  * The S3 provider is a very simple provider for reading commits created by the S3 provider. It's primary purpose is to
@@ -41,7 +40,6 @@ class S3WebRemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() 
         remote as S3WebRemote
         val request = Request.Builder().url("${remote.url}/$path").build()
         return client.newCall(request).execute()
-
     }
 
     private fun getAllCommits(remote: Remote): List<Commit> {
@@ -99,7 +97,7 @@ class S3WebRemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() 
                     operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
                             message = "Downloading archive for $desc"))
 
-                    val path = "${commitId}/${vol.name}.tar.gz"
+                    val path = "$commitId/${vol.name}.tar.gz"
                     val response = getFile(remote, path)
                     if (!response.isSuccessful) {
                         throw IOException("failed to get ${remote.url}/$path, error code ${response.code}")

--- a/server/src/test/kotlin/io/titandata/remote/s3web/S3WebRemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/s3web/S3WebRemoteTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.remote.s3web
+
+import com.google.gson.GsonBuilder
+import io.kotlintest.extensions.system.OverrideMode
+import io.kotlintest.extensions.system.withEnvironment
+import io.kotlintest.matchers.types.shouldBeInstanceOf
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.StringSpec
+import io.titandata.models.Remote
+import io.titandata.models.RemoteParameters
+import io.titandata.serialization.ModelTypeAdapters
+import io.titandata.serialization.RemoteUtil
+
+class S3WebRemoteTest : StringSpec() {
+
+    val gson = ModelTypeAdapters.configure(GsonBuilder()).create()
+    val remoteUtil = RemoteUtil()
+
+    fun parse(uri: String, map: Map<String, String>? = null): Remote {
+        return remoteUtil.parseUri(uri, "name", map ?: mapOf())
+    }
+
+    init {
+        "parsing full S3 web URI succeeds" {
+            val result = parse("s3web://host/object/path")
+            result.shouldBeInstanceOf<S3WebRemote>()
+            val remote = result as S3WebRemote
+            remote.name shouldBe "name"
+            remote.url shouldBe "http://host/object/path"
+        }
+
+        "parsing S3 web without path succeeds" {
+            val result = parse("s3web://host")
+            result.shouldBeInstanceOf<S3WebRemote>()
+            val remote = result as S3WebRemote
+            remote.name shouldBe "name"
+            remote.url shouldBe "http://host"
+        }
+
+        "specifying an invalid property fails" {
+            shouldThrow<IllegalArgumentException> {
+                parse("s3web://host/path", mapOf("foo" to "bar"))
+            }
+        }
+
+        "plain s3web provider fails" {
+            shouldThrow<IllegalArgumentException> {
+                parse("s3web")
+            }
+        }
+
+        "specifying query parameter fails" {
+            shouldThrow<IllegalArgumentException> {
+                parse("s3web://host/path?query")
+            }
+        }
+
+        "specifying fragment fails" {
+            shouldThrow<IllegalArgumentException> {
+                parse("s3web://host/path#fragment")
+            }
+        }
+
+        "specifying user fails" {
+            shouldThrow<IllegalArgumentException> {
+                parse("s3web://user@host/path")
+            }
+        }
+
+        "specifying port succeeds" {
+            val result = parse("s3web://host:1023/object/path")
+            result.shouldBeInstanceOf<S3WebRemote>()
+            val remote = result as S3WebRemote
+            remote.name shouldBe "name"
+            remote.url shouldBe "http://host:1023/object/path"
+        }
+
+        "missing host in s3 web URI fails" {
+            shouldThrow<IllegalArgumentException> {
+                parse("s3:///path")
+            }
+        }
+
+        "serializing a s3web remote succeeds" {
+            val result = gson.toJson(S3WebRemote(name = "foo",
+                    url = "http://host/path"))
+            result.shouldBe("{\"provider\":\"s3web\",\"name\":\"foo\",\"url\":\"http://host/path\"}")
+        }
+
+        "deserializing a s3web remote succeeds" {
+            val result = gson.fromJson("{\"provider\":\"s3web\",\"name\":\"foo\",\"url\":\"http://host/path\"}",
+                    Remote::class.java)
+            result.shouldBeInstanceOf<S3WebRemote>()
+            val remote = result as S3WebRemote
+            remote.provider shouldBe "s3web"
+            remote.url shouldBe "http://host/path"
+        }
+
+        "serializing a s3web request succeeds" {
+            val result = gson.toJson(S3WebParameters())
+            result.shouldBe("{\"provider\":\"s3web\"}")
+        }
+
+        "deserializing a s3web request succeeds" {
+            val result = gson.fromJson("{\"provider\":\"s3web\"}",
+                    RemoteParameters::class.java)
+            result.shouldBeInstanceOf<S3WebParameters>()
+            result as S3WebParameters
+            result.provider shouldBe "s3web"
+        }
+
+        "s3 web remote to URI succeeds" {
+            val (uri, props) = remoteUtil.toUri(S3WebRemote(name = "name", url = "http://host/path"))
+            uri shouldBe "s3web://host/path"
+            props.size shouldBe 0
+        }
+    }
+}

--- a/server/src/test/kotlin/io/titandata/remote/s3web/S3WebRemoteTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/s3web/S3WebRemoteTest.kt
@@ -5,8 +5,6 @@
 package io.titandata.remote.s3web
 
 import com.google.gson.GsonBuilder
-import io.kotlintest.extensions.system.OverrideMode
-import io.kotlintest.extensions.system.withEnvironment
 import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow


### PR DESCRIPTION
## Issues Addressed

Fixes #31 

## Proposed Changes

This creates a read-only HTTP provider that can pull from commits generated by the 's3' provider. While I was here, I also updated some dependencies (leaving OKHTTP for the client since I believe 4.x causes problems).

## Testing

Build and run all endtoend tests (including new one).