### PR TITLE
switch to published sshtest

### DIFF
--- a/server/docker/sshtest.Dockerfile
+++ b/server/docker/sshtest.Dockerfile
@@ -1,4 +1,0 @@
-FROM rastasheep/ubuntu-sshd:18.04
-RUN apt-get -y update --fix-missing
-
-RUN apt-get -y install sudo rsync

--- a/server/gradle/docker.gradle.kts
+++ b/server/gradle/docker.gradle.kts
@@ -32,12 +32,6 @@ var tagLocalDockerServer = tasks.register<Exec>("tagLocalDockerServer") {
     mustRunAfter(tasks.named("buildDockerServer"))
 }
 
-var buildSshServer = tasks.register<Exec>("buildSshTestServer") {
-    group = LifecycleBasePlugin.BUILD_GROUP
-    description = "Build SSH endtoend server image"
-    commandLine("docker", "build", "-t", "sshtest:latest", "-f", "${project.projectDir}/docker/sshtest.Dockerfile", "${project.projectDir}")
-}
-
 tasks.named("assemble").configure {
     dependsOn(buildDockerServer)
     dependsOn(tagDockerServer)
@@ -49,27 +43,3 @@ tasks.named("rebuild").configure {
     dependsOn(rebuildDockerServer)
     dependsOn(tagLocalDockerServer)
 }
-
-tasks.named("endtoendTest").configure {
-    dependsOn(buildSshServer)
-}
-
-var publishDockerVersion = tasks.register<Exec>("publishDockerVersion") {
-    group = "Publishing"
-    description = "Publish versioned docker server image to docker hub"
-    commandLine("docker", "push", "$imageName:${project.version}")
-    mustRunAfter(tasks.named("tagDockerServer"))
-}
-
-var publishDockerLatest = tasks.register<Exec>("publishDockerLatest") {
-    group = "Publishing"
-    description = "Publish latest docker server image to docker hub"
-    commandLine("docker", "push", "$imageName:latest")
-    mustRunAfter(tasks.named("publishDockerVersion"))
-}
-
-tasks.named("publish").configure {
-    dependsOn(publishDockerVersion)
-    dependsOn(publishDockerLatest)
-}
-

--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -166,7 +166,7 @@ class DockerUtil(
 
     fun startSsh() {
         executor.exec("docker", "run", "-p", "$sshPort:22", "-d", "--name", "$identity-ssh",
-                "sshtest:latest")
+                "titandata/ssh-test-server:latest")
     }
 
     fun testSsh(): Boolean {


### PR DESCRIPTION
## Proposed Changes

We now have a `titandata/ssh-test-server` image that we can share across titan projects. This switches `titan-server` over to use it.

## Testing

Ran SshWorkflow endtoend tests.