### PR TITLE
server-side tags support

### DIFF
--- a/client/src/main/kotlin/io/titandata/client/apis/CommitsApi.kt
+++ b/client/src/main/kotlin/io/titandata/client/apis/CommitsApi.kt
@@ -22,7 +22,7 @@ class CommitsApi(basePath: String = "http://localhost:5001") : ApiClient(basePat
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.POST,
-                "/v1/repositories/{repositoryName}/commits/{commitId}/checkout".replace("{" + "repositoryName" + "}", "$repositoryName").replace("{" + "commitId" + "}", "$commitId"),
+                "/v1/repositories/$repositoryName/commits/$commitId/checkout",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -46,7 +46,7 @@ class CommitsApi(basePath: String = "http://localhost:5001") : ApiClient(basePat
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.POST,
-                "/v1/repositories/{repositoryName}/commits".replace("{" + "repositoryName" + "}", "$repositoryName"),
+                "/v1/repositories/$repositoryName/commits",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -63,13 +63,37 @@ class CommitsApi(basePath: String = "http://localhost:5001") : ApiClient(basePat
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
+    fun updateCommit(repositoryName: String, commit: Commit) : Commit {
+        val localVariableBody: Any? = commit
+        val localVariableQuery: Map<String,List<String>> = mapOf()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        val localVariableConfig = RequestConfig(
+                RequestMethod.POST,
+                "/v1/repositories/$repositoryName/commits/${commit.id}",
+                query = localVariableQuery,
+                headers = localVariableHeaders
+        )
+        val response = request<Commit>(
+                localVariableConfig,
+                localVariableBody
+        )
+
+        return when (response.responseType) {
+            ResponseType.Success -> (response as Success<*>).data as Commit
+            ResponseType.ClientError -> throw ClientException.fromResponse(gson, response)
+            ResponseType.ServerError -> throw ServerException.fromResponse(gson, response)
+            else -> throw NotImplementedError(response.responseType.toString())
+        }
+    }
+
     fun deleteCommit(repositoryName: String, commitId: String) {
         val localVariableBody: Any? = null
         val localVariableQuery: Map<String,List<String>> = mapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.DELETE,
-                "/v1/repositories/{repositoryName}/commits/{commitId}".replace("{" + "repositoryName" + "}", "$repositoryName").replace("{" + "commitId" + "}", "$commitId"),
+                "/v1/repositories/$repositoryName/commits/$commitId",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -86,14 +110,13 @@ class CommitsApi(basePath: String = "http://localhost:5001") : ApiClient(basePat
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
     fun getCommit(repositoryName: String, commitId: String) : Commit {
         val localVariableBody: Any? = null
         val localVariableQuery: Map<String,List<String>> = mapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.GET,
-                "/v1/repositories/{repositoryName}/commits/{commitId}".replace("{" + "repositoryName" + "}", "$repositoryName").replace("{" + "commitId" + "}", "$commitId"),
+                "/v1/repositories/$repositoryName/commits/$commitId",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -117,7 +140,7 @@ class CommitsApi(basePath: String = "http://localhost:5001") : ApiClient(basePat
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.GET,
-                "/v1/repositories/{repositoryName}/commits/{commitId}/status".replace("{" + "repositoryName" + "}", "$repositoryName").replace("{" + "commitId" + "}", "$commitId"),
+                "/v1/repositories/$repositoryName/commits/$commitId/status",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -145,7 +168,7 @@ class CommitsApi(basePath: String = "http://localhost:5001") : ApiClient(basePat
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.GET,
-                "/v1/repositories/{repositoryName}/commits".replace("{" + "repositoryName" + "}", "$repositoryName"),
+                "/v1/repositories/$repositoryName/commits",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )

--- a/client/src/main/kotlin/io/titandata/client/apis/CommitsApi.kt
+++ b/client/src/main/kotlin/io/titandata/client/apis/CommitsApi.kt
@@ -135,9 +135,13 @@ class CommitsApi(basePath: String = "http://localhost:5001") : ApiClient(basePat
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun listCommits(repositoryName: String) : Array<Commit> {
+    fun listCommits(repositoryName: String, tags: List<String>? = null) : Array<Commit> {
         val localVariableBody: Any? = null
-        val localVariableQuery: Map<String,List<String>> = mapOf()
+        val localVariableQuery: Map<String,List<String>> = if (tags == null) {
+            mapOf()
+        } else {
+            mapOf("tag" to tags)
+        }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.GET,

--- a/client/src/main/kotlin/io/titandata/client/apis/OperationsApi.kt
+++ b/client/src/main/kotlin/io/titandata/client/apis/OperationsApi.kt
@@ -23,7 +23,7 @@ class OperationsApi(basePath: String = "http://localhost:5001") : ApiClient(base
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.DELETE,
-                "/v1/repositories/{repositoryName}/operations/{operationId}".replace("{" + "repositoryName" + "}", "$repositoryName").replace("{" + "operationId" + "}", "$operationId"),
+                "/v1/repositories/$repositoryName/operations/$operationId",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -40,14 +40,13 @@ class OperationsApi(basePath: String = "http://localhost:5001") : ApiClient(base
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
     fun getOperation(repositoryName: String, operationId: String) : Operation {
         val localVariableBody: Any? = null
         val localVariableQuery: Map<String,List<String>> = mapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.GET,
-                "/v1/repositories/{repositoryName}/operations/{operationId}".replace("{" + "repositoryName" + "}", "$repositoryName").replace("{" + "operationId" + "}", "$operationId"),
+                "/v1/repositories/$repositoryName/operations/$operationId",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -71,7 +70,7 @@ class OperationsApi(basePath: String = "http://localhost:5001") : ApiClient(base
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.GET,
-                "/v1/repositories/{repositoryName}/operations/{operationId}/progress".replace("{" + "repositoryName" + "}", "$repositoryName").replace("{" + "operationId" + "}", "$operationId"),
+                "/v1/repositories/$repositoryName/operations/$operationId/progress",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -95,7 +94,7 @@ class OperationsApi(basePath: String = "http://localhost:5001") : ApiClient(base
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.GET,
-                "/v1/repositories/{repositoryName}/operations".replace("{" + "repositoryName" + "}", "$repositoryName"),
+                "/v1/repositories/$repositoryName/operations",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -105,21 +104,21 @@ class OperationsApi(basePath: String = "http://localhost:5001") : ApiClient(base
         )
 
         return when (response.responseType) {
-            ResponseType.Success -> (response as Success<*>).data as kotlin.Array<Operation>
+            ResponseType.Success -> (response as Success<*>).data as Array<Operation>
             ResponseType.ClientError -> throw ClientException.fromResponse(gson, response)
             ResponseType.ServerError -> throw ServerException.fromResponse(gson, response)
             else -> throw NotImplementedError(response.responseType.toString())
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    fun pull(repositoryName: String, remoteName: String, commitId: String, request: RemoteParameters) : Operation {
+    fun pull(repositoryName: String, remoteName: String, commitId: String, request: RemoteParameters,
+             metadataOnly: Boolean = false) : Operation {
         val localVariableBody: Any? = request
-        val localVariableQuery: Map<String,List<String>> = mapOf()
+        val localVariableQuery: Map<String,List<String>> = mapOf("metadataOnly" to listOf(metadataOnly.toString()))
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.POST,
-                "/v1/repositories/{repositoryName}/remotes/{remoteName}/commits/{commitId}/pull".replace("{" + "repositoryName" + "}", "$repositoryName").replace("{" + "remoteName" + "}", "$remoteName").replace("{" + "commitId" + "}", "$commitId"),
+                "/v1/repositories/$repositoryName/remotes/$remoteName/commits/$commitId/pull",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -136,14 +135,14 @@ class OperationsApi(basePath: String = "http://localhost:5001") : ApiClient(base
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    fun push(repositoryName: String, remoteName: String, commitId: String, anyRequest: RemoteParameters?) : Operation {
-        val localVariableBody: Any? = anyRequest
-        val localVariableQuery: Map<String,List<String>> = mapOf()
+    fun push(repositoryName: String, remoteName: String, commitId: String, request: RemoteParameters,
+             metadataOnly: Boolean = false) : Operation {
+        val localVariableBody: Any? = request
+        val localVariableQuery: Map<String,List<String>> = mapOf("metadataOnly" to listOf(metadataOnly.toString()))
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.POST,
-                "/v1/repositories/{repositoryName}/remotes/{remoteName}/commits/{commitId}/push".replace("{" + "repositoryName" + "}", "$repositoryName").replace("{" + "remoteName" + "}", "$remoteName").replace("{" + "commitId" + "}", "$commitId"),
+                "/v1/repositories/$repositoryName/remotes/$remoteName/commits/$commitId/push",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )

--- a/client/src/main/kotlin/io/titandata/client/apis/RemotesApi.kt
+++ b/client/src/main/kotlin/io/titandata/client/apis/RemotesApi.kt
@@ -91,9 +91,14 @@ class RemotesApi(basePath: String = "http://localhost:5001") : ApiClient(basePat
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun listRemoteCommits(repositoryName: String, remoteName: String, params: RemoteParameters) : Array<Commit> {
+    fun listRemoteCommits(repositoryName: String, remoteName: String, params: RemoteParameters,
+                          tags: List<String>? = null) : Array<Commit> {
         val localVariableBody: Any? = null
-        val localVariableQuery: Map<String,List<String>> = mapOf()
+        val localVariableQuery: Map<String,List<String>> = if (tags == null) {
+            mapOf()
+        } else {
+            mapOf("tag" to tags)
+        }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf(
             "titan-remote-parameters" to gson.toJson(params)
         )

--- a/client/src/main/kotlin/io/titandata/models/Operation.kt
+++ b/client/src/main/kotlin/io/titandata/models/Operation.kt
@@ -9,8 +9,7 @@ data class Operation(
         var type: Type,
         var state: State = State.RUNNING,
         var remote: String,
-        var commitId: String,
-        var metadataOnly: Boolean = false
+        var commitId: String
 ) {
 
     enum class Type(val value: String) {

--- a/client/src/main/kotlin/io/titandata/models/Operation.kt
+++ b/client/src/main/kotlin/io/titandata/models/Operation.kt
@@ -9,7 +9,8 @@ data class Operation(
         var type: Type,
         var state: State = State.RUNNING,
         var remote: String,
-        var commitId: String
+        var commitId: String,
+        var metadataOnly: Boolean = false
 ) {
 
     enum class Type(val value: String) {

--- a/server/src/endtoend-test/kotlin/io/titandata/EndToEndTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/EndToEndTest.kt
@@ -31,7 +31,7 @@ abstract class EndToEndTest : StringSpec() {
         val log = LoggerFactory.getLogger(EndToEndTest::class.java)
     }
 
-    fun getTag(commit: Commit, key: String) : String? {
+    fun getTag(commit: Commit, key: String): String? {
         @Suppress("UNCHECKED_CAST")
         val tags = commit.properties["tags"] as Map<String, String>
         return tags.get(key)

--- a/server/src/endtoend-test/kotlin/io/titandata/EndToEndTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/EndToEndTest.kt
@@ -11,6 +11,7 @@ import io.titandata.client.apis.OperationsApi
 import io.titandata.client.apis.RemotesApi
 import io.titandata.client.apis.RepositoriesApi
 import io.titandata.client.apis.VolumeApi
+import io.titandata.models.Commit
 import io.titandata.models.ProgressEntry
 import org.slf4j.LoggerFactory
 
@@ -28,6 +29,12 @@ abstract class EndToEndTest : StringSpec() {
 
     companion object {
         val log = LoggerFactory.getLogger(EndToEndTest::class.java)
+    }
+
+    fun getTag(commit: Commit, key: String) : String? {
+        @Suppress("UNCHECKED_CAST")
+        val tags = commit.properties["tags"] as Map<String, String>
+        return tags.get(key)
     }
 
     fun waitForOperation(id: String): List<ProgressEntry> {

--- a/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
@@ -171,6 +171,14 @@ class LocalWorkflowTest : EndToEndTest() {
             exception.code shouldBe "NoSuchObjectException"
         }
 
+        "update commit succeeds" {
+            val newCommit = Commit(id = "id", properties = mapOf("tags" to mapOf("a" to "B", "c" to "d")))
+            commitApi.updateCommit("foo", newCommit)
+            getTag(newCommit, "a") shouldBe "B"
+            val commit = commitApi.getCommit("foo", "id")
+            getTag(commit, "a") shouldBe "B"
+        }
+
         "get commit status succeeds" {
             val status = commitApi.getCommitStatus("foo", "id")
             status.logicalSize shouldNotBe 0
@@ -202,13 +210,13 @@ class LocalWorkflowTest : EndToEndTest() {
         }
 
         "commit present when part of filter" {
-            val commits = commitApi.listCommits("foo", listOf("a=b"))
+            val commits = commitApi.listCommits("foo", listOf("a=B"))
             commits.size shouldBe 1
             commits[0].id shouldBe "id"
         }
 
         "commit present when part of compound filter" {
-            val commits = commitApi.listCommits("foo", listOf("a=b", "c"))
+            val commits = commitApi.listCommits("foo", listOf("a=B", "c"))
             commits.size shouldBe 1
             commits[0].id shouldBe "id"
         }
@@ -383,12 +391,10 @@ class LocalWorkflowTest : EndToEndTest() {
         "list commits shows two commits" {
             val commits = commitApi.listCommits("foo")
             commits.size shouldBe 2
-            commits[0].id shouldBe "id"
-            commits[1].id shouldBe "id2"
         }
 
         "list commits filters out commit" {
-            val commits = commitApi.listCommits("foo", listOf("a=b"))
+            val commits = commitApi.listCommits("foo", listOf("a=B"))
             commits.size shouldBe 1
             commits[0].id shouldBe "id"
         }

--- a/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
@@ -145,9 +145,10 @@ class LocalWorkflowTest : EndToEndTest() {
         }
 
         "create commit succeeds" {
-            val commit = commitApi.createCommit("foo", Commit(id = "id", properties = mapOf("a" to "b")))
+            val commit = commitApi.createCommit("foo", Commit(id = "id",
+                    properties = mapOf("tags" to mapOf("a" to "b", "c" to "d"))))
             commit.id shouldBe "id"
-            commit.properties["a"] shouldBe "b"
+            getTag(commit, "a") shouldBe "b"
         }
 
         "create duplicate commit fails" {
@@ -160,7 +161,7 @@ class LocalWorkflowTest : EndToEndTest() {
         "get commit succeeds" {
             val commit = commitApi.getCommit("foo", "id")
             commit.id shouldBe "id"
-            commit.properties["a"] shouldBe "b"
+            getTag(commit, "a") shouldBe "b"
         }
 
         "get non-existent commit fails" {
@@ -191,6 +192,23 @@ class LocalWorkflowTest : EndToEndTest() {
 
         "commit shows up in list" {
             val commits = commitApi.listCommits("foo")
+            commits.size shouldBe 1
+            commits[0].id shouldBe "id"
+        }
+
+        "commit not present when filtered out" {
+            val commits = commitApi.listCommits("foo", listOf("a=c"))
+            commits.size shouldBe 0
+        }
+
+        "commit present when part of filter" {
+            val commits = commitApi.listCommits("foo", listOf("a=b"))
+            commits.size shouldBe 1
+            commits[0].id shouldBe "id"
+        }
+
+        "commit present when part of compound filter" {
+            val commits = commitApi.listCommits("foo", listOf("a=b", "c"))
             commits.size shouldBe 1
             commits[0].id shouldBe "id"
         }
@@ -360,6 +378,19 @@ class LocalWorkflowTest : EndToEndTest() {
         "pulled commit exists" {
             val commit = commitApi.getCommit("foo", "id2")
             commit.id shouldBe "id2"
+        }
+
+        "list commits shows two commits" {
+            val commits = commitApi.listCommits("foo")
+            commits.size shouldBe 2
+            commits[0].id shouldBe "id"
+            commits[1].id shouldBe "id2"
+        }
+
+        "list commits filters out commit" {
+            val commits = commitApi.listCommits("foo", listOf("a=b"))
+            commits.size shouldBe 1
+            commits[0].id shouldBe "id"
         }
 
         "push non-existent commit fails" {

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/s3/S3WorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/s3/S3WorkflowTest.kt
@@ -25,7 +25,6 @@ import io.titandata.models.Repository
 import io.titandata.models.VolumeCreateRequest
 import io.titandata.models.VolumeMountRequest
 import io.titandata.models.VolumeRequest
-import io.titandata.remote.ssh.SshParameters
 import io.titandata.util.GuidGenerator
 import java.io.ByteArrayInputStream
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/s3/S3WorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/s3/S3WorkflowTest.kt
@@ -25,6 +25,7 @@ import io.titandata.models.Repository
 import io.titandata.models.VolumeCreateRequest
 import io.titandata.models.VolumeMountRequest
 import io.titandata.models.VolumeRequest
+import io.titandata.remote.ssh.SshParameters
 import io.titandata.util.GuidGenerator
 import java.io.ByteArrayInputStream
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
@@ -143,9 +144,11 @@ class S3WorkflowTest : EndToEndTest() {
         }
 
         "create commit succeeds" {
-            val commit = commitApi.createCommit("foo", Commit(id = "id", properties = mapOf("a" to "b")))
+            val commit = commitApi.createCommit("foo", Commit(id = "id",
+                    properties = mapOf("tags" to mapOf("a" to "b", "c" to "d"))))
             commit.id shouldBe "id"
-            commit.properties["a"] shouldBe "b"
+            getTag(commit, "a") shouldBe "b"
+            getTag(commit, "c") shouldBe "d"
         }
 
         "add s3 remote succeeds" {
@@ -167,7 +170,18 @@ class S3WorkflowTest : EndToEndTest() {
             val commits = remoteApi.listRemoteCommits("foo", "origin", S3Parameters())
             commits.size shouldBe 1
             commits[0].id shouldBe "id"
-            commits[0].properties["a"] shouldBe "b"
+            getTag(commits[0], "a") shouldBe "b"
+        }
+
+        "list remote commits filters out commit" {
+            val commits = remoteApi.listRemoteCommits("foo", "origin", S3Parameters(), listOf("e"))
+            commits.size shouldBe 0
+        }
+
+        "list remote commits filters include commit" {
+            val commits = remoteApi.listRemoteCommits("foo", "origin", S3Parameters(), listOf("a=b", "c=d"))
+            commits.size shouldBe 1
+            commits[0].id shouldBe "id"
         }
 
         "push of same commit fails" {
@@ -191,6 +205,12 @@ class S3WorkflowTest : EndToEndTest() {
             commits.size shouldBe 2
             commits[0].id shouldBe "id2"
             commits[1].id shouldBe "id"
+        }
+
+        "list remote commits filters commits" {
+            val commits = remoteApi.listRemoteCommits("foo", "origin", S3Parameters(), listOf("a"))
+            commits.size shouldBe 1
+            commits[0].id shouldBe "id"
         }
 
         "delete local commits succeeds" {

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/s3web/S3WebWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/s3web/S3WebWorkflowTest.kt
@@ -157,9 +157,11 @@ class S3WebWorkflowTest : EndToEndTest() {
         }
 
         "create commit succeeds" {
-            val commit = commitApi.createCommit("foo", Commit(id = "id", properties = mapOf("a" to "b")))
+            val commit = commitApi.createCommit("foo", Commit(id = "id",
+                    properties = mapOf("tags" to mapOf("a" to "b", "c" to "d"))))
             commit.id shouldBe "id"
-            commit.properties["a"] shouldBe "b"
+            getTag(commit, "a") shouldBe "b"
+            getTag(commit, "c") shouldBe "d"
         }
 
         "add s3 remote succeeds" {
@@ -186,7 +188,18 @@ class S3WebWorkflowTest : EndToEndTest() {
             val commits = remoteApi.listRemoteCommits("foo", "web", S3WebParameters())
             commits.size shouldBe 1
             commits[0].id shouldBe "id"
-            commits[0].properties["a"] shouldBe "b"
+            getTag(commits[0], "a") shouldBe "b"
+        }
+
+        "list remote commits filters out commit" {
+            val commits = remoteApi.listRemoteCommits("foo", "web", S3WebParameters(), listOf("e"))
+            commits.size shouldBe 0
+        }
+
+        "list remote commits filters include commit" {
+            val commits = remoteApi.listRemoteCommits("foo", "web", S3WebParameters(), listOf("a=b", "c=d"))
+            commits.size shouldBe 1
+            commits[0].id shouldBe "id"
         }
 
         "push of same commit fails" {

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
@@ -73,9 +73,11 @@ class SshWorkflowTest : EndToEndTest() {
         }
 
         "create commit succeeds" {
-            val commit = commitApi.createCommit("foo", Commit(id = "id", properties = mapOf("a" to "b")))
+            val commit = commitApi.createCommit("foo", Commit(id = "id",
+                    properties = mapOf("tags" to mapOf("a" to "b", "c" to "d"))))
             commit.id shouldBe "id"
-            commit.properties["a"] shouldBe "b"
+            getTag(commit, "a") shouldBe "b"
+            getTag(commit, "c") shouldBe "d"
         }
 
         "add ssh remote succeeds" {
@@ -113,7 +115,18 @@ class SshWorkflowTest : EndToEndTest() {
             val commits = remoteApi.listRemoteCommits("foo", "origin", SshParameters())
             commits.size shouldBe 1
             commits[0].id shouldBe "id"
-            commits[0].properties["a"] shouldBe "b"
+            getTag(commits[0], "a") shouldBe "b"
+        }
+
+        "list remote commits filters out commit" {
+            val commits = remoteApi.listRemoteCommits("foo", "origin", SshParameters(), listOf("e"))
+            commits.size shouldBe 0
+        }
+
+        "list remote commits filters include commit" {
+            val commits = remoteApi.listRemoteCommits("foo", "origin", SshParameters(), listOf("a=b", "c=d"))
+            commits.size shouldBe 1
+            commits[0].id shouldBe "id"
         }
 
         "remote file contents is correct" {
@@ -179,7 +192,6 @@ class SshWorkflowTest : EndToEndTest() {
             val commits = remoteApi.listRemoteCommits("foo", "origin", SshParameters(password = "root"))
             commits.size shouldBe 1
             commits[0].id shouldBe "id"
-            commits[0].properties["a"] shouldBe "b"
         }
 
         "list commits without password fails" {
@@ -206,7 +218,6 @@ class SshWorkflowTest : EndToEndTest() {
             val commits = remoteApi.listRemoteCommits("foo", "origin", SshParameters(key = key))
             commits.size shouldBe 1
             commits[0].id shouldBe "id"
-            commits[0].properties["a"] shouldBe "b"
         }
 
         "pull commit with key succeeds" {

--- a/server/src/integration-test/kotlin/io/titandata/CommitsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/CommitsApiTest.kt
@@ -100,6 +100,42 @@ class CommitsApiTest : StringSpec() {
             }
         }
 
+        "list commits filters result with exact match" {
+            every { executor.exec(*anyVararg()) } returns arrayOf(
+                    "test/repo/foo@ignore\toff\t{}",
+                    "test/repo/foo/guid1@hash1\toff\t{\"tags\":{\"a\":\"b\"}}",
+                    "test/repo/foo/guid2@hash2\toff\t{\"tags\":{\"c\":\"d\"}}"
+            ).joinToString("\n")
+            with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/foo/commits?tag=a=b")) {
+                response.status() shouldBe HttpStatusCode.OK
+                response.content shouldBe "[{\"id\":\"hash1\",\"properties\":{\"tags\":{\"a\":\"b\"}}}]"
+            }
+        }
+
+        "list commits filters result with exists match" {
+            every { executor.exec(*anyVararg()) } returns arrayOf(
+                    "test/repo/foo@ignore\toff\t{}",
+                    "test/repo/foo/guid1@hash1\toff\t{\"tags\":{\"a\":\"b\"}}",
+                    "test/repo/foo/guid2@hash2\toff\t{\"tags\":{\"c\":\"d\"}}"
+            ).joinToString("\n")
+            with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/foo/commits?tag=a")) {
+                response.status() shouldBe HttpStatusCode.OK
+                response.content shouldBe "[{\"id\":\"hash1\",\"properties\":{\"tags\":{\"a\":\"b\"}}}]"
+            }
+        }
+
+        "list commits filters result with compound match" {
+            every { executor.exec(*anyVararg()) } returns arrayOf(
+                    "test/repo/foo@ignore\toff\t{}",
+                    "test/repo/foo/guid1@hash1\toff\t{\"tags\":{\"a\":\"b\",\"c\":\"d\"}}",
+                    "test/repo/foo/guid2@hash2\toff\t{\"tags\":{\"c\":\"d\"}}"
+            ).joinToString("\n")
+            with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/foo/commits?tag=a=b&tag=c=d")) {
+                response.status() shouldBe HttpStatusCode.OK
+                response.content shouldBe "[{\"id\":\"hash1\",\"properties\":{\"tags\":{\"a\":\"b\",\"c\":\"d\"}}}]"
+            }
+        }
+
         "list commits fails with non existent repository" {
             every { executor.exec(*anyVararg()) } throws CommandException("", 1, "does not exist")
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/repo/commits")) {

--- a/server/src/main/kotlin/io/titandata/apis/CommitsApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/CommitsApi.kt
@@ -31,7 +31,7 @@ fun Route.CommitsApi(providers: ProviderModule) {
 
         get {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
-            val tags = call.request.queryParameters.getAll("tags")
+            val tags = call.request.queryParameters.getAll("tag")
             call.respond(providers.storage.listCommits(repo, tags))
         }
     }

--- a/server/src/main/kotlin/io/titandata/apis/CommitsApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/CommitsApi.kt
@@ -31,7 +31,8 @@ fun Route.CommitsApi(providers: ProviderModule) {
 
         get {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
-            call.respond(providers.storage.listCommits(repo))
+            val tags = call.request.queryParameters.getAll("tags")
+            call.respond(providers.storage.listCommits(repo, tags))
         }
     }
 

--- a/server/src/main/kotlin/io/titandata/apis/CommitsApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/CommitsApi.kt
@@ -49,6 +49,15 @@ fun Route.CommitsApi(providers: ProviderModule) {
             val commit = call.parameters["commitId"] ?: throw IllegalArgumentException("missing commit id parameter")
             call.respond(providers.storage.getCommit(repo, commit))
         }
+
+        post {
+            val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
+            val commitId = call.parameters["commitId"] ?: throw IllegalArgumentException("missing commit id parameter")
+            val commit = call.receive(Commit::class)
+            commit.id = commitId
+            providers.storage.updateCommit(repo, commit)
+            call.respond(commit)
+        }
     }
 
     route("/v1/repositories/{repositoryName}/commits/{commitId}/status") {

--- a/server/src/main/kotlin/io/titandata/apis/OperationsApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/OperationsApi.kt
@@ -54,7 +54,12 @@ fun Route.OperationsApi(@Suppress("UNUSED_PARAMETER") providers: ProviderModule)
             val remote = call.parameters["remoteName"] ?: throw IllegalArgumentException("missing remote name parameter")
             val commitId = call.parameters["commitId"] ?: throw IllegalArgumentException("missing commit id parameter")
             val params = call.receive(RemoteParameters::class)
-            call.respond(providers.operation.startPull(repo, remote, commitId, params))
+            val metadataOnly = if (call.request.queryParameters.contains("metadataOnly")) {
+                call.request.queryParameters.get("metadataOnly")!!.toBoolean()
+            } else {
+                false
+            }
+            call.respond(providers.operation.startPull(repo, remote, commitId, params, metadataOnly))
         }
     }
 
@@ -64,7 +69,12 @@ fun Route.OperationsApi(@Suppress("UNUSED_PARAMETER") providers: ProviderModule)
             val remote = call.parameters["remoteName"] ?: throw IllegalArgumentException("missing remote name parameter")
             val commitId = call.parameters["commitId"] ?: throw IllegalArgumentException("missing commit id parameter")
             val params = call.receive(RemoteParameters::class)
-            call.respond(providers.operation.startPush(repo, remote, commitId, params))
+            val metadataOnly = if (call.request.queryParameters.contains("metadataOnly")) {
+                call.request.queryParameters.get("metadataOnly")!!.toBoolean()
+            } else {
+                false
+            }
+            call.respond(providers.operation.startPush(repo, remote, commitId, params, metadataOnly))
         }
     }
 }

--- a/server/src/main/kotlin/io/titandata/apis/RemotesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/RemotesApi.kt
@@ -128,7 +128,7 @@ fun Route.RemotesApi(providers: ProviderModule) {
             val remote = remotes[idx]
             val params = providers.gson.fromJson(call.request.headers["titan-remote-parameters"],
                     RemoteParameters::class.java)
-            val tags = call.request.queryParameters.getAll("tags")
+            val tags = call.request.queryParameters.getAll("tag")
             val commits = providers.remote(remote.provider).listCommits(remote, params, tags)
             call.respond(commits.sortedByDescending { OffsetDateTime.parse(it.properties.get("timestamp")?.toString()
                     ?: DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochSecond(0)),

--- a/server/src/main/kotlin/io/titandata/apis/RemotesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/RemotesApi.kt
@@ -128,7 +128,8 @@ fun Route.RemotesApi(providers: ProviderModule) {
             val remote = remotes[idx]
             val params = providers.gson.fromJson(call.request.headers["titan-remote-parameters"],
                     RemoteParameters::class.java)
-            val commits = providers.remote(remote.provider).listCommits(remote, params)
+            val tags = call.request.queryParameters.getAll("tags")
+            val commits = providers.remote(remote.provider).listCommits(remote, params, tags)
             call.respond(commits.sortedByDescending { OffsetDateTime.parse(it.properties.get("timestamp")?.toString()
                     ?: DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochSecond(0)),
                     DateTimeFormatter.ISO_DATE_TIME) })

--- a/server/src/main/kotlin/io/titandata/operation/OperationProvider.kt
+++ b/server/src/main/kotlin/io/titandata/operation/OperationProvider.kt
@@ -187,7 +187,7 @@ class OperationProvider(val providers: ProviderModule) {
             throw IllegalArgumentException("operation parameters type (${params.provider}) doesn't match type of remote '$remote' (${r.provider})")
         }
         val remoteProvider = providers.remote(r.provider)
-        remoteProvider.validateOperation(r, commitId, Operation.Type.PULL, params)
+        remoteProvider.validateOperation(r, commitId, Operation.Type.PULL, params, metadataOnly)
 
         operationsById.values.forEach {
             if (it.repo == repository && it.operation.type == Operation.Type.PULL &&
@@ -238,7 +238,7 @@ class OperationProvider(val providers: ProviderModule) {
             }
         }
 
-        remoteProvider.validateOperation(r, commitId, Operation.Type.PUSH, params)
+        remoteProvider.validateOperation(r, commitId, Operation.Type.PUSH, params, metadataOnly)
 
         return createAndStartOperation(Operation.Type.PUSH, repository, r, commitId, params, metadataOnly)
     }

--- a/server/src/main/kotlin/io/titandata/operation/OperationProvider.kt
+++ b/server/src/main/kotlin/io/titandata/operation/OperationProvider.kt
@@ -227,6 +227,9 @@ class OperationProvider(val providers: ProviderModule) {
         }
         providers.storage.getCommit(repository, commitId) // check commit exists
         val remoteProvider = providers.remote(r.provider)
+        if (metadataOnly) {
+            remoteProvider.getCommit(r, commitId, params) // for metadata only must exist in remote as well
+        }
 
         operationsById.values.forEach {
             if (it.repo == repository && it.operation.type == Operation.Type.PUSH &&

--- a/server/src/main/kotlin/io/titandata/operation/OperationProvider.kt
+++ b/server/src/main/kotlin/io/titandata/operation/OperationProvider.kt
@@ -199,9 +199,13 @@ class OperationProvider(val providers: ProviderModule) {
 
         try {
             providers.storage.getCommit(repository, commitId)
-            throw ObjectExistsException("commit '$commitId' already exists in repository '$repository'")
+            if (!metadataOnly) {
+                throw ObjectExistsException("commit '$commitId' already exists in repository '$repository'")
+            }
         } catch (e: NoSuchObjectException) {
-            // Ignore
+            if (metadataOnly) {
+                throw ObjectExistsException("no such commit '$commitId' in repository '$repository'")
+            }
         }
 
         return createAndStartOperation(Operation.Type.PULL, repository, r, commitId, params, metadataOnly)

--- a/server/src/main/kotlin/io/titandata/operation/OperationProvider.kt
+++ b/server/src/main/kotlin/io/titandata/operation/OperationProvider.kt
@@ -65,14 +65,13 @@ class OperationProvider(val providers: ProviderModule) {
         operationsByRepo.get(exec.repo)!!.remove(exec)
     }
 
-    internal fun buildOperation(type: Operation.Type, remote: String, commitId: String, metadataOnly: Boolean): Operation {
+    internal fun buildOperation(type: Operation.Type, remote: String, commitId: String): Operation {
         return Operation(
                 generator.get(),
                 type,
                 Operation.State.RUNNING,
                 remote,
-                commitId,
-                metadataOnly
+                commitId
         )
     }
 
@@ -84,8 +83,8 @@ class OperationProvider(val providers: ProviderModule) {
         params: RemoteParameters,
         metadataOnly: Boolean
     ): Operation {
-        val op = buildOperation(type, remote.name, commitId, metadataOnly)
-        val exec = OperationExecutor(providers, op, repository, remote, params)
+        val op = buildOperation(type, remote.name, commitId)
+        val exec = OperationExecutor(providers, op, repository, remote, params, false, metadataOnly)
         addOperation(exec)
         val message = when (type) {
             Operation.Type.PULL -> "Pulling $commitId from '${remote.name}'"
@@ -115,7 +114,7 @@ class OperationProvider(val providers: ProviderModule) {
         for (r in providers.storage.listRepositories()) {
             for (op in providers.storage.listOperations(r.name)) {
                 val exec = OperationExecutor(providers, op.operation, r.name,
-                        getRemote(r.name, op.operation.remote), op.params, true)
+                        getRemote(r.name, op.operation.remote), op.params, true, op.metadataOnly)
                 addOperation(exec)
                 if (op.operation.state == Operation.State.RUNNING) {
                     log.info("retrying operation ${op.operation.id} after restart")

--- a/server/src/main/kotlin/io/titandata/remote/BaseRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/BaseRemoteProvider.kt
@@ -18,16 +18,21 @@ abstract class BaseRemoteProvider : RemoteProvider {
         remote: Remote,
         commitId: String,
         opType: Operation.Type,
-        params: RemoteParameters
+        params: RemoteParameters,
+        metadataOnly: Boolean
     ) {
         if (opType == Operation.Type.PULL) {
             getCommit(remote, commitId, params)
         } else {
             try {
                 getCommit(remote, commitId, params)
-                throw ObjectExistsException("commit $commitId exists in remote '${remote.name}'")
+                if (!metadataOnly) {
+                    throw ObjectExistsException("commit $commitId exists in remote '${remote.name}'")
+                }
             } catch (e: NoSuchObjectException) {
-                // Ignore
+                if (metadataOnly) {
+                    throw e
+                }
             }
         }
     }

--- a/server/src/main/kotlin/io/titandata/remote/BaseRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/BaseRemoteProvider.kt
@@ -6,9 +6,12 @@ package io.titandata.remote
 
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
+import io.titandata.models.Commit
 import io.titandata.models.Operation
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
+import io.titandata.models.Volume
+import io.titandata.operation.OperationExecutor
 
 abstract class BaseRemoteProvider : RemoteProvider {
     override fun validateOperation(
@@ -27,5 +30,37 @@ abstract class BaseRemoteProvider : RemoteProvider {
                 // Ignore
             }
         }
+    }
+
+    fun getVolumeDesc(vol: Volume): String {
+        return vol.properties?.get("path")?.toString() ?: vol.name
+    }
+
+    override fun startOperation(operation: OperationExecutor): Any? {
+        return null
+    }
+
+    override fun endOperation(operation: OperationExecutor, data: Any?) {
+        // Do nothing
+    }
+
+    override fun failOperation(operation: OperationExecutor, data: Any?) {
+        // Do nothing
+    }
+
+    open fun syncVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String) {
+        // Do nothing
+    }
+
+    override fun pushVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String) {
+        syncVolume(operation, data, volume, basePath, scratchPath)
+    }
+
+    override fun pullVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String) {
+        syncVolume(operation, data, volume, basePath, scratchPath)
+    }
+
+    override fun pushMetadata(operation: OperationExecutor, data: Any?, commit: Commit, isUpdate: Boolean) {
+        // Do nothing
     }
 }

--- a/server/src/main/kotlin/io/titandata/remote/RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/RemoteProvider.kt
@@ -11,7 +11,7 @@ import io.titandata.models.RemoteParameters
 import io.titandata.operation.OperationExecutor
 
 interface RemoteProvider {
-    fun listCommits(remote: Remote, params: RemoteParameters): List<Commit>
+    fun listCommits(remote: Remote, params: RemoteParameters, tags: List<String>?): List<Commit>
     fun getCommit(remote: Remote, commitId: String, params: RemoteParameters): Commit
     fun runOperation(operation: OperationExecutor)
     fun validateOperation(remote: Remote, commitId: String, opType: Operation.Type, params: RemoteParameters)

--- a/server/src/main/kotlin/io/titandata/remote/RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/RemoteProvider.kt
@@ -15,7 +15,13 @@ interface RemoteProvider {
     fun listCommits(remote: Remote, params: RemoteParameters, tags: List<String>?): List<Commit>
     fun getCommit(remote: Remote, commitId: String, params: RemoteParameters): Commit
 
-    fun validateOperation(remote: Remote, commitId: String, opType: Operation.Type, params: RemoteParameters)
+    fun validateOperation(
+        remote: Remote,
+        commitId: String,
+        opType: Operation.Type,
+        params: RemoteParameters,
+        metadataOnly: Boolean
+    )
 
     fun startOperation(operation: OperationExecutor): Any?
     fun endOperation(operation: OperationExecutor, data: Any?)

--- a/server/src/main/kotlin/io/titandata/remote/RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/RemoteProvider.kt
@@ -8,11 +8,19 @@ import io.titandata.models.Commit
 import io.titandata.models.Operation
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
+import io.titandata.models.Volume
 import io.titandata.operation.OperationExecutor
 
 interface RemoteProvider {
     fun listCommits(remote: Remote, params: RemoteParameters, tags: List<String>?): List<Commit>
     fun getCommit(remote: Remote, commitId: String, params: RemoteParameters): Commit
-    fun runOperation(operation: OperationExecutor)
+
     fun validateOperation(remote: Remote, commitId: String, opType: Operation.Type, params: RemoteParameters)
+
+    fun startOperation(operation: OperationExecutor): Any?
+    fun endOperation(operation: OperationExecutor, data: Any?)
+    fun failOperation(operation: OperationExecutor, data: Any?)
+    fun pushVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String)
+    fun pullVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String)
+    fun pushMetadata(operation: OperationExecutor, data: Any?, commit: Commit, isUpdate: Boolean)
 }

--- a/server/src/main/kotlin/io/titandata/remote/nop/NopRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/nop/NopRemoteProvider.kt
@@ -31,7 +31,8 @@ class NopRemoteProvider : BaseRemoteProvider() {
         remote: Remote,
         commitId: String,
         opType: Operation.Type,
-        params: RemoteParameters
+        params: RemoteParameters,
+        metadataOnly: Boolean
     ) {
         // All operations always succeed
     }

--- a/server/src/main/kotlin/io/titandata/remote/nop/NopRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/nop/NopRemoteProvider.kt
@@ -19,7 +19,7 @@ import io.titandata.remote.BaseRemoteProvider
  * remotes will always return an empty list.
  */
 class NopRemoteProvider : BaseRemoteProvider() {
-    override fun listCommits(remote: Remote, params: RemoteParameters): List<Commit> {
+    override fun listCommits(remote: Remote, params: RemoteParameters, tags: List<String>?): List<Commit> {
         return listOf()
     }
 

--- a/server/src/main/kotlin/io/titandata/remote/nop/NopRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/nop/NopRemoteProvider.kt
@@ -9,6 +9,7 @@ import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
+import io.titandata.models.Volume
 import io.titandata.operation.OperationExecutor
 import io.titandata.remote.BaseRemoteProvider
 
@@ -36,7 +37,7 @@ class NopRemoteProvider : BaseRemoteProvider() {
         // All operations always succeed
     }
 
-    override fun runOperation(operation: OperationExecutor) {
+    override fun syncVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String) {
         operation.addProgress(ProgressEntry(ProgressEntry.Type.START, "Running operation"))
         val request = operation.params as NopParameters
         if (request.delay != 0) {

--- a/server/src/main/kotlin/io/titandata/remote/nop/NopRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/nop/NopRemoteProvider.kt
@@ -9,7 +9,6 @@ import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
-import io.titandata.models.Volume
 import io.titandata.operation.OperationExecutor
 import io.titandata.remote.BaseRemoteProvider
 
@@ -37,12 +36,16 @@ class NopRemoteProvider : BaseRemoteProvider() {
         // All operations always succeed
     }
 
-    override fun syncVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String) {
+    override fun startOperation(operation: OperationExecutor): Any? {
         operation.addProgress(ProgressEntry(ProgressEntry.Type.START, "Running operation"))
         val request = operation.params as NopParameters
         if (request.delay != 0) {
             Thread.sleep(request.delay * 1000L)
         }
+        return null
+    }
+
+    override fun endOperation(operation: OperationExecutor, data: Any?) {
         operation.addProgress(ProgressEntry(ProgressEntry.Type.END))
     }
 }

--- a/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
@@ -16,10 +16,10 @@ import com.google.gson.GsonBuilder
 import io.titandata.ProviderModule
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.models.Commit
-import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
+import io.titandata.models.Volume
 import io.titandata.operation.OperationExecutor
 import io.titandata.remote.BaseRemoteProvider
 import io.titandata.serialization.ModelTypeAdapters
@@ -28,7 +28,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.InputStream
 import java.io.SequenceInputStream
-import java.lang.IllegalArgumentException
+import kotlin.IllegalArgumentException
 
 /**
  * The S3 provider is a very simple provider for storing whole commits directly in a S3 bucket. Each commit is is a
@@ -173,83 +173,86 @@ class S3RemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() {
         }
     }
 
-    // TODO refactor this into manageable chunks
-    override fun runOperation(operation: OperationExecutor) {
-        val s3 = getClient(operation.remote, operation.params)
-        val (bucket, key) = getPath(operation.remote, operation.operation.commitId)
-        val repo = operation.repo
-        val operationId = operation.operation.id
+    private class S3Operation(provider: S3RemoteProvider, operation: OperationExecutor) {
+        val s3: AmazonS3
+        val bucket: String
+        val key: String?
 
-        val scratch = providers.storage.createOperationScratch(repo, operationId)
-        try {
-            val base = providers.storage.mountOperationVolumes(repo, operationId)
-            try {
-                for (vol in providers.storage.listVolumes(repo)) {
-                    val desc = vol.properties?.get("path")?.toString() ?: vol.name
-
-                    if (operation.operation.type == Operation.Type.PUSH) {
-
-                        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
-                                message = "Creating archive for $desc"))
-
-                        val archive = "$scratch/${vol.name}.tar.gz"
-                        val args = arrayOf("tar", "czf", archive, ".")
-                        val process = ProcessBuilder()
-                                .directory(File("$base/${vol.name}"))
-                                .command(*args)
-                                .start()
-                        providers.commandExecutor.exec(process, args.joinToString())
-                        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
-
-                        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
-                                message = "Uploading archive for $desc"))
-                        // TODO - progress monitoring
-                        s3.putObject(bucket, "$key/${vol.name}.tar.gz", File(archive))
-                        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
-                    } else {
-                        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
-                                message = "Downloading archive for $desc"))
-
-                        val archive = "$scratch/${vol.name}.tar.gz"
-                        val obj = s3.getObject(bucket, "$key/${vol.name}.tar.gz")
-                        // TODO - progress monitoring
-                        obj.objectContent.use { input ->
-                            File(archive).outputStream().use { output ->
-                                input.copyTo(output)
-                            }
-                        }
-                        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
-
-                        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
-                                message = "Extracting archive for $desc"))
-                        val args = arrayOf("tar", "xzf", archive)
-                        val process = ProcessBuilder()
-                                .directory(File("$base/${vol.name}"))
-                                .command(*args)
-                                .start()
-                        providers.commandExecutor.exec(process, args.joinToString())
-                        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
-                    }
-                }
-
-                if (operation.operation.type == Operation.Type.PUSH) {
-                    val commit = providers.storage.getCommit(repo, operation.operation.commitId)
-                    val metadata = ObjectMetadata()
-                    val json = gson.toJson(commit)
-                    metadata.userMetadata = mapOf(METADATA_PROP to json)
-                    metadata.contentLength = 0
-                    val input = ByteArrayInputStream("".toByteArray())
-                    val request = PutObjectRequest(bucket, key, input, metadata)
-                    s3.putObject(request)
-
-                    appendMetadata(operation.remote, operation.params, json)
-                }
-            } finally {
-                providers.storage.unmountOperationVolumes(repo, operationId)
-            }
-        } finally {
-            providers.storage.destroyOperationScratch(repo, operationId)
+        init {
+            s3 = provider.getClient(operation.remote, operation.params)
+            val path = provider.getPath(operation.remote, operation.operation.commitId)
+            bucket = path.first
+            key = path.second
         }
-        // TODO cleanup on failure
+    }
+
+    override fun startOperation(operation: OperationExecutor): Any? {
+        return S3Operation(this, operation)
+    }
+
+    override fun pushVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String) {
+        data as S3Operation
+
+        val desc = getVolumeDesc(volume)
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
+                message = "Creating archive for $desc"))
+
+        val archive = "$scratchPath/${volume.name}.tar.gz"
+        val args = arrayOf("tar", "czf", archive, ".")
+        val process = ProcessBuilder()
+                .directory(File("$basePath/${volume.name}"))
+                .command(*args)
+                .start()
+        providers.commandExecutor.exec(process, args.joinToString())
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
+
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
+                message = "Uploading archive for $desc"))
+        // TODO - progress monitoring
+        data.s3.putObject(data.bucket, "${data.key}/${volume.name}.tar.gz", File(archive))
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
+    }
+
+    override fun pullVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String) {
+        data as S3Operation
+        val desc = getVolumeDesc(volume)
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
+                message = "Downloading archive for $desc"))
+
+        val archive = "$scratchPath/${volume.name}.tar.gz"
+        val obj = data.s3.getObject(data.bucket, "${data.key}/${volume.name}.tar.gz")
+        // TODO - progress monitoring
+        obj.objectContent.use { input ->
+            File(archive).outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
+
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
+                message = "Extracting archive for $desc"))
+        val args = arrayOf("tar", "xzf", archive)
+        val process = ProcessBuilder()
+                .directory(File("$basePath/${volume.name}"))
+                .command(*args)
+                .start()
+        providers.commandExecutor.exec(process, args.joinToString())
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
+    }
+
+    override fun pushMetadata(operation: OperationExecutor, data: Any?, commit: Commit, isUpdate: Boolean) {
+        data as S3Operation
+        val metadata = ObjectMetadata()
+        val json = gson.toJson(commit)
+        metadata.userMetadata = mapOf(METADATA_PROP to json)
+        metadata.contentLength = 0
+        val input = ByteArrayInputStream("".toByteArray())
+        val request = PutObjectRequest(data.bucket, data.key, input, metadata)
+        data.s3.putObject(request)
+
+        if (isUpdate) {
+            throw IllegalArgumentException("commit updates not yet supported")
+        }
+        appendMetadata(operation.remote, operation.params, json)
     }
 }

--- a/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
@@ -23,6 +23,7 @@ import io.titandata.models.RemoteParameters
 import io.titandata.operation.OperationExecutor
 import io.titandata.remote.BaseRemoteProvider
 import io.titandata.serialization.ModelTypeAdapters
+import io.titandata.util.TagFilter
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.InputStream
@@ -142,7 +143,7 @@ class S3RemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() {
         s3.putObject(PutObjectRequest(bucket, getMetadataKey(key), stream, objectMetadata))
     }
 
-    override fun listCommits(remote: Remote, params: RemoteParameters): List<Commit> {
+    override fun listCommits(remote: Remote, params: RemoteParameters, tags: List<String>?): List<Commit> {
         val metadata = getMetadataContent(remote, params)
         val ret = mutableListOf<Commit>()
 
@@ -153,7 +154,7 @@ class S3RemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() {
         }
         metadata.close()
 
-        return ret
+        return TagFilter(tags).filter(ret)
     }
 
     override fun getCommit(remote: Remote, commitId: String, params: RemoteParameters): Commit {

--- a/server/src/main/kotlin/io/titandata/remote/s3web/S3WebRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3web/S3WebRemoteProvider.kt
@@ -8,10 +8,10 @@ import com.google.gson.GsonBuilder
 import io.titandata.ProviderModule
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.models.Commit
-import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
+import io.titandata.models.Volume
 import io.titandata.operation.OperationExecutor
 import io.titandata.remote.BaseRemoteProvider
 import io.titandata.serialization.ModelTypeAdapters
@@ -77,58 +77,45 @@ class S3WebRemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() 
                 ?: throw NoSuchObjectException("no such commit $commitId in remote '${remote.name}'")
     }
 
-    // TODO refactor this into manageable chunks
-    override fun runOperation(operation: OperationExecutor) {
-        if (operation.operation.type == Operation.Type.PUSH) {
-            throw IllegalStateException("push operations are not supported for s3web provider")
-        }
+    override fun pushVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String) {
+        throw IllegalStateException("push operations are not supported for s3web provider")
+    }
 
-        val repo = operation.repo
-        val operationId = operation.operation.id
+    override fun pullVolume(operation: OperationExecutor, data: Any?, volume: Volume, basePath: String, scratchPath: String) {
         val remote = operation.remote as S3WebRemote
+        val desc = volume.properties?.get("path")?.toString() ?: volume.name
         val commitId = operation.operation.commitId
 
-        val scratch = providers.storage.createOperationScratch(repo, operationId)
-        try {
-            val base = providers.storage.mountOperationVolumes(repo, operationId)
-            try {
-                for (vol in providers.storage.listVolumes(repo)) {
-                    val desc = vol.properties?.get("path")?.toString() ?: vol.name
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
+                message = "Downloading archive for $desc"))
 
-                    operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
-                            message = "Downloading archive for $desc"))
-
-                    val path = "$commitId/${vol.name}.tar.gz"
-                    val response = getFile(remote, path)
-                    if (!response.isSuccessful) {
-                        throw IOException("failed to get ${remote.url}/$path, error code ${response.code}")
-                    }
-                    val archive = "$scratch/${vol.name}.tar.gz"
-                    val archiveFile = File(archive)
-                    response.body!!.byteStream().use { input ->
-                        archiveFile.outputStream().use { output ->
-                            input.copyTo(output)
-                        }
-                    }
-
-                    operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
-
-                    operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
-                            message = "Extracting archive for $desc"))
-                    val args = arrayOf("tar", "xzf", archive)
-                    val process = ProcessBuilder()
-                            .directory(File("$base/${vol.name}"))
-                            .command(*args)
-                            .start()
-                    providers.commandExecutor.exec(process, args.joinToString())
-                    operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
-                }
-            } finally {
-                providers.storage.unmountOperationVolumes(repo, operationId)
-            }
-        } finally {
-            providers.storage.destroyOperationScratch(repo, operationId)
+        val path = "$commitId/${volume.name}.tar.gz"
+        val response = getFile(remote, path)
+        if (!response.isSuccessful) {
+            throw IOException("failed to get ${remote.url}/$path, error code ${response.code}")
         }
-        // TODO cleanup on failure
+        val archive = "$scratchPath/${volume.name}.tar.gz"
+        val archiveFile = File(archive)
+        response.body!!.byteStream().use { input ->
+            archiveFile.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
+
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
+                message = "Extracting archive for $desc"))
+        val args = arrayOf("tar", "xzf", archive)
+        val process = ProcessBuilder()
+                .directory(File("$basePath/${volume.name}"))
+                .command(*args)
+                .start()
+        providers.commandExecutor.exec(process, args.joinToString())
+        operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
+    }
+
+    override fun pushMetadata(operation: OperationExecutor, data: Any?, commit: Commit, isUpdate: Boolean) {
+        throw IllegalStateException("push operations are not supported for s3web provider")
     }
 }

--- a/server/src/main/kotlin/io/titandata/remote/s3web/S3WebRemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3web/S3WebRemoteProvider.kt
@@ -15,6 +15,7 @@ import io.titandata.models.RemoteParameters
 import io.titandata.operation.OperationExecutor
 import io.titandata.remote.BaseRemoteProvider
 import io.titandata.serialization.ModelTypeAdapters
+import io.titandata.util.TagFilter
 import java.io.File
 import java.io.IOException
 import okhttp3.OkHttpClient
@@ -64,8 +65,8 @@ class S3WebRemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() 
         return ret
     }
 
-    override fun listCommits(remote: Remote, params: RemoteParameters): List<Commit> {
-        return getAllCommits(remote)
+    override fun listCommits(remote: Remote, params: RemoteParameters, tags: List<String> ?): List<Commit> {
+        return TagFilter(tags).filter(getAllCommits(remote))
     }
 
     override fun getCommit(remote: Remote, commitId: String, params: RemoteParameters): Commit {

--- a/server/src/main/kotlin/io/titandata/storage/OperationData.kt
+++ b/server/src/main/kotlin/io/titandata/storage/OperationData.kt
@@ -12,5 +12,6 @@ import io.titandata.models.RemoteParameters
  */
 data class OperationData(
     val operation: Operation,
-    val params: RemoteParameters
+    val params: RemoteParameters,
+    var metadataOnly: Boolean = false
 )

--- a/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
@@ -29,7 +29,7 @@ interface StorageProvider {
     fun createCommit(repo: String, commit: Commit): Commit
     fun getCommit(repo: String, id: String): Commit
     fun getCommitStatus(repo: String, id: String): CommitStatus
-    fun listCommits(repo: String): List<Commit>
+    fun listCommits(repo: String, tags: List<String>?): List<Commit>
     fun deleteCommit(repo: String, commit: String)
     fun checkoutCommit(repo: String, commit: String)
 

--- a/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
@@ -32,6 +32,7 @@ interface StorageProvider {
     fun listCommits(repo: String, tags: List<String>?): List<Commit>
     fun deleteCommit(repo: String, commit: String)
     fun checkoutCommit(repo: String, commit: String)
+    fun updateCommit(repo: String, commit: Commit)
 
     fun createOperation(repo: String, operation: OperationData, localCommit: String? = null)
     fun listOperations(repo: String): List<OperationData>

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsCommitManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsCommitManager.kt
@@ -267,4 +267,17 @@ class ZfsCommitManager(val provider: ZfsStorageProvider) {
             }
         }
     }
+
+    /**
+     * Update the metadata for the given commit. This is generally used to change the tags, though it's up to the
+     * client so it could be used to update other parts of the metadata.
+     */
+    fun updateCommit(repo: String, commit: Commit) {
+        provider.validateRepositoryName(repo)
+        val guid = provider.getCommitGuid(repo, commit.id)
+        guid ?: throw NoSuchObjectException("no such commit '${commit.id}' in repository '$repo'")
+
+        val json = provider.gson.toJson(commit.properties)
+        provider.executor.exec("zfs", "set", "$METADATA_PROP=$json", "$poolName/repo/$repo/$guid@${commit.id}")
+    }
 }

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsRepositoryManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsRepositoryManager.kt
@@ -168,7 +168,8 @@ class ZfsRepositoryManager(val provider: ZfsStorageProvider) {
      */
     fun getRepositoryStatus(name: String): RepositoryStatus {
         provider.validateRepositoryName(name)
-        val commits = provider.commitManager.listCommits(name)
+        // This is not particularly efficient, but we don't have a better way
+        val commits = provider.commitManager.listCommits(name, null)
         val latest = commits.getOrNull(0)?.id
         val guid = provider.getActive(name)
 

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -58,6 +58,7 @@ class ZfsStorageProvider(
     internal val OPERATION_PROP = "io.titan-data:operation"
     internal val REAPER_PROP = "io.titan-data:reaper"
     internal val INITIAL_COMMIT = "initial"
+    internal val TAGS_METADATA = "tags"
     internal val executor = CommandExecutor()
     internal val generator = GuidGenerator()
 
@@ -333,8 +334,8 @@ class ZfsStorageProvider(
     }
 
     @Synchronized
-    override fun listCommits(repo: String): List<Commit> {
-        return commitManager.listCommits(repo)
+    override fun listCommits(repo: String, tags: List<String>?): List<Commit> {
+        return commitManager.listCommits(repo, tags)
     }
 
     @Synchronized

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -351,6 +351,12 @@ class ZfsStorageProvider(
     }
 
     @Synchronized
+    override fun updateCommit(repo: String, commit: Commit) {
+        log.info("updating commit ${commit.id} in $repo")
+        commitManager.updateCommit(repo, commit)
+    }
+
+    @Synchronized
     override fun createOperation(repo: String, operation: OperationData, localCommit: String?) {
         log.info("create operation ${operation.operation.id} in $repo")
         operationManager.createOperation(repo, operation, localCommit)

--- a/server/src/main/kotlin/io/titandata/util/TagFilter.kt
+++ b/server/src/main/kotlin/io/titandata/util/TagFilter.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+package io.titandata.util
+
+import io.titandata.models.Commit
+
+/**
+ * This is a utility class that helps with matching tag searches to commits. While we expect to provide more enhanced
+ * filtering capabilities (e.g. doing it server-side for remote logs), this will always serve as a foundation where
+ * we need basic filtering capabilities.
+ */
+class TagFilter(val tags: List<String> ?) {
+
+    private val TAGS_METADATA = "tags"
+    private val matches: List<Pair<String, String?>>
+
+    init {
+        matches = tags?.map {
+            if (it.contains("=")) {
+                Pair(it.substringBefore("="), it.substringAfter("="))
+            } else {
+                Pair(it, null)
+            }
+        } ?: listOf()
+    }
+
+    fun match(commit: Commit): Boolean {
+        if (matches.size == 0) {
+            return true
+        }
+
+        val metadata = commit.properties.get(TAGS_METADATA)
+        if (metadata == null || metadata !is Map<*, *>) {
+            return false
+        }
+        @Suppress("UNCHECKED_CAST")
+        metadata as Map<String, String>
+
+        for (match in matches) {
+            val key = match.first
+            if (!metadata.containsKey(key)) {
+                return false
+            }
+
+            if (match.second != null && metadata.get(key) != match.second) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    fun filter(commits: List<Commit>): List<Commit> {
+        return commits.filter { match(it) }
+    }
+}

--- a/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
@@ -164,6 +164,14 @@ class OperationProviderTest : StringSpec() {
             }
         }
 
+        "pull fails if local commit does not exist and metadata only set" {
+            every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
+            every { zfsStorageProvider.getCommit(any(), any()) } throws NoSuchObjectException("")
+            shouldThrow<ObjectExistsException> {
+                provider.startPull("foo", "remote", "commit", NopParameters(), true)
+            }
+        }
+
         "pull succeeds" {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
             every { zfsStorageProvider.getCommit(any(), any()) } throws NoSuchObjectException("")

--- a/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
@@ -27,6 +27,7 @@ import io.titandata.models.Commit
 import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Repository
+import io.titandata.models.Volume
 import io.titandata.remote.engine.EngineParameters
 import io.titandata.remote.nop.NopParameters
 import io.titandata.remote.nop.NopRemote
@@ -178,6 +179,11 @@ class OperationProviderTest : StringSpec() {
             every { generator.get() } returns "id"
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.commitOperation("foo", "id", any()) } just Runs
+            every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
+            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
+            every { zfsStorageProvider.listVolumes("foo") } returns listOf(Volume(name = "v0"))
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPull("foo", "remote", "commit", NopParameters())
             op.id shouldBe "id"
             op.commitId shouldBe "commit"
@@ -207,6 +213,11 @@ class OperationProviderTest : StringSpec() {
             every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws Exception("error")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
+            every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
+            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
+            every { zfsStorageProvider.listVolumes("foo") } returns listOf(Volume(name = "v0"))
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPull("foo", "remote", "commit", NopParameters())
             provider.getExecutor("foo", op.id).join()
             op = provider.getOperation("foo", op.id)
@@ -227,6 +238,11 @@ class OperationProviderTest : StringSpec() {
             every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws InterruptedException()
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
+            every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
+            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
+            every { zfsStorageProvider.listVolumes("foo") } returns listOf(Volume(name = "v0"))
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPull("foo", "remote", "commit", NopParameters())
             provider.getExecutor("foo", op.id).join()
             op = provider.getOperation("foo", op.id)
@@ -252,6 +268,11 @@ class OperationProviderTest : StringSpec() {
             every { zfsStorageProvider.getCommit(any(), any()) } throws NoSuchObjectException("")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.commitOperation("foo", "id", any()) } just Runs
+            every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
+            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
+            every { zfsStorageProvider.listVolumes("foo") } returns listOf(Volume(name = "v0"))
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPull("foo", "remote", "commit2", NopParameters())
             provider.getExecutor("foo", op.id).join()
             provider.getOperation("foo", op.id)
@@ -294,6 +315,11 @@ class OperationProviderTest : StringSpec() {
             every { generator.get() } returns "id"
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
+            every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
+            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
+            every { zfsStorageProvider.listVolumes("foo") } returns listOf(Volume(name = "v0"))
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPush("foo", "remote", "commit", NopParameters())
             op.id shouldBe "id"
             op.commitId shouldBe "commit"
@@ -324,6 +350,11 @@ class OperationProviderTest : StringSpec() {
             every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws Exception("error")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
+            every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
+            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
+            every { zfsStorageProvider.listVolumes("foo") } returns listOf(Volume(name = "v0"))
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPush("foo", "remote", "commit", NopParameters())
             provider.getExecutor("foo", op.id).join()
             op = provider.getOperation("foo", op.id)
@@ -344,6 +375,11 @@ class OperationProviderTest : StringSpec() {
             every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws InterruptedException("error")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
+            every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
+            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
+            every { zfsStorageProvider.listVolumes("foo") } returns listOf(Volume(name = "v0"))
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPush("foo", "remote", "commit", NopParameters())
             provider.getExecutor("foo", op.id).join()
             op = provider.getOperation("foo", op.id)
@@ -371,6 +407,11 @@ class OperationProviderTest : StringSpec() {
             every { generator.get() } returns "id"
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
+            every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
+            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
+            every { zfsStorageProvider.listVolumes("foo") } returns listOf(Volume(name = "v0"))
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPush("foo", "remote", "commit2", NopParameters())
             provider.getExecutor("foo", op.id).join()
             op = provider.getOperation("foo", op.id)
@@ -417,6 +458,12 @@ class OperationProviderTest : StringSpec() {
             every { zfsStorageProvider.getRepository("foo") } returns Repository(name = "foo", properties = mapOf())
             every { zfsStorageProvider.getRemotes("foo") } returns listOf(
                     NopRemote(name = "remote"))
+            every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
+            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
+            every { zfsStorageProvider.listVolumes("foo") } returns listOf(Volume(name = "v0"))
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
+            every { zfsStorageProvider.getCommit("foo", any()) } returns Commit(id = "hash", properties = mapOf())
             provider.loadState()
 
             var op = provider.getOperation("foo", "id")

--- a/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
@@ -204,7 +204,7 @@ class OperationProviderTest : StringSpec() {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
             every { zfsStorageProvider.getCommit(any(), any()) } throws NoSuchObjectException("")
             every { generator.get() } returns "id"
-            every { nopRemoteProvider.runOperation(any()) } throws Exception("error")
+            every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws Exception("error")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             var op = provider.startPull("foo", "remote", "commit", NopParameters())
@@ -224,7 +224,7 @@ class OperationProviderTest : StringSpec() {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
             every { zfsStorageProvider.getCommit(any(), any()) } throws NoSuchObjectException("")
             every { generator.get() } returns "id"
-            every { nopRemoteProvider.runOperation(any()) } throws InterruptedException()
+            every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws InterruptedException()
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             var op = provider.startPull("foo", "remote", "commit", NopParameters())
@@ -321,7 +321,7 @@ class OperationProviderTest : StringSpec() {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
             every { zfsStorageProvider.getCommit(any(), any()) } returns Commit(id = "commit", properties = mapOf())
             every { generator.get() } returns "id"
-            every { nopRemoteProvider.runOperation(any()) } throws Exception("error")
+            every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws Exception("error")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             var op = provider.startPush("foo", "remote", "commit", NopParameters())
@@ -341,7 +341,7 @@ class OperationProviderTest : StringSpec() {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
             every { zfsStorageProvider.getCommit(any(), any()) } returns Commit(id = "commit", properties = mapOf())
             every { generator.get() } returns "id"
-            every { nopRemoteProvider.runOperation(any()) } throws InterruptedException("error")
+            every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws InterruptedException("error")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             var op = provider.startPush("foo", "remote", "commit", NopParameters())

--- a/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
@@ -67,7 +67,7 @@ class OperationProviderTest : StringSpec() {
 
     fun addOperation(type: Operation.Type = Operation.Type.PULL) {
         provider.addOperation(OperationExecutor(providers,
-                provider.buildOperation(type, "remote", "commit"),
+                provider.buildOperation(type, "remote", "commit", false),
                 "foo", NopRemote(name = "remote"),
                 NopParameters()))
     }

--- a/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
@@ -151,7 +151,7 @@ class OperationProviderTest : StringSpec() {
 
         "pull fails for non-existent remote commit" {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
-            every { nopRemoteProvider.validateOperation(any(), any(), any(), any()) } throws NoSuchObjectException("")
+            every { nopRemoteProvider.validateOperation(any(), any(), any(), any(), any()) } throws NoSuchObjectException("")
             shouldThrow<NoSuchObjectException> {
                 provider.startPull("foo", "remote", "commit", NopParameters())
             }
@@ -303,7 +303,7 @@ class OperationProviderTest : StringSpec() {
         "push fails if remote commit exists" {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
             every { zfsStorageProvider.getCommit(any(), any()) } returns Commit(id = "commit", properties = mapOf())
-            every { nopRemoteProvider.validateOperation(any(), any(), any(), any()) } throws ObjectExistsException("")
+            every { nopRemoteProvider.validateOperation(any(), any(), any(), any(), any()) } throws ObjectExistsException("")
             shouldThrow<ObjectExistsException> {
                 provider.startPush("foo", "remote", "commit", NopParameters())
             }

--- a/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationProviderTest.kt
@@ -68,7 +68,7 @@ class OperationProviderTest : StringSpec() {
 
     fun addOperation(type: Operation.Type = Operation.Type.PULL) {
         provider.addOperation(OperationExecutor(providers,
-                provider.buildOperation(type, "remote", "commit", false),
+                provider.buildOperation(type, "remote", "commit"),
                 "foo", NopRemote(name = "remote"),
                 NopParameters()))
     }
@@ -210,7 +210,7 @@ class OperationProviderTest : StringSpec() {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
             every { zfsStorageProvider.getCommit(any(), any()) } throws NoSuchObjectException("")
             every { generator.get() } returns "id"
-            every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws Exception("error")
+            every { nopRemoteProvider.startOperation(any()) } throws Exception("error")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
@@ -235,7 +235,7 @@ class OperationProviderTest : StringSpec() {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
             every { zfsStorageProvider.getCommit(any(), any()) } throws NoSuchObjectException("")
             every { generator.get() } returns "id"
-            every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws InterruptedException()
+            every { nopRemoteProvider.startOperation(any()) } throws InterruptedException("error")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
@@ -347,7 +347,7 @@ class OperationProviderTest : StringSpec() {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
             every { zfsStorageProvider.getCommit(any(), any()) } returns Commit(id = "commit", properties = mapOf())
             every { generator.get() } returns "id"
-            every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws Exception("error")
+            every { nopRemoteProvider.startOperation(any()) } throws Exception("error")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
@@ -372,7 +372,7 @@ class OperationProviderTest : StringSpec() {
             every { zfsStorageProvider.getRemotes(any()) } returns listOf(NopRemote(name = "remote"))
             every { zfsStorageProvider.getCommit(any(), any()) } returns Commit(id = "commit", properties = mapOf())
             every { generator.get() } returns "id"
-            every { nopRemoteProvider.syncVolume(any(), any(), any(), any(), any()) } throws InterruptedException("error")
+            every { nopRemoteProvider.startOperation(any()) } throws InterruptedException("error")
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""

--- a/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
@@ -151,7 +151,7 @@ class SshRemoteProviderTest : StringSpec() {
         "validate pull operation succeeds if remote commit exists" {
             every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
                     "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json") } returns "{\"id\":\"a\",\"properties\":{}}"
-            sshRemoteProvider.validateOperation(getRemote(), "a", Operation.Type.PULL, SshParameters())
+            sshRemoteProvider.validateOperation(getRemote(), "a", Operation.Type.PULL, SshParameters(), false)
         }
 
         "validate pull operation fails if remote commit does not exist" {
@@ -160,21 +160,37 @@ class SshRemoteProviderTest : StringSpec() {
                         "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json")
             } throws CommandException("", 1, "No such file or directory")
             shouldThrow<NoSuchObjectException> {
-                sshRemoteProvider.validateOperation(getRemote(), "a", Operation.Type.PULL, SshParameters())
+                sshRemoteProvider.validateOperation(getRemote(), "a", Operation.Type.PULL, SshParameters(), false)
             }
         }
 
         "validate push operation succeeds if remote commit does not exists" {
             every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
                     "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json") } throws CommandException("", 1, "No such file or directory")
-            sshRemoteProvider.validateOperation(getRemote(), "a", Operation.Type.PUSH, SshParameters())
+            sshRemoteProvider.validateOperation(getRemote(), "a", Operation.Type.PUSH, SshParameters(), false)
         }
 
-        "validate pull operation fails if remote commit exists" {
+        "validate push operation fails if remote commit exists" {
             every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
                     "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json") } returns "{\"id\":\"a\",\"properties\":{}}"
             shouldThrow<ObjectExistsException> {
-                sshRemoteProvider.validateOperation(getRemote(), "a", Operation.Type.PUSH, SshParameters())
+                sshRemoteProvider.validateOperation(getRemote(), "a", Operation.Type.PUSH, SshParameters(), false)
+            }
+        }
+
+        "validate metadata only push operation succeeds if remote commit exists" {
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json") } returns "{\"id\":\"a\",\"properties\":{}}"
+            sshRemoteProvider.validateOperation(getRemote(), "a", Operation.Type.PUSH, SshParameters(), true)
+        }
+
+        "validate metadata only push operation fails if remote commit does not exist" {
+            every {
+                executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                        "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json")
+            } throws CommandException("", 1, "No such file or directory")
+            shouldThrow<NoSuchObjectException> {
+                sshRemoteProvider.validateOperation(getRemote(), "a", Operation.Type.PUSH, SshParameters(), true)
             }
         }
 

--- a/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
@@ -98,6 +98,18 @@ class SshRemoteProviderTest : StringSpec() {
             result[1].id shouldBe "b"
         }
 
+        "list commits filters result" {
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "ls", "-1", "/var/tmp") } returns "a\nb\n"
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json") } returns "{\"id\":\"a\",\"properties\":{\"tags\":{\"c\":\"d\"}}}"
+            every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/b/metadata.json") } returns "{\"id\":\"b\",\"properties\":{}}"
+            val result = provider.listCommits(getRemote(), SshParameters(), listOf("c"))
+            result.size shouldBe 1
+            result[0].id shouldBe "a"
+        }
+
         "list commits ignores missing file" {
             every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
                     "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "ls", "-1", "/var/tmp") } returns "a\n"

--- a/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
@@ -81,7 +81,7 @@ class SshRemoteProviderTest : StringSpec() {
     init {
         "list commits returns an empty list" {
             every { executor.exec(*anyVararg()) } returns ""
-            val result = provider.listCommits(getRemote(), SshParameters())
+            val result = provider.listCommits(getRemote(), SshParameters(), null)
             result.size shouldBe 0
         }
 
@@ -92,7 +92,7 @@ class SshRemoteProviderTest : StringSpec() {
                     "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json") } returns "{\"id\":\"a\",\"properties\":{}}"
             every { executor.exec("sshpass", "-f", any(), "ssh", "-o", "StrictHostKeyChecking=no",
                     "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/b/metadata.json") } returns "{\"id\":\"b\",\"properties\":{}}"
-            val result = provider.listCommits(getRemote(), SshParameters())
+            val result = provider.listCommits(getRemote(), SshParameters(), null)
             result.size shouldBe 2
             result[0].id shouldBe "a"
             result[1].id shouldBe "b"
@@ -105,7 +105,7 @@ class SshRemoteProviderTest : StringSpec() {
                     "-o", "UserKnownHostsFile=/dev/null", "root@localhost", "cat", "/var/tmp/a/metadata.json") } throws CommandException("", 1,
                     "No such file or directory")
 
-            val result = provider.listCommits(getRemote(), SshParameters())
+            val result = provider.listCommits(getRemote(), SshParameters(), null)
             result.size shouldBe 0
         }
 

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsCommitTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsCommitTest.kt
@@ -254,6 +254,39 @@ class ZfsCommitTest : StringSpec() {
             result[1].properties["c"] shouldBe "d"
         }
 
+        "list commits filters exact result" {
+            every { executor.exec(*anyVararg()) } returns arrayOf(
+                    "test/repo/foo@ignore\toff\t{}",
+                    "test/repo/foo/guid1@hash1\toff\t{\"tags\":{\"a\":\"b\"}}",
+                    "test/repo/foo/guid2@hash2\toff\t{\"tags\":{\"c\":\"d\"}}"
+            ).joinToString("\n")
+            val result = provider.listCommits("foo", listOf("a=b"))
+            result.size shouldBe 1
+            result[0].id shouldBe "hash1"
+        }
+
+        "list commits filters exists result" {
+            every { executor.exec(*anyVararg()) } returns arrayOf(
+                    "test/repo/foo@ignore\toff\t{}",
+                    "test/repo/foo/guid1@hash1\toff\t{\"tags\":{\"a\":\"b\"}}",
+                    "test/repo/foo/guid2@hash2\toff\t{\"tags\":{\"c\":\"d\"}}"
+            ).joinToString("\n")
+            val result = provider.listCommits("foo", listOf("a"))
+            result.size shouldBe 1
+            result[0].id shouldBe "hash1"
+        }
+
+        "list commits filters compound result" {
+            every { executor.exec(*anyVararg()) } returns arrayOf(
+                    "test/repo/foo@ignore\toff\t{}",
+                    "test/repo/foo/guid1@hash1\toff\t{\"tags\":{\"a\":\"b\",\"c\":\"d\"}}",
+                    "test/repo/foo/guid2@hash2\toff\t{\"tags\":{\"c\":\"d\"}}"
+            ).joinToString("\n")
+            val result = provider.listCommits("foo", listOf("a=b", "c=d"))
+            result.size shouldBe 1
+            result[0].id shouldBe "hash1"
+        }
+
         "list commits ignores initial commit" {
             every { executor.exec(*anyVararg()) } returns arrayOf(
                     "test/repo/foo@ignore\toff\t{}",
@@ -266,7 +299,7 @@ class ZfsCommitTest : StringSpec() {
             result[0].properties["c"] shouldBe "d"
         }
 
-        "list commits ignores snapshots with defer_destory set" {
+        "list commits ignores snapshots with defer_destroy set" {
             every { executor.exec(*anyVararg()) } returns arrayOf(
                     "test/repo/foo@ignore\toff\t{}",
                     "test/repo/foo/guid1@hash1\ton\t{\"a\":\"b\"}",

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsCommitTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsCommitTest.kt
@@ -224,13 +224,13 @@ class ZfsCommitTest : StringSpec() {
 
         "list commits fails with invalid repo name" {
             shouldThrow<IllegalArgumentException> {
-                provider.listCommits("not/ok")
+                provider.listCommits("not/ok", null)
             }
         }
 
         "list commits returns empty list with no output" {
             every { executor.exec(*anyVararg()) } returns ""
-            val result = provider.listCommits("foo")
+            val result = provider.listCommits("foo", null)
             result.size shouldBe 0
             verify {
                 executor.exec("zfs", "list", "-Ho",
@@ -246,7 +246,7 @@ class ZfsCommitTest : StringSpec() {
                     "test/repo/foo/guid1@hash1\toff\t{\"a\":\"b\"}",
                     "test/repo/foo/guid2@hash2\toff\t{\"c\":\"d\"}"
             ).joinToString("\n")
-            val result = provider.listCommits("foo")
+            val result = provider.listCommits("foo", null)
             result.size shouldBe 2
             result[0].id shouldBe "hash1"
             result[0].properties["a"] shouldBe "b"
@@ -260,7 +260,7 @@ class ZfsCommitTest : StringSpec() {
                     "test/repo/foo/guid1@initial\toff\t{\"a\":\"b\"}",
                     "test/repo/foo/guid2@hash2\toff\t{\"c\":\"d\"}"
             ).joinToString("\n")
-            val result = provider.listCommits("foo")
+            val result = provider.listCommits("foo", null)
             result.size shouldBe 1
             result[0].id shouldBe "hash2"
             result[0].properties["c"] shouldBe "d"
@@ -272,7 +272,7 @@ class ZfsCommitTest : StringSpec() {
                     "test/repo/foo/guid1@hash1\ton\t{\"a\":\"b\"}",
                     "test/repo/foo/guid2@hash2\toff\t{\"c\":\"d\"}"
             ).joinToString("\n")
-            val result = provider.listCommits("foo")
+            val result = provider.listCommits("foo", null)
             result.size shouldBe 1
             result[0].id shouldBe "hash2"
             result[0].properties["c"] shouldBe "d"
@@ -283,7 +283,7 @@ class ZfsCommitTest : StringSpec() {
                     "test/repo/foo/guid1@hash1\toff\t{\"timestamp\":\"2019-10-08T15:10:54Z\"}",
                     "test/repo/foo/guid2@hash2\toff\t{\"timestamp\":\"2019-10-08T15:20:54Z\"}"
             ).joinToString("\n")
-            val result = provider.listCommits("foo")
+            val result = provider.listCommits("foo", null)
             result.size shouldBe 2
             result[0].id shouldBe "hash2"
             result[1].id shouldBe "hash1"
@@ -292,7 +292,7 @@ class ZfsCommitTest : StringSpec() {
         "list commits throws exception for non-existent repo" {
             every { executor.exec(*anyVararg()) } throws CommandException("", 1, "does not exist")
             shouldThrow<NoSuchObjectException> {
-                provider.listCommits("foo")
+                provider.listCommits("foo", null)
             }
         }
 

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsOperationTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsOperationTest.kt
@@ -122,7 +122,7 @@ class ZfsOperationTest : StringSpec() {
             val op = getOperation()
             val json = "{\"operation\":{\"id\":\"id\"," +
                     "\"type\":\"PUSH\",\"state\":\"RUNNING\",\"remote\":\"remote\"," +
-                    "\"commitId\":\"commit\"},\"params\":{\"provider\":\"nop\",\"delay\":0}}"
+                    "\"commitId\":\"commit\",\"metadataOnly\":false},\"params\":{\"provider\":\"nop\",\"delay\":0}}"
             every { executor.start(*anyVararg()) } returns mockk()
             every { executor.exec(any<Process>(), any()) } returns ""
             provider.createOperation("foo", op, "hash")
@@ -273,7 +273,7 @@ class ZfsOperationTest : StringSpec() {
             mockOperation()
             val newJson = "{\"operation\":{\"id\":\"id\"," +
                     "\"type\":\"PUSH\",\"state\":\"COMPLETE\",\"remote\":\"remote\"," +
-                    "\"commitId\":\"commit\"},\"params\":{\"provider\":\"nop\",\"delay\":0}}"
+                    "\"commitId\":\"commit\",\"metadataOnly\":false},\"params\":{\"provider\":\"nop\",\"delay\":0}}"
             every { executor.start(*anyVararg()) } returns mockk()
             every { executor.exec(any<Process>(), any()) } returns ""
 

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsOperationTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsOperationTest.kt
@@ -109,20 +109,16 @@ class ZfsOperationTest : StringSpec() {
         }
 
         "create operation succeeds" {
+            every { executor.exec(*anyVararg()) } returns ""
             every { executor.exec("zfs", "list", "-Ho", "name,defer_destroy", "-t", "snapshot",
                     "-d", "2", "test/repo/foo")
             } returns "test/repo/foo/guid@hash\toff"
             every { executor.exec("zfs", "list", "-rHo", "name,io.titan-data:metadata", "test/repo/foo/guid") } returns
                     arrayOf("test/repo/foo/guid\t-", "test/repo/foo/guid/v0\t{}", "test/repo/foo/guid/v1\t{}").joinToString("\n")
-            every { executor.exec("zfs", "create", "test/repo/foo/id") } returns ""
-            every { executor.exec("zfs", "clone", "-o", "io.titan-data:metadata={}", "test/repo/foo/guid/v0@hash",
-                    "test/repo/foo/id/v0") } returns ""
-            every { executor.exec("zfs", "clone", "-o", "io.titan-data:metadata={}", "test/repo/foo/guid/v1@hash",
-                    "test/repo/foo/id/v1") } returns ""
             val op = getOperation()
             val json = "{\"operation\":{\"id\":\"id\"," +
                     "\"type\":\"PUSH\",\"state\":\"RUNNING\",\"remote\":\"remote\"," +
-                    "\"commitId\":\"commit\",\"metadataOnly\":false},\"params\":{\"provider\":\"nop\",\"delay\":0}}"
+                    "\"commitId\":\"commit\"},\"params\":{\"provider\":\"nop\",\"delay\":0},\"metadataOnly\":false}"
             every { executor.start(*anyVararg()) } returns mockk()
             every { executor.exec(any<Process>(), any()) } returns ""
             provider.createOperation("foo", op, "hash")
@@ -273,7 +269,7 @@ class ZfsOperationTest : StringSpec() {
             mockOperation()
             val newJson = "{\"operation\":{\"id\":\"id\"," +
                     "\"type\":\"PUSH\",\"state\":\"COMPLETE\",\"remote\":\"remote\"," +
-                    "\"commitId\":\"commit\",\"metadataOnly\":false},\"params\":{\"provider\":\"nop\",\"delay\":0}}"
+                    "\"commitId\":\"commit\"},\"params\":{\"provider\":\"nop\",\"delay\":0},\"metadataOnly\":false}"
             every { executor.start(*anyVararg()) } returns mockk()
             every { executor.exec(any<Process>(), any()) } returns ""
 

--- a/server/src/test/kotlin/io/titandata/util/TagFilterTest.kt
+++ b/server/src/test/kotlin/io/titandata/util/TagFilterTest.kt
@@ -1,0 +1,59 @@
+package io.titandata.util
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import io.titandata.models.Commit
+
+class TagFilterTest : StringSpec() {
+
+    fun makeCommit(tags: Map<String, String>? = null): Commit {
+        if (tags != null) {
+            return Commit(id = "id", properties = mapOf("tags" to tags as Any))
+        } else {
+            return Commit(id = "id", properties = mapOf())
+        }
+    }
+
+    init {
+        "null tags allows any commit" {
+            TagFilter(null).match(makeCommit()) shouldBe true
+            TagFilter(null).match(makeCommit(mapOf("a" to "b"))) shouldBe true
+            TagFilter(null).match(makeCommit(mapOf("c" to "d"))) shouldBe true
+        }
+
+        "empty tags allows any commit" {
+            TagFilter(listOf()).match(makeCommit()) shouldBe true
+            TagFilter(listOf()).match(makeCommit(mapOf("a" to "b"))) shouldBe true
+            TagFilter(listOf()).match(makeCommit(mapOf("c" to "d"))) shouldBe true
+        }
+
+        "exact match works correctly" {
+            TagFilter(listOf("a=b")).match(makeCommit()) shouldBe false
+            TagFilter(listOf("a=b")).match(makeCommit(mapOf("a" to "b"))) shouldBe true
+            TagFilter(listOf("a=b")).match(makeCommit(mapOf("c" to "d"))) shouldBe false
+        }
+
+        "existence match works correctly" {
+            TagFilter(listOf("a")).match(makeCommit()) shouldBe false
+            TagFilter(listOf("a")).match(makeCommit(mapOf("a" to "b"))) shouldBe true
+            TagFilter(listOf("a")).match(makeCommit(mapOf("c" to "d"))) shouldBe false
+        }
+
+        "multiple checks works correctly" {
+            val filter = TagFilter(listOf("a", "c=d"))
+            filter.match(makeCommit(mapOf("a" to "b"))) shouldBe false
+            filter.match(makeCommit(mapOf("c" to "d"))) shouldBe false
+            filter.match(makeCommit(mapOf("a" to "b", "c" to "d"))) shouldBe true
+        }
+
+        "filter prunes list" {
+            val filter = TagFilter(listOf("a=b"))
+            val commits = filter.filter(listOf(makeCommit(), makeCommit(mapOf("a" to "b")),
+                    makeCommit(mapOf("c" to "d"))))
+            commits.size shouldBe 1
+            @Suppress("UNCHECKED_CAST")
+            val tags = commits[0].properties["tags"] as Map<String, String>
+            tags["a"] shouldBe "b"
+        }
+    }
+}


### PR DESCRIPTION
## Issues Addressed

Fixes #53 

## Proposed Changes

This adds:

- A new updateCommit endpoint that will update local metadata
- New filter parameters to log to be able to filter local and remote commits
- A new 'metadataOnly' flag for push & pull that will only ship commit metadata so tags can be added and pushed after the fact

While doing this work, I decided to refactor the single `runOperation` method of providers into several different steps, otherwise I'd have to push the `metadataonly` logic down into each and every provider.

## Testing

Ran unit, integration, and endtoend tests (including engine tests).