### PR TITLE
remotes as metadata

### DIFF
--- a/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
@@ -322,7 +322,7 @@ class LocalWorkflowTest : EndToEndTest() {
         }
 
         "get push operation progress succeeds" {
-            delay(Duration.ofMillis(500))
+            delay(Duration.ofMillis(1000))
             val result = operationApi.getOperation("foo", currentOp.id)
             result.state shouldBe Operation.State.COMPLETE
             val progress = operationApi.getProgress("foo", currentOp.id)

--- a/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
@@ -29,7 +29,7 @@ import org.jetbrains.exposed.sql.update
  */
 class MetadataProvider(val inMemory: Boolean = true, val databaseName: String = "titan") {
 
-    internal val gson = ModelTypeAdapters.configure(GsonBuilder()).create()
+    private val gson = ModelTypeAdapters.configure(GsonBuilder()).create()
 
     private fun memoryConfig(): HikariDataSource {
         val config = HikariConfig()
@@ -64,6 +64,14 @@ class MetadataProvider(val inMemory: Boolean = true, val databaseName: String = 
 
         transaction {
             SchemaUtils.createMissingTablesAndColumns(Repositories, Remotes)
+        }
+    }
+
+    fun clear() {
+        transaction {
+            for (repo in listRepositories()) {
+                deleteRepository(repo.name)
+            }
         }
     }
 

--- a/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
@@ -123,10 +123,15 @@ class MetadataProvider(val inMemory: Boolean = true, val databaseName: String = 
     }
 
     fun addRemote(repoName: String, remote: Remote) {
-        Remotes.insert {
-            it[name] = remote.name
-            it[repo] = repoName
-            it[metadata] = gson.toJson(remote)
+        getRepository(repoName) // check existence
+        try {
+            Remotes.insert {
+                it[name] = remote.name
+                it[repo] = repoName
+                it[metadata] = gson.toJson(remote)
+            }
+        } catch (e: ExposedSQLException) {
+            throw ObjectExistsException("remote '${remote.name}' already exists in repository $repoName")
         }
     }
 

--- a/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
@@ -171,14 +171,18 @@ class MetadataProvider(val inMemory: Boolean = true, val databaseName: String = 
 
     fun updateRemote(repoName: String, remoteName: String, remote: Remote) {
         getRepository(repoName) // check existence
-        val count = Remotes.update({
-            (Remotes.name eq remoteName) and (Remotes.repo eq repoName)
-        }) {
-            it[name] = remote.name
-            it[metadata] = gson.toJson(remote)
-        }
-        if (count == 0) {
-            throw NoSuchObjectException("no such remote '$remoteName' in repository '$repoName'")
+        try {
+            val count = Remotes.update({
+                (Remotes.name eq remoteName) and (Remotes.repo eq repoName)
+            }) {
+                it[name] = remote.name
+                it[metadata] = gson.toJson(remote)
+            }
+            if (count == 0) {
+                throw NoSuchObjectException("no such remote '$remoteName' in repository '$repoName'")
+            }
+        } catch (e: ExposedSQLException) {
+            throw ObjectExistsException("remote '${remote.name}' already exists in repository '$repoName'")
         }
     }
 }

--- a/server/src/main/kotlin/io/titandata/metadata/table/Remotes.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/table/Remotes.kt
@@ -1,11 +1,10 @@
 package io.titandata.metadata.table
 
-import io.titandata.metadata.table.Repositories.primaryKey
 import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Table
 
 object Remotes : Table() {
-    val name = Repositories.varchar("name", 64).primaryKey()
-    val repo = Repositories.varchar("repositories", 64).references(Repositories.name, onDelete = ReferenceOption.CASCADE).primaryKey()
-    val metadata = Repositories.varchar("metadata", 8192)
+    val name = varchar("name", 64).primaryKey()
+    val repo = varchar("repositories", 64).references(Repositories.name, onDelete = ReferenceOption.CASCADE).primaryKey()
+    val metadata = varchar("metadata", 8192)
 }

--- a/server/src/main/kotlin/io/titandata/metadata/table/Remotes.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/table/Remotes.kt
@@ -1,0 +1,11 @@
+package io.titandata.metadata.table
+
+import io.titandata.metadata.table.Repositories.primaryKey
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.Table
+
+object Remotes : Table() {
+    val name = Repositories.varchar("name", 64).primaryKey()
+    val repo = Repositories.varchar("repositories", 64).references(Repositories.name, onDelete = ReferenceOption.CASCADE).primaryKey()
+    val metadata = Repositories.varchar("metadata", 8192)
+}

--- a/server/src/main/kotlin/io/titandata/orchestrator/NameUtil.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/NameUtil.kt
@@ -1,0 +1,28 @@
+package io.titandata.orchestrator
+
+class NameUtil {
+
+    companion object {
+        private val nameRegex = "^[a-zA-Z0-9_\\-:.]+$".toRegex()
+
+        fun validateRepoName(repoName: String) {
+            if (!nameRegex.matches(repoName)) {
+                throw IllegalArgumentException("invalid repository name, can only contain " +
+                        "alphanumeric characters, '-', ':', '.', or '_'")
+            }
+            if (repoName.length > 64) {
+                throw IllegalArgumentException("invalid repository name, must be 64 characters or less")
+            }
+        }
+
+        fun validateRemoteName(repoName: String) {
+            if (!nameRegex.matches(repoName)) {
+                throw IllegalArgumentException("invalid remote name, can only contain " +
+                        "alphanumeric characters, '-', ':', '.', or '_'")
+            }
+            if (repoName.length > 64) {
+                throw IllegalArgumentException("invalid remote name, must be 64 characters or less")
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/io/titandata/orchestrator/OperationOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/OperationOrchestrator.kt
@@ -106,8 +106,9 @@ class OperationOrchestrator(val providers: ProviderModule) {
     }
 
     private fun getRemote(repository: String, remote: String): Remote {
-        val remotes = providers.storage.getRemotes(repository)
-        return remotes.find { r -> r.name == remote } ?: throw NoSuchObjectException("no such remote '$remote' in repository '$repository'")
+        return transaction {
+            providers.metadata.getRemote(repository, remote)
+        }
     }
 
     @Synchronized

--- a/server/src/main/kotlin/io/titandata/orchestrator/RemoteOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/RemoteOrchestrator.kt
@@ -1,85 +1,58 @@
 package io.titandata.orchestrator
 
 import io.titandata.ProviderModule
-import io.titandata.exception.NoSuchObjectException
-import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Commit
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
+import org.jetbrains.exposed.sql.transactions.transaction
 
 class RemoteOrchestrator(val providers: ProviderModule) {
 
-    private fun findRemote(repo: String, remote: String): Pair<MutableList<Remote>, Int?> {
-        val remotes = providers.storage.getRemotes(repo).toMutableList()
-        remotes.forEachIndexed { idx, r ->
-            if (r.name == remote) {
-                return Pair(remotes, idx)
-            }
-        }
-        return Pair(remotes, null)
-    }
-
     fun listRemotes(repo: String): List<Remote> {
-        return providers.storage.getRemotes(repo)
+        NameUtil.validateRepoName(repo)
+        return transaction {
+            providers.metadata.listRemotes(repo)
+        }
     }
 
     fun addRemote(repo: String, remote: Remote) {
-        val (remotes, idx) = findRemote(repo, remote.name)
-        if (idx != null) {
-            throw ObjectExistsException("remote '${remote.name}' exists for repository '$repo'")
+        NameUtil.validateRepoName(repo)
+        NameUtil.validateRemoteName(remote.name)
+        transaction {
+            providers.metadata.addRemote(repo, remote)
         }
-        remotes.add(remote)
-        providers.storage.updateRemotes(repo, remotes)
     }
 
     fun getRemote(repo: String, remoteName: String): Remote {
-        val (remotes, idx) = findRemote(repo, remoteName)
-        if (idx == null) {
-            throw NoSuchObjectException("no such remote '$remoteName' in repository '$repo'")
+        NameUtil.validateRepoName(repo)
+        NameUtil.validateRemoteName(remoteName)
+        return transaction {
+            providers.metadata.getRemote(repo, remoteName)
         }
-        return remotes[idx]
     }
 
     fun removeRemote(repo: String, remoteName: String) {
-        val (remotes, idx) = findRemote(repo, remoteName)
-        if (idx == null) {
-            throw NoSuchObjectException("no such remote '$remoteName' in repository '$repo'")
+        NameUtil.validateRepoName(repo)
+        NameUtil.validateRemoteName(remoteName)
+        transaction {
+            providers.metadata.removeRemote(repo, remoteName)
         }
-
-        for (op in providers.operations.listOperations(repo)) {
-            if (op.remote == remoteName) {
-                providers.operations.abortOperation(repo, op.id)
-            }
-        }
-
-        remotes.removeAt(idx)
-        providers.storage.updateRemotes(repo, remotes)
     }
 
     fun updateRemote(repo: String, remoteName: String, remote: Remote) {
-        val (remotes, idx) = findRemote(repo, remoteName)
-        if (idx == null) {
-            throw NoSuchObjectException("no such remote '$remoteName' in repository '$repo'")
+        NameUtil.validateRepoName(repo)
+        NameUtil.validateRemoteName(remoteName)
+        NameUtil.validateRemoteName(remote.name)
+        transaction {
+            providers.metadata.updateRemote(repo, remoteName, remote)
         }
-        if (remoteName != remote.name) {
-            val (_, newIdx) = findRemote(repo, remote.name)
-            if (newIdx != null) {
-                throw ObjectExistsException("remote '$remoteName' already exists for repository '$repo'")
-            }
-        }
-        remotes[idx] = remote
-        providers.storage.updateRemotes(repo, remotes)
     }
 
     fun listRemoteCommits(repo: String, remoteName: String, params: RemoteParameters, tags: List<String>?): List<Commit> {
-        val (remotes, idx) = findRemote(repo, remoteName)
-        if (idx == null) {
-            throw NoSuchObjectException("no such remote '$remoteName' in repository '$repo'")
-        }
-        val remote = remotes[idx]
+        val remote = getRemote(repo, remoteName)
         val commits = providers.remote(remote.provider).listCommits(remote, params, tags)
         return commits.sortedByDescending { OffsetDateTime.parse(it.properties.get("timestamp")?.toString()
                 ?: DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochSecond(0)),
@@ -87,11 +60,7 @@ class RemoteOrchestrator(val providers: ProviderModule) {
     }
 
     fun getRemoteCommit(repo: String, remoteName: String, params: RemoteParameters, commitId: String): Commit {
-        val (remotes, idx) = findRemote(repo, remoteName)
-        if (idx == null) {
-            throw NoSuchObjectException("no such remote '$remoteName' in repository '$repo'")
-        }
-        val remote = remotes[idx]
+        val remote = getRemote(repo, remoteName)
         return providers.remote(remote.provider).getCommit(remote, commitId, params)
     }
 }

--- a/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
@@ -7,20 +7,8 @@ import org.jetbrains.exposed.sql.transactions.transaction
 
 class RepositoryOrchestrator(val providers: ProviderModule) {
 
-    internal val nameRegex = "^[a-zA-Z0-9_\\-:.]+$".toRegex()
-
-    private fun validateRepoName(repoName: String) {
-        if (!nameRegex.matches(repoName)) {
-            throw IllegalArgumentException("invalid repository name, can only contain " +
-                    "alphanumeric characters, '-', ':', '.', or '_'")
-        }
-        if (repoName.length > 64) {
-            throw IllegalArgumentException("invalid repository name, must be 64 characters or less")
-        }
-    }
-
     fun createRepository(repo: Repository) {
-        validateRepoName(repo.name)
+        NameUtil.validateRepoName(repo.name)
         transaction {
             providers.metadata.createRepository(repo)
         }
@@ -34,25 +22,25 @@ class RepositoryOrchestrator(val providers: ProviderModule) {
     }
 
     fun getRepository(name: String): Repository {
-        validateRepoName(name)
+        NameUtil.validateRepoName(name)
         return transaction {
             providers.metadata.getRepository(name)
         }
     }
 
     fun getRepositoryStatus(name: String): RepositoryStatus {
-        validateRepoName(name)
+        NameUtil.validateRepoName(name)
         return providers.storage.getRepositoryStatus(name)
     }
 
     fun updateRepository(name: String, repo: Repository) {
-        validateRepoName(name)
-        validateRepoName(repo.name)
+        NameUtil.validateRepoName(name)
+        NameUtil.validateRepoName(repo.name)
         providers.metadata.updateRepository(name, repo)
     }
 
     fun deleteRepository(name: String) {
-        validateRepoName(name)
+        NameUtil.validateRepoName(name)
         transaction {
             providers.metadata.deleteRepository(name)
         }

--- a/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
@@ -36,7 +36,9 @@ class RepositoryOrchestrator(val providers: ProviderModule) {
     fun updateRepository(name: String, repo: Repository) {
         NameUtil.validateRepoName(name)
         NameUtil.validateRepoName(repo.name)
-        providers.metadata.updateRepository(name, repo)
+        transaction {
+            providers.metadata.updateRepository(name, repo)
+        }
     }
 
     fun deleteRepository(name: String) {

--- a/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
@@ -7,7 +7,6 @@ package io.titandata.storage
 import io.titandata.models.Commit
 import io.titandata.models.CommitStatus
 import io.titandata.models.Operation
-import io.titandata.models.Remote
 import io.titandata.models.Repository
 import io.titandata.models.RepositoryStatus
 import io.titandata.models.Volume
@@ -19,9 +18,6 @@ interface StorageProvider {
     fun createRepository(repo: Repository)
     fun getRepositoryStatus(name: String): RepositoryStatus
     fun deleteRepository(name: String)
-
-    fun getRemotes(repo: String): List<Remote>
-    fun updateRemotes(repo: String, remotes: List<Remote>)
 
     fun createCommit(repo: String, commit: Commit): Commit
     fun getCommit(repo: String, id: String): Commit

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -14,7 +14,6 @@ import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Commit
 import io.titandata.models.CommitStatus
 import io.titandata.models.Operation
-import io.titandata.models.Remote
 import io.titandata.models.Repository
 import io.titandata.models.RepositoryStatus
 import io.titandata.models.Volume

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -54,7 +54,6 @@ class ZfsStorageProvider(
 
     internal val METADATA_PROP = "io.titan-data:metadata"
     internal val ACTIVE_PROP = "io.titan-data:active"
-    internal val REMOTES_PROP = "io.titan-data:remotes"
     internal val OPERATION_PROP = "io.titan-data:operation"
     internal val REAPER_PROP = "io.titan-data:reaper"
     internal val INITIAL_COMMIT = "initial"
@@ -307,17 +306,6 @@ class ZfsStorageProvider(
     override fun deleteRepository(name: String) {
         log.info("delete repository $name")
         repositoryManager.deleteRepository(name)
-    }
-
-    @Synchronized
-    override fun getRemotes(repo: String): List<Remote> {
-        return repositoryManager.getRemotes(repo)
-    }
-
-    @Synchronized
-    override fun updateRemotes(repo: String, remotes: List<Remote>) {
-        log.info("update remotes for repository $repo")
-        repositoryManager.updateRemotes(repo, remotes)
     }
 
     @Synchronized

--- a/server/src/test/kotlin/io/titandata/metadata/RemoteMetadataTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/RemoteMetadataTest.kt
@@ -1,0 +1,174 @@
+package io.titandata.metadata
+
+import io.kotlintest.TestCase
+import io.kotlintest.matchers.types.shouldBeInstanceOf
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.StringSpec
+import io.titandata.exception.NoSuchObjectException
+import io.titandata.exception.ObjectExistsException
+import io.titandata.models.Repository
+import io.titandata.remote.nop.NopRemote
+import io.titandata.remote.s3.S3Remote
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class RemoteMetadataTest : StringSpec() {
+
+    companion object {
+        var dbIdentifier = 0
+    }
+
+    lateinit var md: MetadataProvider
+
+    override fun beforeTest(testCase: TestCase) {
+        dbIdentifier++
+        md = MetadataProvider(true, "db$dbIdentifier")
+        md.init()
+    }
+
+    init {
+        "add remote succeeds" {
+            transaction {
+                md.createRepository(Repository(name = "foo", properties = mapOf()))
+                md.addRemote("foo", NopRemote(name = "origin"))
+            }
+        }
+
+        "add remote for non-existent repository fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.addRemote("foo", NopRemote(name = "origin"))
+                }
+            }
+        }
+
+        "add duplicate remote fails" {
+            shouldThrow<ObjectExistsException> {
+                transaction {
+                    md.createRepository(Repository(name = "foo", properties = mapOf()))
+                    md.addRemote("foo", NopRemote(name = "origin"))
+                    md.addRemote("foo", NopRemote(name = "origin"))
+                }
+            }
+        }
+
+        "get remote succeeds" {
+            val remote = transaction {
+                md.createRepository(Repository(name = "foo", properties = mapOf()))
+                md.addRemote("foo", NopRemote(name = "origin"))
+                md.getRemote("foo", "origin")
+            }
+            remote.name shouldBe "origin"
+            remote.shouldBeInstanceOf<NopRemote>()
+        }
+
+        "get non-existent remote fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.createRepository(Repository(name = "foo", properties = mapOf()))
+                    md.getRemote("foo", "origin")
+                }
+            }
+        }
+
+        "get remote of non-existent repo fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.getRemote("foo", "origin")
+                }
+            }
+        }
+
+        "list remotes succeeds" {
+            val remotes = transaction {
+                md.createRepository(Repository(name = "foo", properties = mapOf()))
+                md.addRemote("foo", NopRemote(name = "foo"))
+                md.addRemote("foo", S3Remote(name = "bar", bucket = "bucket"))
+                md.listRemotes("foo")
+            }
+
+            remotes.size shouldBe 2
+            remotes[0].name shouldBe "foo"
+            remotes[1].name shouldBe "bar"
+            remotes[1].shouldBeInstanceOf<S3Remote>()
+            val s3 = remotes[1] as S3Remote
+            s3.bucket shouldBe "bucket"
+        }
+
+        "list remotes of non-existent repository fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.listRemotes("foo")
+                }
+            }
+        }
+
+        "remove remote succeeds" {
+            val remotes = transaction {
+                md.createRepository(Repository(name = "foo", properties = mapOf()))
+                md.addRemote("foo", NopRemote(name = "foo"))
+                md.removeRemote("foo", "foo")
+                md.listRemotes("foo")
+            }
+            remotes.size shouldBe 0
+        }
+
+        "remove non-existent remote fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.createRepository(Repository(name = "foo", properties = mapOf()))
+                    md.removeRemote("foo", "foo")
+                }
+            }
+        }
+
+        "remove remote from non-existent repo fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.removeRemote("foo", "foo")
+                }
+            }
+        }
+
+        "update remote succeeds" {
+            val remote = transaction {
+                md.createRepository(Repository(name = "foo", properties = mapOf()))
+                md.addRemote("foo", NopRemote(name = "origin"))
+                md.updateRemote("foo", "origin", S3Remote(name = "origin", bucket = "bucket"))
+                md.getRemote("foo", "origin")
+            }
+            remote.shouldBeInstanceOf<S3Remote>()
+            remote.name shouldBe "origin"
+            val s3 = remote as S3Remote
+            s3.bucket shouldBe "bucket"
+        }
+        
+        "rename remote succeeds" {
+            val remote = transaction {
+                md.createRepository(Repository(name = "foo", properties = mapOf()))
+                md.addRemote("foo", NopRemote(name = "origin"))
+                md.updateRemote("foo", "origin", NopRemote(name = "upstream"))
+                md.getRemote("foo", "upstream")
+            }
+            remote.name shouldBe "upstream"
+        }
+        
+        "update of non-existent remote fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.createRepository(Repository(name = "foo", properties = mapOf()))
+                    md.updateRemote("foo", "origin", NopRemote(name = "upstream"))
+                }
+            }
+        }
+        
+        "update of remote for non-existent repo fails" {
+            shouldThrow<NoSuchObjectException> {
+                transaction {
+                    md.updateRemote("foo", "origin", NopRemote(name = "upstream"))
+                }
+            }
+        }
+    }
+}

--- a/server/src/test/kotlin/io/titandata/metadata/RemoteMetadataTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/RemoteMetadataTest.kt
@@ -1,9 +1,9 @@
 package io.titandata.metadata
 
+import io.kotlintest.Spec
 import io.kotlintest.TestCase
 import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
-import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
 import io.titandata.exception.NoSuchObjectException
@@ -15,16 +15,14 @@ import org.jetbrains.exposed.sql.transactions.transaction
 
 class RemoteMetadataTest : StringSpec() {
 
-    companion object {
-        var dbIdentifier = 0
+    val md = MetadataProvider()
+
+    override fun beforeSpec(spec: Spec) {
+        md.init()
     }
 
-    lateinit var md: MetadataProvider
-
     override fun beforeTest(testCase: TestCase) {
-        dbIdentifier++
-        md = MetadataProvider(true, "db$dbIdentifier")
-        md.init()
+        md.clear()
     }
 
     init {
@@ -143,7 +141,7 @@ class RemoteMetadataTest : StringSpec() {
             val s3 = remote as S3Remote
             s3.bucket shouldBe "bucket"
         }
-        
+
         "rename remote succeeds" {
             val remote = transaction {
                 md.createRepository(Repository(name = "foo", properties = mapOf()))
@@ -153,7 +151,7 @@ class RemoteMetadataTest : StringSpec() {
             }
             remote.name shouldBe "upstream"
         }
-        
+
         "update of non-existent remote fails" {
             shouldThrow<NoSuchObjectException> {
                 transaction {
@@ -162,7 +160,7 @@ class RemoteMetadataTest : StringSpec() {
                 }
             }
         }
-        
+
         "update of remote for non-existent repo fails" {
             shouldThrow<NoSuchObjectException> {
                 transaction {

--- a/server/src/test/kotlin/io/titandata/metadata/RepositoryMetadataTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/RepositoryMetadataTest.kt
@@ -1,6 +1,7 @@
 package io.titandata.metadata
 
 import io.kotlintest.TestCase
+import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
@@ -8,9 +9,10 @@ import io.kotlintest.specs.StringSpec
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Repository
+import io.titandata.remote.nop.NopRemote
 import org.jetbrains.exposed.sql.transactions.transaction
 
-class MetadataProviderTest : StringSpec() {
+class RepositoryMetadataTest : StringSpec() {
 
     companion object {
         var dbIdentifier = 0

--- a/server/src/test/kotlin/io/titandata/metadata/RepositoryMetadataTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/RepositoryMetadataTest.kt
@@ -1,7 +1,7 @@
 package io.titandata.metadata
 
+import io.kotlintest.Spec
 import io.kotlintest.TestCase
-import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
@@ -9,21 +9,18 @@ import io.kotlintest.specs.StringSpec
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Repository
-import io.titandata.remote.nop.NopRemote
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class RepositoryMetadataTest : StringSpec() {
 
-    companion object {
-        var dbIdentifier = 0
+    val md = MetadataProvider()
+
+    override fun beforeSpec(spec: Spec) {
+        md.init()
     }
 
-    lateinit var md: MetadataProvider
-
     override fun beforeTest(testCase: TestCase) {
-        dbIdentifier++
-        md = MetadataProvider(true, "db$dbIdentifier")
-        md.init()
+        md.clear()
     }
 
     init {

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
@@ -7,7 +7,6 @@ package io.titandata.storage.zfs
 import io.kotlintest.TestCase
 import io.kotlintest.TestCaseOrder
 import io.kotlintest.TestResult
-import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
@@ -19,7 +18,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
-import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
 import io.titandata.exception.CommandException
@@ -27,8 +25,6 @@ import io.titandata.exception.InvalidStateException
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Repository
-import io.titandata.remote.engine.EngineRemote
-import io.titandata.remote.nop.NopRemote
 import io.titandata.util.CommandExecutor
 import io.titandata.util.GuidGenerator
 

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsRepositoryTest.kt
@@ -207,41 +207,5 @@ class ZfsRepositoryTest : StringSpec() {
                 provider.getActive("foo")
             }
         }
-
-        "get remotes with no property set succeeds" {
-            every { executor.exec(*anyVararg()) } returns "-\n"
-            val result = provider.getRemotes("repo")
-            result.size shouldBe 0
-        }
-
-        "get remotes returns success" {
-            every { executor.exec(*anyVararg()) } returns
-                "[{\"provider\":\"nop\",\"name\":\"foo\"}," +
-                        "{\"provider\":\"engine\",\"name\":\"bar\",\"address\":\"a\"," +
-                        "\"username\":\"u\",\"password\":\"p\"}]"
-            val result = provider.getRemotes("repo")
-            result.size shouldBe 2
-            result[0].shouldBeInstanceOf<NopRemote>()
-            result[0].provider shouldBe "nop"
-            result[0].name shouldBe "foo"
-            result[1].shouldBeInstanceOf<EngineRemote>()
-            result[1].provider shouldBe "engine"
-            result[1].name shouldBe "bar"
-            (result[1] as EngineRemote).username shouldBe "u"
-            (result[1] as EngineRemote).address shouldBe "a"
-            (result[1] as EngineRemote).password shouldBe "p"
-        }
-
-        "update remotes succeeds" {
-            every { executor.start(*anyVararg()) } returns mockk()
-            every { executor.exec(any<Process>(), any()) } returns ""
-            every { executor.exec(*anyVararg()) } returns ""
-            provider.updateRemotes("repo", listOf(NopRemote(name = "foo")))
-            verify {
-                executor.start("zfs", "set",
-                        "io.titan-data:remotes=[{\"provider\":\"nop\",\"name\":\"foo\"}]",
-                        "test/repo/repo")
-            }
-        }
     }
 }


### PR DESCRIPTION
## Proposed Changes

This moves the remotes from being stored on-disk as part of ZFS to the database layer. While testing this, some of the shenanigans I was doing trying to mock out the metadata layer were causing problems, so I left it intact and instead switched to clearing it before each test.

## Testing

Build, test, integrationTest, endtoendTest