### PR TITLE
Add source commit and fix S3 metadata update

### DIFF
--- a/client/src/main/kotlin/io/titandata/models/RepositoryStatus.kt
+++ b/client/src/main/kotlin/io/titandata/models/RepositoryStatus.kt
@@ -7,7 +7,7 @@ package io.titandata.models
 data class RepositoryStatus(
     var logicalSize: Long,
     var actualSize: Long,
-    var checkedOutFrom: String?,
     var lastCommit: String?,
+    var sourceCommit: String?,
     var volumeStatus: List<RepositoryVolumeStatus>
 )

--- a/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
@@ -144,6 +144,12 @@ class LocalWorkflowTest : EndToEndTest() {
             result shouldBe "Hello\n"
         }
 
+        "last commit should not be set" {
+            val status = repoApi.getRepositoryStatus("foo")
+            status.sourceCommit shouldBe null
+            status.lastCommit shouldBe null
+        }
+
         "create commit succeeds" {
             val commit = commitApi.createCommit("foo", Commit(id = "id",
                     properties = mapOf("tags" to mapOf("a" to "b", "c" to "d"))))
@@ -188,7 +194,7 @@ class LocalWorkflowTest : EndToEndTest() {
 
         "get repository status succeeds" {
             val status = repoApi.getRepositoryStatus("foo")
-            status.checkedOutFrom shouldBe null
+            status.sourceCommit shouldBe "id"
             status.lastCommit shouldBe "id"
             status.logicalSize shouldNotBe 0
             status.actualSize shouldNotBe 0
@@ -244,7 +250,7 @@ class LocalWorkflowTest : EndToEndTest() {
 
         "get repository status indicates source commit" {
             val status = repoApi.getRepositoryStatus("foo")
-            status.checkedOutFrom shouldBe "id"
+            status.sourceCommit shouldBe "id"
             status.lastCommit shouldBe "id"
         }
 

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/s3/S3WorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/s3/S3WorkflowTest.kt
@@ -190,6 +190,11 @@ class S3WorkflowTest : EndToEndTest() {
             exception.code shouldBe "ObjectExistsException"
         }
 
+        "push same commit metadata succeeds" {
+            val op = operationApi.push("foo", "origin", "id", S3Parameters(), true)
+            waitForOperation(op.id)
+        }
+
         "create second commit succeeds" {
             commitApi.createCommit("foo", Commit(id = "id2", properties = mapOf()))
         }

--- a/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
@@ -121,6 +121,7 @@ class RepositoriesApiTest : StringSpec() {
         }
 
         "get repository status succeeds" {
+            every { executor.exec(*anyVararg()) } returns ""
             every { executor.exec("zfs", "list", "-Ho", "name,defer_destroy,io.titan-data:metadata", "-t", "snapshot",
                     "-d", "2", "test/repo/foo") } returns "test/repo/foo/guid@hash\toff\t{}\n"
             every { executor.exec("zfs", "list", "-Ho", "io.titan-data:metadata",
@@ -140,7 +141,7 @@ class RepositoriesApiTest : StringSpec() {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
                 response.content shouldBe "{\"logicalSize\":40,\"actualSize\":20," +
-                    "\"checkedOutFrom\":\"sourcehash\",\"lastCommit\":\"hash\",\"volumeStatus\":[" +
+                    "\"lastCommit\":\"hash\",\"sourceCommit\":\"sourcehash\",\"volumeStatus\":[" +
                 "{\"name\":\"v0\",\"logicalSize\":5,\"actualSize\":10,\"properties\":{\"path\":\"/var/a\"}}," +
                 "{\"name\":\"v1\",\"logicalSize\":8,\"actualSize\":16,\"properties\":{\"path\":\"/var/b\"}}]}"
             }

--- a/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
@@ -154,7 +154,7 @@ class S3RemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() {
             } else {
                 gson.toJson(it)
             }
-        }.joinToString("\n")
+        }.joinToString("\n") + "\n"
 
         s3.putObject(bucket, getMetadataKey(key), metadata)
     }

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -263,6 +263,25 @@ class ZfsStorageProvider(
         return executor.exec(process, argString)
     }
 
+    /**
+     * Return the latest snapshot for a given ZFS dataset.
+     */
+    fun getLatestSnapshot(dataset: String): String? {
+        val output = executor.exec("zfs", "list", "-pHo", "name,creation", "-t", "snapshot", "-d", "1",
+                dataset).trim()
+
+        if (output == "") {
+            return null
+        }
+
+        // Get the most recent snapshot
+        val snaps = output.split("\n").map {
+            it.trim().split("\t")
+        }
+        val sorted = snaps.sortedByDescending { it[1].toLong() }
+        return sorted[0][0].substringAfterLast("@")
+    }
+
     /*
      * The remainder of this class simply redirects methods to the appropriate helper class. They
      * are all annotated as synchronized as a simple (if incomplete) guard to prevent concurrent


### PR DESCRIPTION
## Issues Addressed

Fixes #54 

## Proposed Changes

While testing the new tags changes, I found that S3 was broken. When we updated the metadata, we did not include a trailing newline in the S3 metadata. When you later pushed another commit, this would end up with two commits on the same line, breaking the ability to list commits from then on.

While I was there, I also fixed #54 so that we track the proper sourceCommit for any repository. The source commit is the "last commit" prior to the current state. This is either (a) the previous commit if one was made after checkout, or (b) the source commit of the checkout if no commits have been made since.

## Testing

Build, test, integration test, end to end test. Manually tested with in-progress CLI support for tags.