### PR TITLE
configure a database for titan-server

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -16,6 +16,7 @@ repositories {
     jcenter()
     maven("https://dl.bintray.com/kotlin/ktor")
     maven("https://dl.bintray.com/kotlin/kotlinx")
+    maven("https://dl.bintray.com/kotlin/exposed")
 }
 
 val ktorVersion = "1.2.5"
@@ -29,11 +30,14 @@ dependencies {
     compile("ch.qos.logback:logback-classic:1.2.3")
     compile("com.google.code.gson:gson:2.8.6")
     compile("com.squareup.okhttp3:okhttp:4.2.2")
+    compile("org.jetbrains.exposed:exposed:0.17.6")
+    compile("org.postgresql:postgresql:42.2.8")
 
     // S3 Provider dependencies
     compile("com.amazonaws:aws-java-sdk-s3:1.11.650")
     compile("javax.xml.bind:jaxb-api:2.3.1")
 
+    testCompile("com.h2database:h2:1.4.200")
     testCompile("io.ktor:ktor-server-test-host:$ktorVersion")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
     testImplementation("io.mockk:mockk:1.9.3")

--- a/server/docker/server.Dockerfile
+++ b/server/docker/server.Dockerfile
@@ -18,6 +18,9 @@ RUN add-apt-repository \
 RUN apt-get -y update --fix-missing
 RUN apt-get -y install docker-ce
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata
+RUN apt-get -y install postgresql-10
+
 COPY build/libs/titan-server.jar /titan/
 COPY src/scripts/* /titan/
 

--- a/server/docker/server.Dockerfile
+++ b/server/docker/server.Dockerfile
@@ -1,29 +1,55 @@
 FROM ubuntu:bionic
-RUN apt-get -y update --fix-missing
-RUN apt-get -y install kmod iproute2
-RUN apt-get -y install socat vim curl rsync sshpass jq
-RUN apt-get -y install openjdk-11-jre-headless
-RUN apt-get -y install lsof
 
+################################################
+# Ubuntu repository configuration
+################################################
+
+RUN apt-get -y update --fix-missing
+
+# Tools required for adding repositories
 RUN apt-get -y install apt-transport-https \
      ca-certificates \
      curl \
      gnupg2 \
      software-properties-common
+
+# Add docker repository
 RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg > /tmp/dkey; apt-key add /tmp/dkey
 RUN add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
    $(lsb_release -cs) \
    stable"
-RUN apt-get -y update --fix-missing
-RUN apt-get -y install docker-ce
 
+# Add postgresql repository
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc > /tmp/dkey; apt-key add /tmp/dkey
+RUN add-apt-repository \
+    "deb http://apt.postgresql.org/pub/repos/apt/ \
+    $(lsb_release -cs)-pgdg \
+    main"
+
+RUN apt-get -y update --fix-missing
+
+################################################
+# Ubuntu software installation
+################################################
+
+RUN apt-get -y install kmod iproute2
+RUN apt-get -y install socat vim rsync sshpass jq
+RUN apt-get -y install openjdk-11-jre-headless
+RUN apt-get -y install lsof
+RUN apt-get -y install docker-ce
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata
-RUN apt-get -y install postgresql-10
+RUN apt-get -y install postgresql-12 postgresql-client-12
+
+################################################
+# Titan software installation and configuration
+################################################
 
 COPY build/libs/titan-server.jar /titan/
 COPY src/scripts/* /titan/
 
 RUN /titan/get-userland
+
+RUN echo 'alias psql="psql postgres://postgres:postgres@localhost/titan"' >> /etc/bash.bashrc
 
 WORKDIR /titan

--- a/server/gradle/ktlint.gradle.kts
+++ b/server/gradle/ktlint.gradle.kts
@@ -1,7 +1,7 @@
 val ktlint by configurations.creating
 
 dependencies {
-    ktlint("com.pinterest:ktlint:0.34.2")
+    ktlint("com.pinterest:ktlint:0.35.0")
 }
 
 var ktlintTask = tasks.register<JavaExec>("ktlint") {

--- a/server/src/scripts/run
+++ b/server/src/scripts/run
@@ -4,6 +4,51 @@
 # Main entry point for the titan server.
 #
 
+DB_DIR=/var/lib/$TITAN_POOL/mnt/_db
+
+#
+# Mount the database filesystem for the titan server. We only do this if the pool is configured, so that titan-server
+# can run without ZFS if needed.
+#
+function mount_database() {
+  zfs list $TITAN_POOL >/dev/null 2>&1
+  if [[ $? == 0 ]]; then
+    mount | grep ^$TITAN_POOL/db > /dev/null
+    if [[ $? != 0 ]]; then
+      echo "Mounting $TITAN_POOL/db at $DB_DIR"
+      mkdir -p $DB_DIR
+      mount -t zfs $TITAN_POOL/db $DB_DIR || log_error "failed to mount database directory"
+    fi
+  fi
+}
+
+
+#
+# Initialize the database
+#
+function start_database() {
+  CREATE_DB=false
+  mkdir -p $DB_DIR
+  if [[ ! -f $DB_DIR/postgresql.conf ]]; then
+    echo "Initializing database at $DB_DIR"
+    chown postgres $DB_DIR
+    su - postgres -c "/usr/lib/postgresql/10/bin/pg_ctl -D $DB_DIR initdb" || exit 1
+    CREATE_DB=true
+  fi
+
+  # Start postgres
+  echo "Starting postgres"
+  rm -f $DB_DIR/postmaster.pid
+  su - postgres -c "/usr/lib/postgresql/10/bin/pg_ctl -D $DB_DIR -l /var/log/postgresql/logfile start" || exit 1
+  [[ $CREATE_DB == "true" ]] && su - postgres -c "/usr/lib/postgresql/10/bin/createdb titan"
+  echo "Postgres started"
+}
+
+mount_database
+start_database
+
 # Run socat to pipe from unix socket to server port
 socat -v -d -lf /var/log/socat.log UNIX-LISTEN:/run/docker/plugins/titan.sock,reuseaddr,fork TCP:localhost:5001 2>/var/log/socat.trace &
+
+# Run the main titan server
 exec java -jar /titan/titan-server.jar

--- a/server/src/scripts/run
+++ b/server/src/scripts/run
@@ -32,15 +32,19 @@ function start_database() {
   if [[ ! -f $DB_DIR/postgresql.conf ]]; then
     echo "Initializing database at $DB_DIR"
     chown postgres $DB_DIR
-    su - postgres -c "/usr/lib/postgresql/10/bin/pg_ctl -D $DB_DIR initdb" || exit 1
+    su - postgres -c "/usr/lib/postgresql/12/bin/pg_ctl -D $DB_DIR initdb" || exit 1
     CREATE_DB=true
   fi
 
   # Start postgres
   echo "Starting postgres"
   rm -f $DB_DIR/postmaster.pid
-  su - postgres -c "/usr/lib/postgresql/10/bin/pg_ctl -D $DB_DIR -l /var/log/postgresql/logfile start" || exit 1
-  [[ $CREATE_DB == "true" ]] && su - postgres -c "/usr/lib/postgresql/10/bin/createdb titan"
+  su - postgres -c "/usr/lib/postgresql/12/bin/pg_ctl -D $DB_DIR -l /var/log/postgresql/logfile start"
+  if [[ $? == 1 ]]; then
+    cat /var/log/postgresql/logfile
+    exit 1
+  fi
+  [[ $CREATE_DB == "true" ]] && su - postgres -c "/usr/lib/postgresql/12/bin/createdb titan"
   echo "Postgres started"
 }
 

--- a/server/src/scripts/titan.sh
+++ b/server/src/scripts/titan.sh
@@ -45,6 +45,8 @@ function create_import_pool() {
     fi
     log_end
   fi
+  # Update any existing pool
+  update_pool $pool
   return 0
 }
 
@@ -92,7 +94,7 @@ function unbind_mounts() {
 #
 function create_network() {
   local identity=$1
-  docker network inspect $identity || docker network create $identity || log_error "failed to create $identity network"
+  docker network inspect $identity >/dev/null || docker network create $identity || log_error "failed to create $identity network"
 }
 
 #

--- a/server/src/scripts/zfs.sh
+++ b/server/src/scripts/zfs.sh
@@ -185,7 +185,19 @@ function create_pool() {
   local cachefile=$4
   zpool create -m $mountpoint -o cachefile=$cachefile $pool $data
   zfs create -o mountpoint=none -o compression=lz4 $pool/repo
-  zfs create -o mountpoint=none $pool/deathrow
+  zfs create -o mountpoint=none $pool/db
+}
+
+#
+# Update an existing pool that may have been created on an ealier version.
+#
+function update_pool() {
+  local pool=$1
+
+  # We didn't end up using this space, remove it now
+  zfs list $pool/deathrow > /dev/null 2>&1 && zfs destroy $pool/deathrow
+  # Create the db filesystem if it doesn't exist
+  zfs list $pool/db > /dev/null 2>&1 || zfs create -o mountpoint=none $pool/db
 }
 
 #


### PR DESCRIPTION
## Proposed Changes

This adds the infrastructure work to have a working database within titan-server, and adds some of the dependencies we'll need to use it. As part of making titan-server more scalable, and prepping for k8s support, we're adding a metadata layer on top of the data layer. I opted for postgres over an embedded database (though we'll use H2 for in-memory testing) primarily because it makes it way easier to debug via the psql command line, and provides easier migration paths and future flexibility should we want to run that postgresql database in a different manner (e.g. via RDS). It will potentially give us access to some nice features like jsonb fields, etc.

## Testing

Build, test, endtoend tests. Ran titan-server and ensured that postgres was running and we could connect to the titan database.