### PR TITLE
repository metadata, phase one

### DIFF
--- a/server/src/integration-test/kotlin/io/titandata/RemotesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RemotesApiTest.kt
@@ -26,8 +26,11 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
+import io.mockk.impl.annotations.SpyK
 import io.mockk.mockk
 import io.mockk.verify
+import io.titandata.metadata.MetadataProvider
+import io.titandata.models.Repository
 import io.titandata.remote.engine.EngineRemoteProvider
 import io.titandata.storage.zfs.ZfsStorageProvider
 import io.titandata.util.CommandExecutor
@@ -42,6 +45,9 @@ class RemotesApiTest : StringSpec() {
     @InjectMockKs
     @OverrideMockKs
     var zfsStorageProvider = ZfsStorageProvider("test")
+
+    @SpyK
+    var metadata = MetadataProvider()
 
     @MockK
     lateinit var engineRemoteProvider: EngineRemoteProvider
@@ -225,6 +231,7 @@ class RemotesApiTest : StringSpec() {
         }
 
         "delete remote succeeds" {
+            every { metadata.getRepository("repo") } returns Repository(name = "repo", properties = mapOf())
             every { executor.start(*anyVararg()) } returns mockk()
             every { executor.exec(any<Process>(), any()) } returns ""
             every { executor.exec(*anyVararg()) } returns ""

--- a/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
@@ -174,6 +174,7 @@ class RepositoriesApiTest : StringSpec() {
         }
 
         "create repository succeeds" {
+            every { metadata.createRepository(any()) } just runs
             every { executor.exec(*anyVararg()) } returns ""
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())

--- a/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
@@ -27,8 +27,12 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
-import io.titandata.exception.CommandException
+import io.mockk.impl.annotations.SpyK
+import io.mockk.just
+import io.mockk.runs
+import io.titandata.metadata.MetadataProvider
 import io.titandata.models.Error
+import io.titandata.models.Repository
 import io.titandata.storage.zfs.ZfsStorageProvider
 import io.titandata.util.CommandExecutor
 import java.util.concurrent.TimeUnit
@@ -43,6 +47,9 @@ class RepositoriesApiTest : StringSpec() {
     @OverrideMockKs
     var zfsStorageProvider = ZfsStorageProvider("test")
 
+    @SpyK
+    var metadata = MetadataProvider()
+
     @InjectMockKs
     @OverrideMockKs
     var providers = ProviderModule("test")
@@ -52,7 +59,7 @@ class RepositoriesApiTest : StringSpec() {
     override fun beforeSpec(spec: Spec) {
         with(engine) {
             start()
-            providers.metadata.init()
+            MetadataProvider().init()
             application.mainProvider(providers)
         }
     }
@@ -73,7 +80,7 @@ class RepositoriesApiTest : StringSpec() {
 
     init {
         "list empty repositories succeeds" {
-            every { executor.exec(*anyVararg()) } returns ""
+            every { metadata.listRepositories() } returns listOf()
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories")) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -82,10 +89,10 @@ class RepositoriesApiTest : StringSpec() {
         }
 
         "list repositories succeeds" {
-            every { executor.exec(*anyVararg()) } returns
-            "test\t-\n" +
-            "test/repo/repo1\t{\"a\":\"b\"}\n" +
-            "test/repo/repo2\t{}\n"
+            every { metadata.listRepositories() } returns listOf(
+                    Repository(name = "repo1", properties = mapOf("a" to "b")),
+                    Repository(name = "repo2", properties = mapOf())
+            )
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories")) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.content shouldBe "[{\"name\":\"repo1\",\"properties\":{\"a\":\"b\"}}," +
@@ -94,7 +101,8 @@ class RepositoriesApiTest : StringSpec() {
         }
 
         "get repository succeeds" {
-            every { executor.exec(*anyVararg()) } returns "test/repo/repo\t{\"a\": \"b\"}"
+            every { metadata.getRepository(any()) } returns
+                    Repository(name = "repo", properties = mapOf("a" to "b"))
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/repo")) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -103,7 +111,6 @@ class RepositoriesApiTest : StringSpec() {
         }
 
         "get unknown repository returns not found" {
-            every { executor.exec(*anyVararg()) } throws CommandException("", 1, "dataset does not exist")
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/repo")) {
                 response.status() shouldBe HttpStatusCode.NotFound
                 val error = Gson().fromJson(response.content, Error::class.java)
@@ -149,6 +156,7 @@ class RepositoriesApiTest : StringSpec() {
         }
 
         "delete repository succeeds" {
+            every { metadata.deleteRepository(any()) } just runs
             every { executor.exec(*anyVararg()) } returns ""
             with(engine.handleRequest(HttpMethod.Delete, "/v1/repositories/repo")) {
                 response.status() shouldBe HttpStatusCode.NoContent
@@ -202,7 +210,7 @@ class RepositoriesApiTest : StringSpec() {
         }
 
         "update repository succeeds" {
-            every { executor.exec(*anyVararg()) } returns ""
+            every { metadata.updateRepository(any(), any()) } just runs
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/repo1") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody("{\"name\":\"repo2\",\"properties\":{\"a\":\"b\"}}")

--- a/server/src/integration-test/kotlin/io/titandata/VolumesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/VolumesApiTest.kt
@@ -25,8 +25,11 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
+import io.mockk.impl.annotations.SpyK
 import io.mockk.verify
 import io.titandata.exception.CommandException
+import io.titandata.metadata.MetadataProvider
+import io.titandata.models.Repository
 import io.titandata.storage.zfs.ZfsStorageProvider
 import io.titandata.util.CommandExecutor
 import java.util.concurrent.TimeUnit
@@ -41,6 +44,9 @@ class VolumesApiTest : StringSpec() {
     @InjectMockKs
     @OverrideMockKs
     var zfsStorageProvider = ZfsStorageProvider("test")
+
+    @SpyK
+    var metadata = MetadataProvider()
 
     @InjectMockKs
     @OverrideMockKs
@@ -223,8 +229,7 @@ class VolumesApiTest : StringSpec() {
         }
 
         "list volumes succeeds" {
-            every { executor.exec("zfs", "list", "-Ho", "name,io.titan-data:metadata",
-                    "-d", "1", "test/repo") } returns "test/repo/foo\t{}"
+            every { metadata.listRepositories() } returns listOf(Repository(name = "foo", properties = mapOf()))
             every { executor.exec("zfs", "list", "-Hpo", "io.titan-data:active",
                     "test/repo/foo") } returns "guid"
             every { executor.exec("zfs", "list", "-Ho", "name,io.titan-data:metadata",

--- a/server/src/main/kotlin/io/titandata/Application.kt
+++ b/server/src/main/kotlin/io/titandata/Application.kt
@@ -78,8 +78,8 @@ class ProviderModule(pool: String, inMemory: Boolean = true) {
     private val sshRemoteProvider = SshRemoteProvider(this)
     private val s3Provider = S3RemoteProvider(this)
     private val s3WebProvider = S3WebRemoteProvider(this)
-    private val metadataProvider = MetadataProvider(inMemory)
 
+    val metadata = MetadataProvider(inMemory)
     val commits = CommitOrchestrator(this)
     val repositories = RepositoryOrchestrator(this)
     val operations = OperationOrchestrator(this)
@@ -92,10 +92,6 @@ class ProviderModule(pool: String, inMemory: Boolean = true) {
     // Return the default storage provider
     val storage: StorageProvider
         get() = zfsStorageProvider
-
-    // Return the metadata provider
-    val metadata: MetadataProvider
-        get() = metadataProvider
 
     // Get a storage provider by name (only ZFS is supported)
     fun storage(type: String): StorageProvider {

--- a/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
@@ -24,7 +24,7 @@ import org.jetbrains.exposed.sql.update
  * The metadata provider is responsible for persistence of all metadata to the titan database. With the exception of
  * init(), it's up to the caller to manage transactions.
  */
-class MetadataProvider(val inMemory: Boolean = true, val databaseName:String = "titan") {
+class MetadataProvider(val inMemory: Boolean = true, val databaseName: String = "titan") {
 
     internal val gson = ModelTypeAdapters.configure(GsonBuilder()).create()
 
@@ -101,7 +101,7 @@ class MetadataProvider(val inMemory: Boolean = true, val databaseName:String = "
             if (count == 0) {
                 throw NoSuchObjectException("no such repository '$repoName'")
             }
-        } catch (e:ExposedSQLException) {
+        } catch (e: ExposedSQLException) {
             throw ObjectExistsException("repository '${repo.name}' already exists")
         }
     }

--- a/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
@@ -1,21 +1,37 @@
 package io.titandata.metadata
 
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import io.titandata.exception.NoSuchObjectException
+import io.titandata.exception.ObjectExistsException
 import io.titandata.metadata.table.Repositories
+import io.titandata.models.Repository
+import io.titandata.serialization.ModelTypeAdapters
+import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
 
 /*
- * The metadata provider is responsible for persistence of all metadata to the titan database.
+ * The metadata provider is responsible for persistence of all metadata to the titan database. With the exception of
+ * init(), it's up to the caller to manage transactions.
  */
-class MetadataProvider(val inMemory: Boolean = true) {
+class MetadataProvider(val inMemory: Boolean = true, val databaseName:String = "titan") {
+
+    internal val gson = ModelTypeAdapters.configure(GsonBuilder()).create()
 
     private fun memoryConfig(): HikariDataSource {
         val config = HikariConfig()
         config.driverClassName = "org.h2.Driver"
-        config.jdbcUrl = "jdbc:h2:mem:titan"
+        config.jdbcUrl = "jdbc:h2:mem:$databaseName"
         config.maximumPoolSize = 3
         config.isAutoCommit = false
         config.transactionIsolation = "TRANSACTION_READ_COMMITTED"
@@ -26,7 +42,7 @@ class MetadataProvider(val inMemory: Boolean = true) {
     private fun persistentConfig(): HikariDataSource {
         val config = HikariConfig()
         config.driverClassName = "org.postgresql.Driver"
-        config.jdbcUrl = "jdbc:postgresql:titan"
+        config.jdbcUrl = "jdbc:postgresql:$databaseName"
         config.username = "postgres"
         config.password = "postgres"
         config.maximumPoolSize = 3
@@ -44,7 +60,58 @@ class MetadataProvider(val inMemory: Boolean = true) {
         }
 
         transaction {
-            SchemaUtils.createMissingTablesAndColumns(Repositories())
+            SchemaUtils.createMissingTablesAndColumns(Repositories)
+        }
+    }
+
+    private fun convertRepository(it: ResultRow) = Repository(
+            name = it[Repositories.name],
+            properties = gson.fromJson(it[Repositories.metadata], object : TypeToken<Map<String, Any>>() {}.type)
+    )
+
+    fun createRepository(repo: Repository) {
+        try {
+            Repositories.insert {
+                it[name] = repo.name
+                it[metadata] = gson.toJson(repo.properties)
+            }
+        } catch (e: ExposedSQLException) {
+            throw ObjectExistsException("repository '${repo.name}' already exists")
+        }
+    }
+
+    fun listRepositories(): List<Repository> {
+        return Repositories.selectAll().map { convertRepository(it) }
+    }
+
+    fun getRepository(repoName: String): Repository {
+        return Repositories.select {
+            Repositories.name eq repoName
+        }.map { convertRepository(it) }
+                .firstOrNull()
+                ?: throw NoSuchObjectException("no such repository '$repoName'")
+    }
+
+    fun updateRepository(repoName: String, repo: Repository) {
+        try {
+            val count = Repositories.update({ Repositories.name eq repoName }) {
+                it[name] = repo.name
+                it[metadata] = gson.toJson(repo.properties)
+            }
+            if (count == 0) {
+                throw NoSuchObjectException("no such repository '$repoName'")
+            }
+        } catch (e:ExposedSQLException) {
+            throw ObjectExistsException("repository '${repo.name}' already exists")
+        }
+    }
+
+    fun deleteRepository(repoName: String) {
+        val count = Repositories.deleteWhere {
+            Repositories.name eq repoName
+        }
+        if (count == 0) {
+            throw NoSuchObjectException("no such repository '$repoName'")
         }
     }
 }

--- a/server/src/main/kotlin/io/titandata/metadata/table/Repositories.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/table/Repositories.kt
@@ -2,7 +2,12 @@ package io.titandata.metadata.table
 
 import org.jetbrains.exposed.sql.Table
 
-class Repositories : Table() {
+/*
+ * Repositories are the top level abstraction within the titan metadata. Everything is connected in some shape or form
+ * to a repository, and repository names must be unique. There is no on-disk state associated with repositories
+ * (only volumes and/or volumesets have such state), so these exist entirely within titan metadata.
+ */
+object Repositories : Table() {
     val name = varchar("name", 64).primaryKey()
     val metadata = varchar("metadata", 8192)
 }

--- a/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
@@ -3,19 +3,27 @@ package io.titandata.orchestrator
 import io.titandata.ProviderModule
 import io.titandata.models.Repository
 import io.titandata.models.RepositoryStatus
+import org.jetbrains.exposed.sql.transactions.transaction
 
 class RepositoryOrchestrator(val providers: ProviderModule) {
 
     fun createRepository(repo: Repository) {
+        transaction {
+            providers.metadata.createRepository(repo)
+        }
         providers.storage.createRepository(repo)
     }
 
     fun listRepositories(): List<Repository> {
-        return providers.storage.listRepositories()
+        return transaction {
+            providers.metadata.listRepositories()
+        }
     }
 
     fun getRepository(name: String): Repository {
-        return providers.storage.getRepository(name)
+        return transaction {
+            providers.metadata.getRepository(name)
+        }
     }
 
     fun getRepositoryStatus(name: String): RepositoryStatus {
@@ -27,6 +35,9 @@ class RepositoryOrchestrator(val providers: ProviderModule) {
     }
 
     fun deleteRepository(name: String) {
+        transaction {
+            providers.metadata.deleteRepository(name)
+        }
         providers.storage.deleteRepository(name)
     }
 }

--- a/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
@@ -7,7 +7,20 @@ import org.jetbrains.exposed.sql.transactions.transaction
 
 class RepositoryOrchestrator(val providers: ProviderModule) {
 
+    internal val nameRegex = "^[a-zA-Z0-9_\\-:.]+$".toRegex()
+
+    private fun validateRepoName(repoName: String) {
+        if (!nameRegex.matches(repoName)) {
+            throw IllegalArgumentException("invalid repository name, can only contain " +
+                    "alphanumeric characters, '-', ':', '.', or '_'")
+        }
+        if (repoName.length > 64) {
+            throw IllegalArgumentException("invalid repository name, must be 64 characters or less")
+        }
+    }
+
     fun createRepository(repo: Repository) {
+        validateRepoName(repo.name)
         transaction {
             providers.metadata.createRepository(repo)
         }
@@ -21,20 +34,25 @@ class RepositoryOrchestrator(val providers: ProviderModule) {
     }
 
     fun getRepository(name: String): Repository {
+        validateRepoName(name)
         return transaction {
             providers.metadata.getRepository(name)
         }
     }
 
     fun getRepositoryStatus(name: String): RepositoryStatus {
+        validateRepoName(name)
         return providers.storage.getRepositoryStatus(name)
     }
 
     fun updateRepository(name: String, repo: Repository) {
-        providers.storage.updateRepository(name, repo)
+        validateRepoName(name)
+        validateRepoName(repo.name)
+        providers.metadata.updateRepository(name, repo)
     }
 
     fun deleteRepository(name: String) {
+        validateRepoName(name)
         transaction {
             providers.metadata.deleteRepository(name)
         }

--- a/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
@@ -17,10 +17,7 @@ interface StorageProvider {
     fun load()
 
     fun createRepository(repo: Repository)
-    fun listRepositories(): List<Repository>
-    fun getRepository(name: String): Repository
     fun getRepositoryStatus(name: String): RepositoryStatus
-    fun updateRepository(name: String, repo: Repository)
     fun deleteRepository(name: String)
 
     fun getRemotes(repo: String): List<Remote>

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsOperationManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsOperationManager.kt
@@ -95,8 +95,6 @@ class ZfsOperationManager(val provider: ZfsStorageProvider) {
     }
 
     fun getOperation(repo: String, id: String): OperationData {
-        // Call this separately so we can distinguish no such repo from no such operation
-        provider.getRepository(repo)
         try {
             val output = provider.executor.exec("zfs", "list", "-Ho", "name,$OPERATION_PROP",
                     "$poolName/repo/$repo/$id")

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -299,24 +299,8 @@ class ZfsStorageProvider(
     }
 
     @Synchronized
-    override fun listRepositories(): List<Repository> {
-        return repositoryManager.listRepositories()
-    }
-
-    @Synchronized
-    override fun getRepository(name: String): Repository {
-        return repositoryManager.getRepository(name)
-    }
-
-    @Synchronized
     override fun getRepositoryStatus(name: String): RepositoryStatus {
         return repositoryManager.getRepositoryStatus(name)
-    }
-
-    @Synchronized
-    override fun updateRepository(name: String, repo: Repository) {
-        log.info("update repository $name")
-        repositoryManager.updateRepository(name, repo)
     }
 
     @Synchronized

--- a/server/src/test/kotlin/io/titandata/metadata/MetadataProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/MetadataProviderTest.kt
@@ -16,11 +16,11 @@ class MetadataProviderTest : StringSpec() {
         var dbIdentifier = 0
     }
 
-    lateinit var md : MetadataProvider
+    lateinit var md: MetadataProvider
 
     override fun beforeTest(testCase: TestCase) {
         dbIdentifier++
-        md = MetadataProvider(true, "db${dbIdentifier}")
+        md = MetadataProvider(true, "db$dbIdentifier")
         md.init()
     }
 
@@ -33,7 +33,7 @@ class MetadataProviderTest : StringSpec() {
 
         "create repository succeeds" {
             transaction {
-                val repo = Repository(name="foo", properties=mapOf("a" to "b"))
+                val repo = Repository(name = "foo", properties = mapOf("a" to "b"))
                 md.createRepository(repo)
             }
         }
@@ -129,5 +129,4 @@ class MetadataProviderTest : StringSpec() {
             }
         }
     }
-
 }

--- a/server/src/test/kotlin/io/titandata/metadata/MetadataProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/MetadataProviderTest.kt
@@ -1,0 +1,133 @@
+package io.titandata.metadata
+
+import io.kotlintest.TestCase
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.StringSpec
+import io.titandata.exception.NoSuchObjectException
+import io.titandata.exception.ObjectExistsException
+import io.titandata.models.Repository
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class MetadataProviderTest : StringSpec() {
+
+    companion object {
+        var dbIdentifier = 0
+    }
+
+    lateinit var md : MetadataProvider
+
+    override fun beforeTest(testCase: TestCase) {
+        dbIdentifier++
+        md = MetadataProvider(true, "db${dbIdentifier}")
+        md.init()
+    }
+
+    init {
+        "list repositories returns empty list" {
+            transaction {
+                md.listRepositories().size shouldBe 0
+            }
+        }
+
+        "create repository succeeds" {
+            transaction {
+                val repo = Repository(name="foo", properties=mapOf("a" to "b"))
+                md.createRepository(repo)
+            }
+        }
+
+        "get repository succeeds" {
+            transaction {
+                md.createRepository(Repository(name = "foo", properties = mapOf("a" to "b")))
+                val result = md.getRepository("foo")
+                result.name shouldBe "foo"
+                result.properties["a"] shouldBe "b"
+            }
+        }
+
+        "get non-existent repository fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.getRepository("foo")
+                }
+            }
+        }
+
+        "list repository succeeds" {
+            transaction {
+                md.createRepository(Repository(name = "foo", properties = mapOf("a" to "b")))
+                md.createRepository(Repository(name = "bar", properties = mapOf("b" to "b")))
+                val result = md.listRepositories()
+                result.size shouldBe 2
+                result.find { it.name == "foo" } shouldNotBe null
+                result.find { it.name == "bar" } shouldNotBe null
+            }
+        }
+
+        "create duplicate repository fails" {
+            shouldThrow<ObjectExistsException> {
+                transaction {
+                    md.createRepository(Repository(name = "foo", properties = mapOf("a" to "b")))
+                    md.createRepository(Repository(name = "foo", properties = mapOf("a" to "b")))
+                }
+            }
+        }
+
+        "delete repository succeeds" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.createRepository(Repository(name = "foo", properties = mapOf("a" to "b")))
+                    md.deleteRepository("foo")
+                    md.getRepository("foo")
+                }
+            }
+        }
+
+        "delete non-existent repository fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.deleteRepository("foo")
+                }
+            }
+        }
+
+        "update repository succeeds" {
+            transaction {
+                md.createRepository(Repository(name = "foo", properties = mapOf("a" to "b")))
+                md.updateRepository("foo", Repository(name = "foo", properties = mapOf("a" to "c")))
+                val result = md.getRepository("foo")
+                result.properties["a"] shouldBe "c"
+            }
+        }
+
+        "rename repository succeeds" {
+            transaction {
+                md.createRepository(Repository(name = "foo", properties = mapOf("a" to "b")))
+                md.updateRepository("foo", Repository(name = "bar", properties = mapOf("a" to "c")))
+                val result = md.getRepository("bar")
+                result.properties["a"] shouldBe "c"
+            }
+        }
+
+        "rename repository to conflicting name fails" {
+            shouldThrow<ObjectExistsException> {
+                transaction {
+                    md.createRepository(Repository(name = "foo", properties = mapOf("a" to "b")))
+                    md.createRepository(Repository(name = "bar", properties = mapOf("a" to "b")))
+                    md.updateRepository("foo", Repository(name = "bar", properties = mapOf("a" to "c")))
+                }
+            }
+        }
+
+        "update of non-existent repository fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.updateRepository("foo", Repository(name = "bar", properties = mapOf("a" to "c")))
+                }
+            }
+        }
+    }
+
+}

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsOperationTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsOperationTest.kt
@@ -100,14 +100,6 @@ class ZfsOperationTest : StringSpec() {
             }
         }
 
-        "create operation fails for unknown repository" {
-            every { executor.exec(*anyVararg()) } throws CommandException("", 1, "does not exist")
-            val exception = shouldThrow<NoSuchObjectException> {
-                provider.createOperation("foo", getOperation(), null)
-            }
-            exception.message shouldContain "repository"
-        }
-
         "create operation succeeds" {
             every { executor.exec(*anyVararg()) } returns ""
             every { executor.exec("zfs", "list", "-Ho", "name,defer_destroy", "-t", "snapshot",
@@ -173,15 +165,6 @@ class ZfsOperationTest : StringSpec() {
             result[1].operation.commitId shouldBe op2.operation.commitId
         }
 
-        "get operation for non existent repo fails" {
-            every { executor.exec("zfs", "list", "-Ho", "name,io.titan-data:metadata",
-                    "test/repo/foo") } throws CommandException("", 1, "does not exist")
-            val exception = shouldThrow<NoSuchObjectException> {
-                provider.getOperation("foo", "op")
-            }
-            exception.message shouldContain "repository"
-        }
-
         "get operation for non existent operation fails" {
             every { executor.exec("zfs", "list", "-Ho", "name,io.titan-data:metadata",
                     "test/repo/foo") } returns "test/repo/foo\t{}"
@@ -211,15 +194,6 @@ class ZfsOperationTest : StringSpec() {
             op.operation.commitId shouldBe "commit"
         }
 
-        "commit operation fails for unknown repo" {
-            every { executor.exec(*anyVararg()) } throws CommandException("", 1, "does not exist")
-            val exception = shouldThrow<NoSuchObjectException> {
-                val commit = Commit(id = "commit", properties = mapOf("a" to "b"))
-                provider.commitOperation("foo", "id", commit)
-            }
-            exception.message shouldContain "repository"
-        }
-
         "commit operation succeeds" {
             mockOperation()
             every { executor.exec("zfs", "snapshot", "-r", "-o",
@@ -238,14 +212,6 @@ class ZfsOperationTest : StringSpec() {
             }
         }
 
-        "discard operation fails for unknown repo" {
-            every { executor.exec(*anyVararg()) } throws CommandException("", 1, "does not exist")
-            val exception = shouldThrow<NoSuchObjectException> {
-                provider.discardOperation("foo", "id")
-            }
-            exception.message shouldContain "repository"
-        }
-
         "discard operation succeeds" {
             mockOperation()
             every { executor.exec("zfs", "destroy", "-r", "test/repo/foo/id") } returns ""
@@ -255,14 +221,6 @@ class ZfsOperationTest : StringSpec() {
             verify {
                 executor.exec("zfs", "destroy", "-r", "test/repo/foo/id")
             }
-        }
-
-        "update operation state fails for unknown repo" {
-            every { executor.exec(*anyVararg()) } throws CommandException("", 1, "does not exist")
-            val exception = shouldThrow<NoSuchObjectException> {
-                provider.updateOperationState("foo", "id", Operation.State.COMPLETE)
-            }
-            exception.message shouldContain "repository"
         }
 
         "update operation state succeeds" {
@@ -279,14 +237,6 @@ class ZfsOperationTest : StringSpec() {
                 executor.start("zfs", "set", "io.titan-data:operation=$newJson",
                         "test/repo/foo/id")
             }
-        }
-
-        "mount operation volumes fail for unknown repo" {
-            every { executor.exec(*anyVararg()) } throws CommandException("", 1, "does not exist")
-            val exception = shouldThrow<NoSuchObjectException> {
-                provider.mountOperationVolumes("foo", "id")
-            }
-            exception.message shouldContain "repository"
         }
 
         "mount operation volumes succeeds" {
@@ -313,14 +263,6 @@ class ZfsOperationTest : StringSpec() {
                 executor.exec("mount", "-t", "zfs",
                         "test/repo/foo/id/two", "/var/lib/test/mnt/id/two")
             }
-        }
-
-        "unmount operation volumes fail for unknown repo" {
-            every { executor.exec(*anyVararg()) } throws CommandException("", 1, "does not exist")
-            val exception = shouldThrow<NoSuchObjectException> {
-                provider.unmountOperationVolumes("foo", "id")
-            }
-            exception.message shouldContain "repository"
         }
 
         "unmount operation volumes succeeds" {


### PR DESCRIPTION
## Proposed Changes

This adds the metadata layer on top of the data layer for repositories, and we now consult the metadata layer for all reads and updates of repositories. However, this is only phase one because we're still leaving the storage layer untouched, creating and destroying repositories there. The next phase will involve getting rid of the concept of repositories at the storage layer but that's a ton more work and requires moving more pieces to be metadata only.

## Testing

Build, test, integrationTest, endtoendTest.