### PR TITLE
improve teardown and network isolation

### DIFF
--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -4,7 +4,6 @@
 
 package io.titandata
 
-import com.google.gson.GsonBuilder
 import com.jcraft.jsch.JSch
 import io.titandata.exception.CommandException
 import io.titandata.util.CommandExecutor
@@ -30,7 +29,6 @@ class DockerUtil(
     private val timeout = 1000L
     private val sshUser = "root"
     private val sshPassword = "root"
-    private val gson = GsonBuilder().create()
 
     fun url(path: String): String {
         return "http://localhost:$port/v1/$path"

--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -4,10 +4,10 @@
 
 package io.titandata
 
+import com.google.gson.GsonBuilder
 import com.jcraft.jsch.JSch
 import io.titandata.exception.CommandException
 import io.titandata.util.CommandExecutor
-import java.net.InetAddress
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.slf4j.LoggerFactory
@@ -30,8 +30,7 @@ class DockerUtil(
     private val timeout = 1000L
     private val sshUser = "root"
     private val sshPassword = "root"
-    val sshHost: String
-        get() = InetAddress.getLocalHost().hostAddress
+    private val gson = GsonBuilder().create()
 
     fun url(path: String): String {
         return "http://localhost:$port/v1/$path"
@@ -166,7 +165,7 @@ class DockerUtil(
 
     fun startSsh() {
         executor.exec("docker", "run", "-p", "$sshPort:22", "-d", "--name", "$identity-ssh",
-                "titandata/ssh-test-server:latest")
+                "--network", "$identity", "titandata/ssh-test-server:latest")
     }
 
     fun testSsh(): Boolean {
@@ -202,7 +201,12 @@ class DockerUtil(
         }
     }
 
+    fun getSshHost(): String {
+        return executor.exec("docker", "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+                "$identity-ssh").trim()
+    }
+
     fun getSshUri(): String {
-        return "ssh://root:root@$sshHost:$sshPort"
+        return "ssh://root:root@${getSshHost()}"
     }
 }

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
@@ -85,10 +85,10 @@ class SshWorkflowTest : EndToEndTest() {
 
             val remote = RemoteUtil().parseUri("${dockerUtil.getSshUri()}/bar", "origin", mapOf())
             val sshRemote = remote as SshRemote
-            sshRemote.address shouldBe dockerUtil.sshHost
+            sshRemote.address shouldBe dockerUtil.getSshHost()
             sshRemote.password shouldBe "root"
             sshRemote.username shouldBe "root"
-            sshRemote.port shouldBe 6003
+            sshRemote.port shouldBe null
             sshRemote.name shouldBe "origin"
 
             remoteApi.createRemote("foo", remote)
@@ -209,12 +209,12 @@ class SshWorkflowTest : EndToEndTest() {
         }
 
         "add remote without password succeeds" {
-            val remote = SshRemote(address = dockerUtil.sshHost, username = "root",
-                    port = 6003, name = "origin", path = "/bar")
-            remote.address shouldBe dockerUtil.sshHost
+            val remote = SshRemote(address = dockerUtil.getSshHost(), username = "root",
+                    name = "origin", path = "/bar")
+            remote.address shouldBe dockerUtil.getSshHost()
             remote.password shouldBe null
             remote.username shouldBe "root"
-            remote.port shouldBe 6003
+            remote.port shouldBe null
             remote.name shouldBe "origin"
 
             remoteApi.createRemote("foo", remote)

--- a/server/src/scripts/launch
+++ b/server/src/scripts/launch
@@ -106,6 +106,9 @@ bind_mounts $MNT_DIR
 check_zfs
 create_import_pool $POOL $POOL_DIR $MNT_DIR
 
+# Create our network
+create_network $IDENTITY
+
 # Launch the server
 launch_server $IDENTITY $POOL $PORT $IMAGE $MNT_DIR
 

--- a/server/src/scripts/teardown
+++ b/server/src/scripts/teardown
@@ -10,21 +10,23 @@
 #   * Uninstall ZFS modules, if we were responsible for installing them in the first place
 #   * Remove the local, including the underlying datafile
 #
-# It should be run as part of 'titan uninstall', as well as after endtoend tests. It is up to
-# the user to make sure all repositories are destroyed prior to invoking this, otherwise it
-# could get an EBUSY error.
+# It should be run as part of 'titan uninstall', as well as after endtoend tests.
 
 source $(dirname $0)/zfs.sh
 source $(dirname $0)/titan.sh
 source $(dirname $0)/util.sh
 
 if pool_exists $POOL; then
+  echo "Unmounting all ZFS filesystems"
+  unmount_filesystems $POOL
   echo "Destroying pool $POOL"
   destroy_pool $POOL  || log_error "Failed to destroy storage pool"
   rm -f $POOL_DIR/data || log_error "Failed to remove pool data file"
   rm -f $POOL_DIR/cachefile || log_error "Failed to remove pool cache file"
 fi
 
+echo "Removing titan network"
+remove_network $IDENTITY
 echo "Unbinding mounts"
 unbind_mounts $MNT_DIR
 echo "Unloading ZFS"

--- a/server/src/scripts/titan.sh
+++ b/server/src/scripts/titan.sh
@@ -86,6 +86,24 @@ function unbind_mounts() {
 }
 
 #
+# Creates a bridge network specifically for titan. This is not generally required for normal operation, but provides
+# better isolation and makes endtoend testing easier by providing an isolated network within which to run the
+# SSH server.
+#
+function create_network() {
+  local identity=$1
+  docker network inspect $identity || docker network create $identity || log_error "failed to create $identity network"
+}
+
+#
+# Remove the bridge network created for the titan server.
+#
+function remove_network() {
+  local identity=$1
+  docker network rm $identity
+}
+
+#
 # Launch the actual titan server.
 #
 function launch_server() {
@@ -110,6 +128,7 @@ function launch_server() {
       -v $mount:$mount:rshared \
       -e TITAN_POOL=$pool \
       -p $port:5001 \
+      --network $identity \
       $image \
       /titan/run
 }

--- a/server/src/scripts/zfs.sh
+++ b/server/src/scripts/zfs.sh
@@ -341,3 +341,14 @@ function unload_zfs() {
   fi
   return 0
 }
+
+#
+# Unmounts all filesystems within the pool. This is only used during teardown, as a stopgap measure
+#
+function unmount_filesystems() {
+  local pool=$1
+  local dirs=$(mount -t zfs | grep ^$pool | awk '{print $3}')
+  for dir in $dirs; do
+     nsenter -m -u -t 1 -n -i umount $dir
+  done
+}


### PR DESCRIPTION
## Issues Addressed

Fixes #19 

## Proposed Changes

This improves the teardown process to handle cases where volumes may still be mounted (as is the case when end2end tests fail unexpectedly). While I was here, I also updated titan-server to run on a dedicated bridge network. This is just generally good practice, but has the advantage that we can then run the ssh test server on that network and not have to rely on finding the local machine's IP, which is flaky.

## Testing

Build, test, integration test, and end2end tests.