### PR TITLE
TODO cleanup

### DIFF
--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -38,7 +38,7 @@ class DockerUtil(
     }
 
     companion object {
-        val log = LoggerFactory.getLogger(CommandExecutor::class.java)
+        val log = LoggerFactory.getLogger(DockerUtil::class.java)
     }
 
     fun startTitan(entryPoint: String, daemon: Boolean): String {

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/engine/EngineWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/engine/EngineWorkflowTest.kt
@@ -244,15 +244,6 @@ class EngineWorkflowTest : EndToEndTest() {
             exception.code shouldBe "IllegalArgumentException"
         }
 
-        /* TODO - we're not mapping login errors correctly in the SDK
-        "list commits with incorrect password fails" {
-            val exception = shouldThrow<ServerException> {
-                remoteApi.listRemoteCommits("foo", "origin", EngineParameters(password = "bar"))
-            }
-            exception.code shouldBe "CommandException"
-        }
-         */
-
         "delete volume succeeds" {
             volumeApi.unmountVolume(VolumeMountRequest(name = "foo/vol"))
             volumeApi.removeVolume(VolumeRequest(name = "foo/vol"))

--- a/server/src/integration-test/kotlin/io/titandata/RemotesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RemotesApiTest.kt
@@ -226,7 +226,10 @@ class RemotesApiTest : StringSpec() {
         "delete remote succeeds" {
             every { executor.start(*anyVararg()) } returns mockk()
             every { executor.exec(any<Process>(), any()) } returns ""
-            every { executor.exec(*anyVararg()) } returns
+            every { executor.exec(*anyVararg()) } returns ""
+            every { executor.exec("zfs", "list", "-Ho", "name,io.titan-data:metadata",
+                    "test/repo/repo") } returns "test/repo/repo\t{}"
+            every { executor.exec("zfs", "list", "-Ho", "io.titan-data:remotes", "test/repo/repo") } returns
                     "[{\"provider\":\"nop\",\"name\":\"foo\"}," +
                     "{\"provider\":\"engine\",\"name\":\"bar\",\"address\":\"a\"," +
                     "\"username\":\"u\",\"password\":\"p\"}]"

--- a/server/src/main/kotlin/io/titandata/apis/RemotesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/RemotesApi.kt
@@ -90,7 +90,13 @@ fun Route.RemotesApi(providers: ProviderModule) {
             if (idx == null) {
                 throw NoSuchObjectException("no such remote '$remoteName' in repository '$repo'")
             }
-            // TODO cancel any in-flight operations
+
+            for (op in providers.operation.listOperations(repo)) {
+                if (op.remote == remoteName) {
+                    providers.operation.abortOperation(repo, op.id)
+                }
+            }
+
             remotes.removeAt(idx)
             providers.storage.updateRemotes(repo, remotes)
             call.respond(HttpStatusCode.NoContent)

--- a/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3/S3RemoteProvider.kt
@@ -224,7 +224,6 @@ class S3RemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() {
 
         operation.addProgress(ProgressEntry(type = ProgressEntry.Type.START,
                 message = "Uploading archive for $desc"))
-        // TODO - progress monitoring
         data.s3.putObject(data.bucket, "${data.key}/${volume.name}.tar.gz", File(archive))
         operation.addProgress(ProgressEntry(type = ProgressEntry.Type.END))
     }
@@ -237,7 +236,6 @@ class S3RemoteProvider(val providers: ProviderModule) : BaseRemoteProvider() {
 
         val archive = "$scratchPath/${volume.name}.tar.gz"
         val obj = data.s3.getObject(data.bucket, "${data.key}/${volume.name}.tar.gz")
-        // TODO - progress monitoring
         obj.objectContent.use { input ->
             File(archive).outputStream().use { output ->
                 input.copyTo(output)

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsOperationManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsOperationManager.kt
@@ -176,7 +176,6 @@ class ZfsOperationManager(val provider: ZfsStorageProvider) {
     }
 
     fun createOperationScratch(repo: String, id: String): String {
-        // TODO reserve "_" in volume names
         val dataset = "$poolName/repo/$repo/$id/_scratch"
         provider.executor.exec("zfs", "create", dataset)
 

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsRepositoryManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsRepositoryManager.kt
@@ -254,8 +254,6 @@ class ZfsRepositoryManager(val provider: ZfsStorageProvider) {
     /**
      * Delete a repository. We use the '-R' flag to 'zfs destroy' to destroy all clones in the
      * appropriate order.
-     *
-     * TODO remove all directories underneath the mountpoint
      */
     fun deleteRepository(name: String) {
         provider.validateRepositoryName(name)
@@ -268,7 +266,7 @@ class ZfsRepositoryManager(val provider: ZfsStorageProvider) {
 
         // Try to delete the directory, but it may not exist if no volumes have been created
         try {
-            provider.executor.exec("rmdir", provider.getMountpoint(name))
+            provider.executor.exec("rm", "-rf", provider.getMountpoint(name))
         } catch (e: CommandException) {
             if (!e.output.contains("No such file or directory")) {
                 throw e

--- a/server/src/main/kotlin/io/titandata/sync/RsyncExecutor.kt
+++ b/server/src/main/kotlin/io/titandata/sync/RsyncExecutor.kt
@@ -35,7 +35,7 @@ class RsyncExecutor(
 ) : Runnable {
 
     companion object {
-        val log = LoggerFactory.getLogger(CommandExecutor::class.java)
+        val log = LoggerFactory.getLogger(RsyncExecutor::class.java)
     }
 
     private var tmpfile: File? = null


### PR DESCRIPTION
## Issues Addressed

Fixes #27 

## Proposed Changes

This addresses all remaining TODO comments. They were all fixed, with the exception of two:

- The engine login commit was simply removed because we'll move away from this model in the near future
- The s3 progress monitoring was removed because it's now covered by a GitHub issue

It also turned out that I long ago changed the rules to prohibit volume names starting with "_" but just never deleted the comment.

## Testing

Build, test, integration test, endtoend test.