### PR TITLE
Feature/reaper

### DIFF
--- a/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
@@ -209,15 +209,12 @@ class SshWorkflowTest : EndToEndTest() {
             commits[0].properties["a"] shouldBe "b"
         }
 
-        // TODO - this doesn't yet work because we can't destroy a commit that has been cloned
-        /*
         "pull commit with key succeeds" {
             val key = getResource("/id_rsa")
             commitApi.deleteCommit("foo", "id")
             val op = operationApi.pull("foo", "origin", "id", SshParameters(key = key))
             waitForOperation(op.id)
         }
-         */
 
         "delete volume succeeds" {
             volumeApi.unmountVolume(VolumeMountRequest(name = "foo/vol"))

--- a/server/src/main/kotlin/io/titandata/Application.kt
+++ b/server/src/main/kotlin/io/titandata/Application.kt
@@ -122,6 +122,7 @@ internal fun ApplicationCompressionConfiguration(): Compression.Configuration.()
 @KtorExperimentalAPI
 fun Application.main() {
     val providers = ProviderModule(System.getenv("TITAN_POOL") ?: "titan")
+    providers.storage.load()
     providers.operation.loadState()
     mainProvider(providers)
 }

--- a/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
@@ -14,6 +14,8 @@ import io.titandata.models.Volume
 
 interface StorageProvider {
 
+    fun load()
+
     fun createRepository(repo: Repository)
     fun listRepositories(): List<Repository>
     fun getRepository(name: String): Repository

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsCommitManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsCommitManager.kt
@@ -205,10 +205,15 @@ class ZfsCommitManager(val provider: ZfsStorageProvider) {
             val output = provider.executor.exec("zfs", "list", "-H", "-t", "snapshot", "-d", "1",
                     "$poolName/repo/$repo/$guid").trim()
             if (output == "") {
-                // There were no snapshots, so we can destroy the entire guid. We should be able
-                // to use '-r' or '-R' since there are no snapshots, but we use '-r' just to be
-                // safe and not accidentally destroy clones should something go horribly wrong.
-                provider.executor.exec("zfs", "destroy", "-r", "$poolName/repo/$repo/$guid")
+                /*
+                 * The above command will recursively destroy any snapshots. If this commit
+                 * has been checked out, then there may be clones of a child dataset (e.g. "vol@commit")
+                 * in the deferred destroy state, even if the parent snapshot on the dataset itself
+                 * was deleted. Because of this, a vanilla destroy command can fail due to dependent
+                 * clones. To deal with this, we instead set a flag, "io.titan-data:deathrow", that the
+                 * ZFS reaper class will periodically try to clean these up in the background.
+                 */
+                provider.executor.exec("zfs", "set", "io.titan-data:deathrow=on", "$poolName/repo/$repo/$guid")
             }
         }
     }
@@ -219,13 +224,10 @@ class ZfsCommitManager(val provider: ZfsStorageProvider) {
      *  1. Find the source guid for the given commit
      *  2. Clone the dataset and all volumes into a new GUID
      *  3. Set the active guid for the repo to point to the new clone
+     *  4. Cleanup the previous active guid
      *
-     * The exception is if the hash is the latest snapshot for the given GUID. If so, we will
-     * rollback to the previous state instead of cloning a new copy. This keeps storage sprawl
-     * down for cases where the user is repeatedly checking out a previous commit and not
-     * making any subsequent commits.
-     *
-     * TODO rollback the previous filesystem to discard any head state
+     * To cleanup the guid we do one of two things. First, if the guid has no active snapshots, then we can simply
+     * blow it away. Otherwise, we rollback to the most recent commit as we no longer need the head filesystem data.
      */
     fun checkoutCommit(repo: String, commit: String) {
         provider.validateRepositoryName(repo)
@@ -235,8 +237,29 @@ class ZfsCommitManager(val provider: ZfsStorageProvider) {
 
         val newGuid = provider.generator.get()
 
-        // TODO roll back if this is the last snapshot of a guid
+        val active = provider.getActive(repo)
         provider.cloneCommit(repo, guid, commit, newGuid)
         provider.executor.exec("zfs", "set", "$ACTIVE_PROP=$newGuid", "$poolName/repo/$repo")
+
+        val output = provider.executor.exec("zfs", "list", "-pHo", "name,creation", "-t", "snapshot", "-d", "1",
+                "$poolName/repo/$repo/$active").trim()
+
+        if (output == "") {
+             // If there were no active snapshots (and hence commits) on the previous active GUID, destroy it now.
+            provider.executor.exec("zfs", "destroy", "-r", "$poolName/repo/$repo/$active")
+        } else {
+            // Get the most recent snapshot
+            val snaps = output.split("\n").map {
+                it.trim().split("\t")
+            }
+            val sorted = snaps.sortedByDescending { it[1].toLong() }
+            val mostRecentSnap = sorted[0][0].substringAfterLast("@")
+
+            // Now iterate over all children and rollback
+            val datasets = provider.executor.exec("zfs", "list", "-Ho", "name", "-r", "$poolName/repo/$repo/$active")
+            for (dataset in datasets.split("\n")) {
+                provider.executor.exec("zfs", "rollback", "${dataset.trim()}@$mostRecentSnap")
+            }
+        }
     }
 }

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsReaper.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsReaper.kt
@@ -4,10 +4,50 @@
 
 package io.titandata.storage.zfs
 
+import io.titandata.exception.CommandException
+import java.time.Duration
+import org.slf4j.LoggerFactory
+
 /*
  * The reaper class is responsible for cleaning up repositories commits that can't be deleted because there are
  * dependent clones. Most of the time, we are just deleting snapshots - which can be handled by by using the
- * deferred destroy capability of ZFS. But when we
+ * deferred destroy capability of ZFS. But when we encounter a whole dataset that needs to be destroyed (such as
+ * when we remove the last commit for a given checkout), that can then fail because there may be clones of those
+ * deferred snapshots, and there is no mechanism to defer destroy a whole datset.
+ *
+ * Instead, we mark these datasets with the "io.titan-data:reap=on" property. The reaper then just periodically
+ * scans all datasets to see if this property is set, and attempts to destroy them.
  */
-class ZfsReaper {
+class ZfsReaper(val provider: ZfsStorageProvider) : Runnable {
+
+    private val DELAY = 300L
+    private val poolName = provider.poolName
+    private val REAPER_PROP = provider.REAPER_PROP
+
+    companion object {
+        val log = LoggerFactory.getLogger(ZfsCommitManager::class.java)
+    }
+
+    override fun run() {
+        while (true) {
+            reap()
+            Thread.sleep(Duration.ofSeconds(DELAY).toMillis())
+        }
+    }
+
+    fun reap() {
+        val regex = "^(.*)\ton$".toRegex()
+        val output = provider.executor.exec("zfs", "list", "-Hpo", "name,$REAPER_PROP", "-r", "-d", "2", "$poolName/repo")
+        for (line in output.lines()) {
+            val result = regex.find(line) ?: continue
+            val dataset = result.groupValues.get(1)
+
+            try {
+                provider.executor.exec("zfs", "destroy", "-r", dataset)
+                log.info("reaped dataset $dataset")
+            } catch (e: CommandException) {
+                // Ignore errors
+            }
+        }
+    }
 }

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsReaper.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsReaper.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.storage.zfs
+
+/*
+ * The reaper class is responsible for cleaning up repositories commits that can't be deleted because there are
+ * dependent clones. Most of the time, we are just deleting snapshots - which can be handled by by using the
+ * deferred destroy capability of ZFS. But when we
+ */
+class ZfsReaper {
+}

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -56,6 +56,7 @@ class ZfsStorageProvider(
     internal val ACTIVE_PROP = "io.titan-data:active"
     internal val REMOTES_PROP = "io.titan-data:remotes"
     internal val OPERATION_PROP = "io.titan-data:operation"
+    internal val REAPER_PROP = "io.titan-data:reaper"
     internal val INITIAL_COMMIT = "initial"
     internal val executor = CommandExecutor()
     internal val generator = GuidGenerator()
@@ -64,8 +65,13 @@ class ZfsStorageProvider(
     internal val operationManager = ZfsOperationManager(this)
     internal val repositoryManager = ZfsRepositoryManager(this)
     internal val commitManager = ZfsCommitManager(this)
+    internal val reaper = ZfsReaper(this)
 
     internal val gson = ModelTypeAdapters.configure(GsonBuilder()).create()
+
+    override fun load() {
+        Thread(reaper).start()
+    }
 
     // Utility methods that translate from generic CommandExceptions into a more specific
     // exception based on error output

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsReaperTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsReaperTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.storage.zfs
+
+import io.kotlintest.TestCase
+import io.kotlintest.TestCaseOrder
+import io.kotlintest.TestResult
+import io.kotlintest.specs.StringSpec
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.OverrideMockKs
+import io.mockk.verify
+import io.titandata.exception.CommandException
+import io.titandata.util.CommandExecutor
+
+class ZfsReaperTest : StringSpec() {
+
+    @MockK
+    lateinit var executor: CommandExecutor
+
+    @InjectMockKs
+    @OverrideMockKs
+    var provider = ZfsStorageProvider("test")
+
+    override fun beforeTest(testCase: TestCase) {
+        return MockKAnnotations.init(this)
+    }
+
+    override fun afterTest(testCase: TestCase, result: TestResult) {
+        clearAllMocks()
+    }
+
+    override fun testCaseOrder() = TestCaseOrder.Random
+
+    init {
+        "reaper destroys datasets with the reaper property set" {
+            every { executor.exec("zfs", "list", "-Hpo", "name,io.titan-data:reaper", "-r", "-d", "2", "test/repo") } returns arrayOf(
+                    "test/repo/foo\t-",
+                    "test/repo/foo/guid\t-",
+                    "test/repo/bar\t-",
+                    "test/repo/bar/guid\ton"
+            ).joinToString("\n")
+            every { executor.exec("zfs", "destroy", "-r", "test/repo/bar/guid") } returns ""
+
+            provider.reaper.reap()
+
+            verify {
+                executor.exec("zfs", "destroy", "-r", "test/repo/bar/guid")
+            }
+        }
+
+        "reaper ignores failure when destroying datasets" {
+            every { executor.exec("zfs", "list", "-Hpo", "name,io.titan-data:reaper", "-r", "-d", "2", "test/repo") } returns arrayOf(
+                    "test/repo/foo\t-",
+                    "test/repo/foo/guid\t-",
+                    "test/repo/bar\t-",
+                    "test/repo/bar/guid\ton"
+            ).joinToString("\n")
+            every { executor.exec("zfs", "destroy", "-r", "test/repo/bar/guid") } throws CommandException("", 1, "dataset is busy")
+
+            provider.reaper.reap()
+
+            verify {
+                executor.exec("zfs", "destroy", "-r", "test/repo/bar/guid")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Issues Addressed

Fixes #20 

## Proposed Changes

This changes the code to asynchronously destroy datasets that can't be deleted due to dependent clones. We do this by instead setting a property and asynchronously running a reaper process that will periodically look for these datasets and attempt to delete them. When the dependent clone is deleted, then that destroy should succeed. While I was here, I took care of some TODOs related to cleanup to make sure we rollback the head dataset after checkout.

## Testing

New unit tests. Ran endtoendtest that was previously failing. Manual testing:

```
$ titan commit -m "first" repo
$ titan checkout -c <first> repo
$ titan commit -m "second" repo
$ titan checkout -c <second> repo
$ titan delete -c <second>
... check that reaper is set ....
$ titan checkout -c <first> repo
... check that second dataset is cleaned up ...
```
