### PR TITLE
add volumes to metadata layer

### DIFF
--- a/server/src/integration-test/kotlin/io/titandata/VolumesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/VolumesApiTest.kt
@@ -148,7 +148,7 @@ class VolumesApiTest : StringSpec() {
             val guid = transaction {
                 providers.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
                 val vs = providers.metadata.createVolumeSet("foo", true)
-                providers.metadata.createVolume(vs, Volume(name="vol"))
+                providers.metadata.createVolume(vs, Volume(name = "vol"))
                 vs
             }
             every { executor.exec("zfs", "destroy", "-R", "test/repo/foo/$guid/vol") } returns ""
@@ -169,7 +169,7 @@ class VolumesApiTest : StringSpec() {
             val guid = transaction {
                 providers.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
                 val vs = providers.metadata.createVolumeSet("foo", true)
-                providers.metadata.createVolume(vs, Volume(name="vol"))
+                providers.metadata.createVolume(vs, Volume(name = "vol"))
                 vs
             }
             every { executor.exec("mount", "-t", "zfs", "test/repo/foo/$guid/vol",
@@ -207,7 +207,7 @@ class VolumesApiTest : StringSpec() {
             transaction {
                 providers.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
                 val vs = providers.metadata.createVolumeSet("foo", true)
-                providers.metadata.createVolume(vs, Volume(name = "vol", properties=emptyMap()))
+                providers.metadata.createVolume(vs, Volume(name = "vol", properties = emptyMap()))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Path") {
                 setBody("{\"Name\":\"foo/vol\"}")
@@ -222,7 +222,7 @@ class VolumesApiTest : StringSpec() {
             transaction {
                 providers.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
                 val vs = providers.metadata.createVolumeSet("foo", true)
-                providers.metadata.createVolume(vs, Volume("vol", properties=mapOf("a" to "b")))
+                providers.metadata.createVolume(vs, Volume("vol", properties = mapOf("a" to "b")))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Get") {
                 setBody("{\"Name\":\"foo/vol\"}")
@@ -243,8 +243,8 @@ class VolumesApiTest : StringSpec() {
             transaction {
                 providers.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
                 val vs = providers.metadata.createVolumeSet("foo", true)
-                providers.metadata.createVolume(vs, Volume(name="one", properties=mapOf("a" to "b")))
-                providers.metadata.createVolume(vs, Volume(name="two", properties=mapOf("c" to "d")))
+                providers.metadata.createVolume(vs, Volume(name = "one", properties = mapOf("a" to "b")))
+                providers.metadata.createVolume(vs, Volume(name = "two", properties = mapOf("c" to "d")))
             }
 
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.List")) {

--- a/server/src/main/kotlin/io/titandata/apis/VolumesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/VolumesApi.kt
@@ -80,12 +80,7 @@ fun Route.VolumeApi(providers: ProviderModule) {
 
     route("/VolumeDriver.List") {
         post {
-            val result = mutableListOf<Volume>()
-            for (repo in providers.repositories.listRepositories()) {
-                for (vol in providers.volumes.listVolumes(repo.name)) {
-                    result.add(vol.copy(name = "${repo.name}/${vol.name}"))
-                }
-            }
+            val result = providers.volumes.listAllVolumes()
             call.respond(VolumeListResponse(volumes = result.toTypedArray()))
         }
     }
@@ -94,8 +89,9 @@ fun Route.VolumeApi(providers: ProviderModule) {
         post {
             val request = call.receive(VolumeMountRequest::class)
             val (repo, volname) = getVolumeName(request.name)
-            val result = providers.volumes.mountVolume(repo, volname)
-            call.respond(VolumePathResponse(mountpoint = result.mountpoint))
+            providers.volumes.mountVolume(repo, volname)
+            val vol = providers.volumes.getVolume(repo, volname)
+            call.respond(VolumePathResponse(mountpoint = vol.mountpoint))
         }
     }
 

--- a/server/src/main/kotlin/io/titandata/apis/VolumesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/VolumesApi.kt
@@ -12,7 +12,6 @@ import io.ktor.routing.post
 import io.ktor.routing.route
 import io.titandata.ProviderModule
 import io.titandata.models.PluginDescription
-import io.titandata.models.Volume
 import io.titandata.models.VolumeCapabilities
 import io.titandata.models.VolumeCapabilitiesResponse
 import io.titandata.models.VolumeCreateRequest

--- a/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
@@ -258,7 +258,6 @@ class MetadataProvider(val inMemory: Boolean = true, val databaseName: String = 
             properties = gson.fromJson(it[Volumes.metadata], object : TypeToken<Map<String, Any>>() {}.type)
     )
 
-
     fun createVolume(volumeSet: String, volume: Volume) {
         try {
             Volumes.insert {

--- a/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
@@ -9,8 +9,10 @@ import io.titandata.exception.ObjectExistsException
 import io.titandata.metadata.table.Remotes
 import io.titandata.metadata.table.Repositories
 import io.titandata.metadata.table.VolumeSets
+import io.titandata.metadata.table.Volumes
 import io.titandata.models.Remote
 import io.titandata.models.Repository
+import io.titandata.models.Volume
 import io.titandata.serialization.ModelTypeAdapters
 import java.util.UUID
 import org.jetbrains.exposed.exceptions.ExposedSQLException
@@ -72,14 +74,15 @@ class MetadataProvider(val inMemory: Boolean = true, val databaseName: String = 
         }
 
         transaction {
-            SchemaUtils.createMissingTablesAndColumns(Repositories, Remotes, VolumeSets)
+            SchemaUtils.createMissingTablesAndColumns(Repositories, Remotes, VolumeSets, Volumes)
         }
     }
 
     fun clear() {
         transaction {
-            Repositories.deleteAll()
+            Volumes.deleteAll()
             VolumeSets.deleteAll()
+            Repositories.deleteAll()
         }
     }
 
@@ -248,5 +251,53 @@ class MetadataProvider(val inMemory: Boolean = true, val databaseName: String = 
         return VolumeSets.select {
             VolumeSets.state eq VolumeState.DELETING
         }.map { it[VolumeSets.id].toString() }
+    }
+
+    private fun convertVolume(it: ResultRow) = Volume(
+            name = it[Volumes.name],
+            properties = gson.fromJson(it[Volumes.metadata], object : TypeToken<Map<String, Any>>() {}.type)
+    )
+
+
+    fun createVolume(volumeSet: String, volume: Volume) {
+        // It is a programming error to create a conflicting volume name, so no need to translate into a user exception
+        Volumes.insert {
+            it[Volumes.volumeSet] = UUID.fromString(volumeSet)
+            it[name] = volume.name
+            it[metadata] = gson.toJson(volume.properties)
+            it[state] = VolumeState.INACTIVE
+        }
+    }
+
+    fun markVolumeDeleting(volumeSet: String, volumeName: String) {
+        Volumes.update({
+            (Volumes.volumeSet eq UUID.fromString(volumeSet)) and (Volumes.name eq volumeName)
+        }) {
+            it[state] = VolumeState.DELETING
+        }
+    }
+
+    fun deleteVolume(volumeSet: String, volumeName: String) {
+        Volumes.deleteWhere {
+            (Volumes.volumeSet eq UUID.fromString(volumeSet)) and (Volumes.name eq volumeName)
+        }
+    }
+
+    fun getVolume(volumeSet: String, volumeName: String): Volume {
+        return Volumes.select {
+            (Volumes.volumeSet eq UUID.fromString(volumeSet)) and (Volumes.name eq volumeName)
+        }.map { convertVolume(it) }
+                .firstOrNull()
+                ?: throw NoSuchObjectException("no such volume '$volumeName'")
+    }
+
+    fun listVolumes(volumeSet: String): List<Volume> {
+        return Volumes.select {
+            Volumes.volumeSet eq UUID.fromString(volumeSet)
+        }.map { convertVolume(it) }
+    }
+
+    fun listAllVolumes(): List<Volume> {
+        return Volumes.selectAll().map { convertVolume(it) }
     }
 }

--- a/server/src/main/kotlin/io/titandata/metadata/table/Volumes.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/table/Volumes.kt
@@ -1,0 +1,24 @@
+package io.titandata.metadata.table
+
+import io.titandata.metadata.MetadataProvider
+import io.titandata.metadata.table.Remotes.primaryKey
+import io.titandata.metadata.table.Remotes.references
+import org.jetbrains.exposed.dao.UUIDTable
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.Table
+
+/*
+ * Volumes represent a single mount within a repository. They are grouped into VolumeSets, so that they are snapshotted
+ * and cloned as a group. Volume names are not globally unique, but are unique within a given volumeset, so the
+ * (volumeset, name) tuple uniquely identifies any volume in the system. Volumes can have user properties, which can
+ * be used to store the path where the volume is supposed to be mounted or other useful mmetadata.
+ *
+ * Volumes have a foreign key relationship with volumesets, but we don't cascade on delete because we want to ensure
+ * that all volumes are explicitly deleted prior to deleting the volumeset.
+ */
+object Volumes : Table("volumes") {
+    val volumeSet = uuid("volume_set").references(VolumeSets.id).primaryKey()
+    val name = varchar("name", 64).primaryKey()
+    val metadata = varchar("metadata", 8192)
+    val state = enumerationByName("state", 16, MetadataProvider.VolumeState::class)
+}

--- a/server/src/main/kotlin/io/titandata/metadata/table/Volumes.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/table/Volumes.kt
@@ -3,8 +3,6 @@ package io.titandata.metadata.table
 import io.titandata.metadata.MetadataProvider
 import io.titandata.metadata.table.Remotes.primaryKey
 import io.titandata.metadata.table.Remotes.references
-import org.jetbrains.exposed.dao.UUIDTable
-import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Table
 
 /*

--- a/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
+++ b/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
@@ -13,6 +13,7 @@ import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
 import io.titandata.remote.RemoteProvider
 import io.titandata.storage.OperationData
+import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.LoggerFactory
 
 /*
@@ -136,7 +137,7 @@ class OperationExecutor(
             val volumes = providers.volumes.listVolumes(repo)
             val base = providers.storage.mountOperationVolumes(repo, operationId, volumes)
             try {
-                for (volume in providers.metadata.listVolumes(repo)) {
+                for (volume in volumes) {
                     if (operation.type == Operation.Type.PULL) {
                         provider.pullVolume(this, data, volume, base, scratch)
                     } else {

--- a/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
+++ b/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
@@ -133,9 +133,10 @@ class OperationExecutor(
         val operationId = operation.id
         val scratch = providers.storage.createOperationScratch(repo, operationId)
         try {
-            val base = providers.storage.mountOperationVolumes(repo, operationId)
+            val volumes = providers.volumes.listVolumes(repo)
+            val base = providers.storage.mountOperationVolumes(repo, operationId, volumes)
             try {
-                for (volume in providers.storage.listVolumes(repo, operationId)) {
+                for (volume in providers.metadata.listVolumes(repo)) {
                     if (operation.type == Operation.Type.PULL) {
                         provider.pullVolume(this, data, volume, base, scratch)
                     } else {
@@ -143,7 +144,7 @@ class OperationExecutor(
                     }
                 }
             } finally {
-                providers.storage.unmountOperationVolumes(repo, operationId)
+                providers.storage.unmountOperationVolumes(repo, operationId, volumes)
             }
         } finally {
             providers.storage.destroyOperationScratch(repo, operationId)

--- a/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
+++ b/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
@@ -13,7 +13,6 @@ import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
 import io.titandata.remote.RemoteProvider
 import io.titandata.storage.OperationData
-import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.LoggerFactory
 
 /*

--- a/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
@@ -17,7 +17,7 @@ class VolumeOrchestrator(val providers: ProviderModule) {
      * Things like 'mountpoint' would only exist in the latter. For now, to minimize disruption as we go through
      * the metadata transition, we simply supplment the volume definition we get from the storage provider.
      */
-    fun convertVolume(repo: String, volume: Volume) : Volume {
+    fun convertVolume(repo: String, volume: Volume): Volume {
         return Volume(
                 name = "$repo/${volume.name}",
                 properties = volume.properties,
@@ -67,7 +67,7 @@ class VolumeOrchestrator(val providers: ProviderModule) {
         providers.storage.unmountVolume(repo, name)
     }
 
-    fun listVolumes(repo: String) : List<Volume> {
+    fun listVolumes(repo: String): List<Volume> {
         return transaction {
             val vs = providers.metadata.getActiveVolumeSet(repo)
             providers.metadata.listVolumes(vs).map { convertVolume(repo, it) }

--- a/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
@@ -12,27 +12,69 @@ class VolumeOrchestrator(val providers: ProviderModule) {
         }
     }
 
+    /*
+     * We need to create two volume definitions: one that is generic, and one that is unique to the current context.
+     * Things like 'mountpoint' would only exist in the latter. For now, to minimize disruption as we go through
+     * the metadata transition, we simply supplment the volume definition we get from the storage provider.
+     */
+    fun convertVolume(repo: String, volume: Volume) : Volume {
+        return Volume(
+                name = volume.name,
+                properties = volume.properties,
+                mountpoint = providers.storage.getVolumeMountpoint(repo, volume.name),
+                status = mapOf<String, Any>()
+        )
+    }
+
     fun createVolume(repo: String, name: String, properties: Map<String, Any>): Volume {
-        return providers.storage.createVolume(repo, getVolumeSet(repo), name, properties)
+        val vol = Volume(name = name, properties = properties)
+        val vs = transaction {
+            val vs = providers.metadata.getActiveVolumeSet(repo)
+            providers.metadata.createVolume(vs, vol)
+            vs
+        }
+        providers.storage.createVolume(repo, vs, vol)
+        return convertVolume(repo, vol)
     }
 
     fun deleteVolume(repo: String, name: String) {
+        transaction {
+            val vs = providers.metadata.getActiveVolumeSet(repo)
+            providers.metadata.deleteVolume(vs, name)
+        }
         providers.storage.deleteVolume(repo, getVolumeSet(repo), name)
     }
 
     fun getVolume(repo: String, name: String): Volume {
-        return providers.storage.getVolume(repo, getVolumeSet(repo), name)
+        val vol = transaction {
+            val vs = providers.metadata.getActiveVolumeSet(repo)
+            providers.metadata.getVolume(vs, name)
+        }
+        return convertVolume(repo, vol)
     }
 
-    fun mountVolume(repo: String, name: String): Volume {
-        return providers.storage.mountVolume(repo, getVolumeSet(repo), name)
+    fun mountVolume(repo: String, name: String) {
+        val vs = transaction {
+            providers.metadata.getActiveVolumeSet(repo)
+        }
+        val vol = transaction {
+            providers.metadata.getVolume(vs, name)
+        }
+        providers.storage.mountVolume(repo, vs, vol)
     }
 
     fun unmountVolume(repo: String, name: String) {
         providers.storage.unmountVolume(repo, name)
     }
 
-    fun listVolumes(repo: String): List<Volume> {
-        return providers.storage.listVolumes(repo, getVolumeSet(repo))
+    fun listVolumes(repo: String) : List<Volume> {
+        return transaction {
+            val vs = providers.metadata.getActiveVolumeSet(repo)
+            providers.metadata.listVolumes(vs)
+        }
+    }
+
+    fun listAllVolumes(): List<Volume> {
+        return providers.metadata.listAllVolumes()
     }
 }

--- a/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
@@ -33,15 +33,14 @@ interface StorageProvider {
     fun commitOperation(repo: String, id: String, commit: Commit)
     fun discardOperation(repo: String, id: String)
     fun updateOperationState(repo: String, id: String, state: Operation.State)
-    fun mountOperationVolumes(repo: String, id: String): String
-    fun unmountOperationVolumes(repo: String, id: String)
+    fun mountOperationVolumes(repo: String, id: String, volumes: List<Volume>): String
+    fun unmountOperationVolumes(repo: String, id: String, volumes: List<Volume>)
     fun createOperationScratch(repo: String, id: String): String
     fun destroyOperationScratch(repo: String, id: String)
 
-    fun createVolume(repo: String, volumeSet: String, name: String, properties: Map<String, Any>): Volume
+    fun createVolume(repo: String, volumeSet: String, volume: Volume)
     fun deleteVolume(repo: String, volumeSet: String, name: String)
-    fun getVolume(repo: String, volumeSet: String, name: String): Volume
-    fun mountVolume(repo: String, volumeSet: String, name: String): Volume
+    fun getVolumeMountpoint(repo: String, volumeName: String) : String
+    fun mountVolume(repo: String, volumeSet: String, volume: Volume)
     fun unmountVolume(repo: String, name: String)
-    fun listVolumes(repo: String, volumeSet: String): List<Volume>
 }

--- a/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
@@ -40,7 +40,7 @@ interface StorageProvider {
 
     fun createVolume(repo: String, volumeSet: String, volume: Volume)
     fun deleteVolume(repo: String, volumeSet: String, name: String)
-    fun getVolumeMountpoint(repo: String, volumeName: String) : String
+    fun getVolumeMountpoint(repo: String, volumeName: String): String
     fun mountVolume(repo: String, volumeSet: String, volume: Volume)
     fun unmountVolume(repo: String, name: String)
 }

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsOperationManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsOperationManager.kt
@@ -148,7 +148,7 @@ class ZfsOperationManager(val provider: ZfsStorageProvider) {
      * then mount all volumes within it based on their name ("/v0"). We return the base mountpoint
      * so that the caller can then access the data within those volumes.
      */
-    fun mountOperationVolumes(repo: String, id: String, volumes : List<Volume>): String {
+    fun mountOperationVolumes(repo: String, id: String, volumes: List<Volume>): String {
         val op = getOperation(repo, id)
         // We use the operation ID as the mountpoint so it can be mounted in parallel
         val base = provider.getMountpoint(op.operation.id)

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsOperationManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsOperationManager.kt
@@ -10,6 +10,7 @@ import io.titandata.exception.InvalidStateException
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.models.Commit
 import io.titandata.models.Operation
+import io.titandata.models.Volume
 import io.titandata.storage.OperationData
 
 /**
@@ -147,11 +148,11 @@ class ZfsOperationManager(val provider: ZfsStorageProvider) {
      * then mount all volumes within it based on their name ("/v0"). We return the base mountpoint
      * so that the caller can then access the data within those volumes.
      */
-    fun mountOperationVolumes(repo: String, id: String): String {
+    fun mountOperationVolumes(repo: String, id: String, volumes : List<Volume>): String {
         val op = getOperation(repo, id)
         // We use the operation ID as the mountpoint so it can be mounted in parallel
         val base = provider.getMountpoint(op.operation.id)
-        for (v in provider.listVolumes(repo, id)) {
+        for (v in volumes) {
             val mountpoint = "$base/${v.name}"
             provider.executor.exec("mkdir", "-p", mountpoint)
             provider.executor.exec("mount", "-t", "zfs",
@@ -163,11 +164,11 @@ class ZfsOperationManager(val provider: ZfsStorageProvider) {
     /**
      * Unmount volumes.
      */
-    fun unmountOperationVolumes(repo: String, id: String) {
+    fun unmountOperationVolumes(repo: String, id: String, volumes: List<Volume>) {
         val op = getOperation(repo, id)
         // We use the operation ID as the mountpoint so it can be mounted in parallel
         val base = provider.getMountpoint(op.operation.id)
-        for (v in provider.listVolumes(repo, id)) {
+        for (v in volumes) {
             val mountpoint = "$base/${v.name}"
             provider.safeUnmount(mountpoint)
         }

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsRepositoryManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsRepositoryManager.kt
@@ -5,7 +5,6 @@
 package io.titandata.storage.zfs
 
 import io.titandata.exception.CommandException
-import io.titandata.exception.InvalidStateException
 import io.titandata.models.Repository
 import io.titandata.models.RepositoryStatus
 import io.titandata.models.RepositoryVolumeStatus

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -361,15 +361,15 @@ class ZfsStorageProvider(
     }
 
     @Synchronized
-    override fun mountOperationVolumes(repo: String, id: String): String {
+    override fun mountOperationVolumes(repo: String, id: String, volumes: List<Volume>): String {
         log.info("mount volumes for operation $id in $repo")
-        return operationManager.mountOperationVolumes(repo, id)
+        return operationManager.mountOperationVolumes(repo, id, volumes)
     }
 
     @Synchronized
-    override fun unmountOperationVolumes(repo: String, id: String) {
+    override fun unmountOperationVolumes(repo: String, id: String, volumes: List<Volume>) {
         log.info("unmount volumes for operation $id in $repo")
-        operationManager.unmountOperationVolumes(repo, id)
+        operationManager.unmountOperationVolumes(repo, id, volumes)
     }
 
     override fun createOperationScratch(repo: String, id: String): String {
@@ -383,9 +383,9 @@ class ZfsStorageProvider(
     }
 
     @Synchronized
-    override fun createVolume(repo: String, volumeSet: String, name: String, properties: Map<String, Any>): Volume {
-        log.info("create volume $name in $repo")
-        return volumeManager.createVolume(repo, volumeSet, name, properties)
+    override fun createVolume(repo: String, volumeSet: String, volume: Volume) {
+        log.info("create volume ${volume.name} in $repo")
+        volumeManager.createVolume(repo, volumeSet, volume)
     }
 
     @Synchronized
@@ -394,25 +394,19 @@ class ZfsStorageProvider(
         return volumeManager.deleteVolume(repo, volumeSet, name)
     }
 
-    @Synchronized
-    override fun getVolume(repo: String, volumeSet: String, name: String): Volume {
-        return volumeManager.getVolume(repo, volumeSet, name)
+    override fun getVolumeMountpoint(repo: String, volumeName: String): String {
+        return getMountpoint(repo, volumeName)
     }
 
     @Synchronized
-    override fun mountVolume(repo: String, volumeSet: String, name: String): Volume {
-        log.info("mount volume $name in $repo")
-        return volumeManager.mountVolume(repo, volumeSet, name)
+    override fun mountVolume(repo: String, volumeSet: String, volume: Volume) {
+        log.info("mount volume ${volume.name} in $repo")
+        volumeManager.mountVolume(repo, volumeSet, volume)
     }
 
     @Synchronized
     override fun unmountVolume(repo: String, name: String) {
         log.info("unmount volume $name in $repo")
         volumeManager.unmountVolume(repo, name)
-    }
-
-    @Synchronized
-    override fun listVolumes(repo: String, volumeSet: String): List<Volume> {
-        return volumeManager.listVolumes(repo, volumeSet)
     }
 }

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsVolumeManager.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsVolumeManager.kt
@@ -30,23 +30,21 @@ class ZfsVolumeManager(val provider: ZfsStorageProvider) {
      * Create a new volume. This will simply create a dataset with the given name within the
      * current active dataset, storing any metadata properties along with it.
      */
-    fun createVolume(repo: String, volumeSet: String, name: String, properties: Map<String, Any>): Volume {
-        validate(repo, name)
+    fun createVolume(repo: String, volumeSet: String, volume: Volume) {
+        validate(repo, volume.name)
 
         try {
-            val json = provider.gson.toJson(properties)
+            val json = provider.gson.toJson(volume.properties)
             provider.executor.exec("zfs", "create", "-o", "$METADATA_PROP=$json",
-                    "$poolName/repo/$repo/$volumeSet/$name")
+                    "$poolName/repo/$repo/$volumeSet/${volume.name}")
             // Always create an initial snapshot (see createRepository for why)
             provider.executor.exec("zfs", "snapshot",
-                    "$poolName/repo/$repo/$volumeSet/$name@$INITIAL_COMMIT")
+                    "$poolName/repo/$repo/$volumeSet/${volume.name}@$INITIAL_COMMIT")
             // Create the mountpoint
-            val mountpoint = provider.getMountpoint(repo, name)
+            val mountpoint = provider.getMountpoint(repo, volume.name)
             provider.executor.exec("mkdir", "-p", mountpoint)
-            return Volume(name = name, properties = properties,
-                    mountpoint = mountpoint, status = mapOf<String, Any>())
         } catch (e: CommandException) {
-            provider.checkVolumeExists(e, name)
+            provider.checkVolumeExists(e, volume.name)
             throw e
         }
     }
@@ -70,34 +68,13 @@ class ZfsVolumeManager(val provider: ZfsStorageProvider) {
     }
 
     /**
-     * Get info about a volume. This does a lookup to make sure that it exists, and get any
-     * local properties, returning the result.
-     */
-    fun getVolume(repo: String, volumeSet: String, name: String): Volume {
-        validate(repo, name)
-
-        try {
-            val output = provider.executor.exec("zfs", "list", "-Ho", METADATA_PROP,
-                    "$poolName/repo/$repo/$volumeSet/$name")
-            return Volume(name = name, mountpoint = provider.getMountpoint(repo, name),
-                    properties = provider.parseMetadata(output), status = mapOf<String, Any>())
-        } catch (e: CommandException) {
-            provider.checkNoSuchVolume(e, name)
-            throw e
-        }
-    }
-
-    /**
      * Mount a volume. This is always mounted in a predictable location, independent of what
      * GUID may be active.
      */
-    fun mountVolume(repo: String, volumeSet: String, name: String): Volume {
-        validate(repo, name)
-        val volume = getVolume(repo, volumeSet, name)
-
-        provider.executor.exec("mount", "-t", "zfs", "$poolName/repo/$repo/$volumeSet/$name",
-                provider.getMountpoint(repo, name))
-        return volume
+    fun mountVolume(repo: String, volumeSet: String, volume: Volume) {
+        validate(repo, volume.name)
+        provider.executor.exec("mount", "-t", "zfs", "$poolName/repo/$repo/$volumeSet/${volume.name}",
+                provider.getMountpoint(repo, volume.name))
     }
 
     /**
@@ -108,32 +85,5 @@ class ZfsVolumeManager(val provider: ZfsStorageProvider) {
     fun unmountVolume(repo: String, name: String) {
         validate(repo, name)
         provider.safeUnmount(provider.getMountpoint(repo, name))
-    }
-
-    /**
-     * List all volumes within a given repository. We simply get the current active dataset,
-     * and then list any immediate descendants of it, along with their metadata.
-     */
-    fun listVolumes(repo: String, volumeSet: String): List<Volume> {
-        provider.validateRepositoryName(repo)
-
-        val output = provider.executor.exec("zfs", "list", "-Ho", "name,$METADATA_PROP",
-                "-r", "$poolName/repo/$repo/$volumeSet")
-        val volumes = mutableListOf<Volume>()
-        val regex = "$poolName/repo/$repo/$volumeSet/([^/\t]+)\t(.*)$".toRegex()
-        for (line in output.lines()) {
-            var result = regex.find(line)
-            if (result != null) {
-                val volName = result.groupValues.get(1)
-                val metadata = result.groupValues.get(2)
-                if (!volName.startsWith("_")) {
-                    volumes.add(Volume(name = volName, properties = provider.parseMetadata(metadata),
-                            mountpoint = provider.getMountpoint(repo, volName),
-                            status = mapOf<String, Any>()))
-                }
-            }
-        }
-
-        return volumes
     }
 }

--- a/server/src/test/kotlin/io/titandata/metadata/VolumeMetadataTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/VolumeMetadataTest.kt
@@ -9,7 +9,6 @@ import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Repository
 import io.titandata.models.Volume
-import java.util.UUID
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class VolumeMetadataTest : StringSpec() {
@@ -24,7 +23,7 @@ class VolumeMetadataTest : StringSpec() {
         md.clear()
     }
 
-    fun createVolumeSet() : String {
+    fun createVolumeSet(): String {
         return transaction {
             md.createRepository(Repository(name = "foo", properties = emptyMap()))
             md.createVolumeSet("foo", true)
@@ -35,7 +34,7 @@ class VolumeMetadataTest : StringSpec() {
         "create volume succeeds" {
             val vs = createVolumeSet()
             transaction {
-                md.createVolume(vs, Volume(name="vol", properties=emptyMap()))
+                md.createVolume(vs, Volume(name = "vol", properties = emptyMap()))
             }
         }
 
@@ -52,7 +51,7 @@ class VolumeMetadataTest : StringSpec() {
         "get volume succeeds" {
             val vs = createVolumeSet()
             transaction {
-                md.createVolume(vs, Volume(name="vol", properties=mapOf("a" to "b")))
+                md.createVolume(vs, Volume(name = "vol", properties = mapOf("a" to "b")))
                 val vol = md.getVolume(vs, "vol")
                 vol.name shouldBe "vol"
                 vol.properties!!["a"] shouldBe "b"
@@ -71,7 +70,7 @@ class VolumeMetadataTest : StringSpec() {
         "mark volume deleting succeeds" {
             val vs = createVolumeSet()
             transaction {
-                md.createVolume(vs, Volume(name="vol", properties=mapOf("a" to "b")))
+                md.createVolume(vs, Volume(name = "vol", properties = mapOf("a" to "b")))
                 md.markVolumeDeleting(vs, "vol")
             }
         }
@@ -85,11 +84,11 @@ class VolumeMetadataTest : StringSpec() {
             }
         }
 
-        "list volumes succeeds"{
+        "list volumes succeeds" {
             val vs = createVolumeSet()
             transaction {
-                md.createVolume(vs, Volume(name="vol1", properties=mapOf("a" to "b")))
-                md.createVolume(vs, Volume(name="vol2", properties=mapOf("c" to "d")))
+                md.createVolume(vs, Volume(name = "vol1", properties = mapOf("a" to "b")))
+                md.createVolume(vs, Volume(name = "vol2", properties = mapOf("c" to "d")))
                 val vols = md.listVolumes(vs).sortedBy { it.name }
                 vols.size shouldBe 2
                 vols[0].name shouldBe "vol1"
@@ -99,11 +98,11 @@ class VolumeMetadataTest : StringSpec() {
             }
         }
 
-        "list all volumes succeeds"{
+        "list all volumes succeeds" {
             val vs = createVolumeSet()
             transaction {
-                md.createVolume(vs, Volume(name="vol1", properties=mapOf("a" to "b")))
-                md.createVolume(vs, Volume(name="vol2", properties=mapOf("c" to "d")))
+                md.createVolume(vs, Volume(name = "vol1", properties = mapOf("a" to "b")))
+                md.createVolume(vs, Volume(name = "vol2", properties = mapOf("c" to "d")))
                 val vols = md.listAllVolumes().sortedBy { it.name }
                 vols.size shouldBe 2
                 vols[0].name shouldBe "vol1"
@@ -116,7 +115,7 @@ class VolumeMetadataTest : StringSpec() {
         "delete volume succeeds" {
             val vs = createVolumeSet()
             transaction {
-                md.createVolume(vs, Volume(name="vol", properties=emptyMap()))
+                md.createVolume(vs, Volume(name = "vol", properties = emptyMap()))
                 md.deleteVolume(vs, "vol")
                 shouldThrow<NoSuchObjectException> {
                     md.getVolume(vs, "vol")

--- a/server/src/test/kotlin/io/titandata/metadata/VolumeMetadataTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/VolumeMetadataTest.kt
@@ -1,0 +1,98 @@
+package io.titandata.metadata
+
+import io.kotlintest.Spec
+import io.kotlintest.TestCase
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.StringSpec
+import io.titandata.exception.NoSuchObjectException
+import io.titandata.models.Repository
+import io.titandata.models.Volume
+import java.util.UUID
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class VolumeMetadataTest : StringSpec() {
+
+    val md = MetadataProvider()
+
+    override fun beforeSpec(spec: Spec) {
+        md.init()
+    }
+
+    override fun beforeTest(testCase: TestCase) {
+        md.clear()
+    }
+
+    fun createVolumeSet() : String {
+        return transaction {
+            md.createRepository(Repository(name = "foo", properties = emptyMap()))
+            md.createVolumeSet("foo", true)
+        }
+    }
+
+    init {
+        "create volume succeeds" {
+            val vs = createVolumeSet()
+            transaction {
+                md.createVolume(vs, Volume(name="vol", properties=emptyMap()))
+            }
+        }
+
+        "get volume succeeds" {
+            val vs = createVolumeSet()
+            transaction {
+                md.createVolume(vs, Volume(name="vol", properties=mapOf("a" to "b")))
+                val vol = md.getVolume(vs, "vol")
+                vol.name shouldBe "vol"
+                vol.properties!!["a"] shouldBe "b"
+            }
+        }
+
+        "mark volume deleting succeeds" {
+            val vs = createVolumeSet()
+            transaction {
+                md.createVolume(vs, Volume(name="vol", properties=mapOf("a" to "b")))
+                md.markVolumeDeleting(vs, "vol")
+            }
+        }
+
+        "list volumes succeeds"{
+            val vs = createVolumeSet()
+            transaction {
+                md.createVolume(vs, Volume(name="vol1", properties=mapOf("a" to "b")))
+                md.createVolume(vs, Volume(name="vol2", properties=mapOf("c" to "d")))
+                val vols = md.listVolumes(vs).sortedBy { it.name }
+                vols.size shouldBe 2
+                vols[0].name shouldBe "vol1"
+                vols[0].properties!!["a"] shouldBe "b"
+                vols[1].name shouldBe "vol2"
+                vols[1].properties!!["c"] shouldBe "d"
+            }
+        }
+
+        "list all volumes succeeds"{
+            val vs = createVolumeSet()
+            transaction {
+                md.createVolume(vs, Volume(name="vol1", properties=mapOf("a" to "b")))
+                md.createVolume(vs, Volume(name="vol2", properties=mapOf("c" to "d")))
+                val vols = md.listAllVolumes().sortedBy { it.name }
+                vols.size shouldBe 2
+                vols[0].name shouldBe "vol1"
+                vols[0].properties!!["a"] shouldBe "b"
+                vols[1].name shouldBe "vol2"
+                vols[1].properties!!["c"] shouldBe "d"
+            }
+        }
+
+        "volume deletion succeeds" {
+            val vs = createVolumeSet()
+            transaction {
+                md.createVolume(vs, Volume(name="vol", properties=emptyMap()))
+                md.deleteVolume(vs, "vol")
+                shouldThrow<Exception> {
+                    md.getVolume(vs, "vol")
+                }
+            }
+        }
+    }
+}

--- a/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
@@ -192,9 +192,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.commitOperation("foo", "id", any()) } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
-            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
-            every { zfsStorageProvider.listVolumes("foo", any()) } returns listOf(Volume(name = "v0"))
-            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.mountOperationVolumes("foo", any(), any()) } returns ""
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any(), any()) } just Runs
             every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPull("foo", "remote", "commit", NopParameters())
             op.id shouldBe "id"
@@ -228,9 +227,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
-            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
-            every { zfsStorageProvider.listVolumes("foo", any()) } returns listOf(Volume(name = "v0"))
-            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.mountOperationVolumes("foo", any(), any()) } returns ""
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any(), any()) } just Runs
             every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPull("foo", "remote", "commit", NopParameters())
             provider.getExecutor("foo", op.id).join()
@@ -255,9 +253,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
-            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
-            every { zfsStorageProvider.listVolumes("foo", any()) } returns listOf(Volume(name = "v0"))
-            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.mountOperationVolumes("foo", any(), any()) } returns ""
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any(), any()) } just Runs
             every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPull("foo", "remote", "commit", NopParameters())
             provider.getExecutor("foo", op.id).join()
@@ -290,9 +287,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.commitOperation("foo", "id", any()) } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
-            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
-            every { zfsStorageProvider.listVolumes("foo", any()) } returns listOf(Volume(name = "v0"))
-            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.mountOperationVolumes("foo", any(), any()) } returns ""
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any(), any()) } just Runs
             every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPull("foo", "remote", "commit2", NopParameters())
             provider.getExecutor("foo", op.id).join()
@@ -347,9 +343,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
-            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
-            every { zfsStorageProvider.listVolumes("foo", any()) } returns listOf(Volume(name = "v0"))
-            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.mountOperationVolumes("foo", any(), any()) } returns ""
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any(), any()) } just Runs
             every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPush("foo", "remote", "commit", NopParameters())
             op.id shouldBe "id"
@@ -384,9 +379,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
-            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
-            every { zfsStorageProvider.listVolumes("foo", any()) } returns listOf(Volume(name = "v0"))
-            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.mountOperationVolumes("foo", any(), any()) } returns ""
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any(), any()) } just Runs
             every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPush("foo", "remote", "commit", NopParameters())
             provider.getExecutor("foo", op.id).join()
@@ -411,9 +405,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
-            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
-            every { zfsStorageProvider.listVolumes("foo", any()) } returns listOf(Volume(name = "v0"))
-            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.mountOperationVolumes("foo", any(), any()) } returns ""
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any(), any()) } just Runs
             every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPush("foo", "remote", "commit", NopParameters())
             provider.getExecutor("foo", op.id).join()
@@ -447,9 +440,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { zfsStorageProvider.discardOperation("foo", "id") } just Runs
             every { zfsStorageProvider.createOperation("foo", any(), any()) } just Runs
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
-            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
-            every { zfsStorageProvider.listVolumes("foo", any()) } returns listOf(Volume(name = "v0"))
-            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.mountOperationVolumes("foo", any(), any()) } returns ""
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any(), any()) } just Runs
             every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             var op = provider.startPush("foo", "remote", "commit2", NopParameters())
             provider.getExecutor("foo", op.id).join()
@@ -498,9 +490,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { metadata.listRemotes("foo") } returns listOf(
                     NopRemote(name = "remote"))
             every { zfsStorageProvider.createOperationScratch("foo", any()) } returns ""
-            every { zfsStorageProvider.mountOperationVolumes("foo", any()) } returns ""
-            every { zfsStorageProvider.listVolumes("foo", any()) } returns listOf(Volume(name = "v0"))
-            every { zfsStorageProvider.unmountOperationVolumes("foo", any()) } just Runs
+            every { zfsStorageProvider.mountOperationVolumes("foo", any(), any()) } returns ""
+            every { zfsStorageProvider.unmountOperationVolumes("foo", any(), any()) } just Runs
             every { zfsStorageProvider.destroyOperationScratch("foo", any()) } just Runs
             every { zfsStorageProvider.getCommit("foo", any()) } returns Commit(id = "hash", properties = mapOf())
             provider.loadState()

--- a/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
@@ -24,12 +24,10 @@ import io.mockk.verify
 import io.titandata.ProviderModule
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
-import io.titandata.metadata.MetadataProvider
 import io.titandata.models.Commit
 import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Repository
-import io.titandata.models.Volume
 import io.titandata.operation.OperationExecutor
 import io.titandata.remote.engine.EngineParameters
 import io.titandata.remote.nop.NopParameters
@@ -63,7 +61,7 @@ class OperationOrchestratorTest : StringSpec() {
         provider = OperationOrchestrator(providers)
         providers.metadata.clear()
         transaction {
-            providers.metadata.createRepository(Repository(name="foo",properties=emptyMap()))
+            providers.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
             providers.metadata.createVolumeSet("foo", true)
         }
         return MockKAnnotations.init(this)

--- a/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
@@ -212,12 +212,10 @@ class SshRemoteProviderTest : StringSpec() {
 
             every { executor.start(*anyVararg()) } returns process
 
-            every { zfsStorageProvider.mountOperationVolumes(any(), any()) } returns
+            every { zfsStorageProvider.mountOperationVolumes(any(), any(), any()) } returns
                     "/var/operation"
             every { zfsStorageProvider.getCommit(any(), any()) } returns Commit(id = "commitId", properties = mapOf())
-            every { zfsStorageProvider.listVolumes(any(), any()) } returns
-                    listOf(Volume(name = "v0"), Volume(name = "v1", properties = mapOf("path" to "/volume")))
-            every { zfsStorageProvider.unmountOperationVolumes(any(), any()) } just Runs
+            every { zfsStorageProvider.unmountOperationVolumes(any(), any(), any()) } just Runs
             every { zfsStorageProvider.createOperation("repo", any(), any()) } just Runs
             every { zfsStorageProvider.createOperationScratch("repo", any()) } returns ""
             every { zfsStorageProvider.destroyOperationScratch("repo", any()) } just Runs
@@ -255,12 +253,10 @@ class SshRemoteProviderTest : StringSpec() {
 
             every { executor.start(*anyVararg()) } returns process
 
-            every { zfsStorageProvider.mountOperationVolumes(any(), any()) } returns
+            every { zfsStorageProvider.mountOperationVolumes(any(), any(), any()) } returns
                     "/var/operation"
             every { zfsStorageProvider.getCommit(any(), any()) } returns Commit(id = "commitId", properties = mapOf())
-            every { zfsStorageProvider.listVolumes(any(), any()) } returns
-                    listOf(Volume(name = "v0"), Volume(name = "v1", properties = mapOf("path" to "/volume")))
-            every { zfsStorageProvider.unmountOperationVolumes(any(), any()) } just Runs
+            every { zfsStorageProvider.unmountOperationVolumes(any(), any(), any()) } just Runs
             every { zfsStorageProvider.createOperation("repo", any(), any()) } just Runs
             every { zfsStorageProvider.createOperationScratch("repo", any()) } returns ""
             every { zfsStorageProvider.destroyOperationScratch("repo", any()) } just Runs

--- a/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
@@ -35,11 +35,11 @@ import io.titandata.models.Volume
 import io.titandata.operation.OperationExecutor
 import io.titandata.storage.zfs.ZfsStorageProvider
 import io.titandata.util.CommandExecutor
-import org.jetbrains.exposed.sql.transactions.transaction
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
+import org.jetbrains.exposed.sql.transactions.transaction
 
 class SshRemoteProviderTest : StringSpec() {
 
@@ -221,10 +221,10 @@ class SshRemoteProviderTest : StringSpec() {
             every { executor.start(*anyVararg()) } returns process
 
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties=emptyMap()))
+                providers.metadata.createRepository(Repository(name = "repo", properties = emptyMap()))
                 val vs = providers.metadata.createVolumeSet("repo", true)
-                providers.metadata.createVolume(vs, Volume(name="v0", properties=emptyMap()))
-                providers.metadata.createVolume(vs, Volume(name="v1", properties=mapOf("path" to "/volume")))
+                providers.metadata.createVolume(vs, Volume(name = "v0", properties = emptyMap()))
+                providers.metadata.createVolume(vs, Volume(name = "v1", properties = mapOf("path" to "/volume")))
             }
 
             every { zfsStorageProvider.mountOperationVolumes(any(), any(), any()) } returns
@@ -234,7 +234,7 @@ class SshRemoteProviderTest : StringSpec() {
             every { zfsStorageProvider.createOperation("repo", any(), any()) } just Runs
             every { zfsStorageProvider.createOperationScratch("repo", any()) } returns ""
             every { zfsStorageProvider.destroyOperationScratch("repo", any()) } just Runs
-            every { zfsStorageProvider.getVolumeMountpoint(any(), any())} returns "/"
+            every { zfsStorageProvider.getVolumeMountpoint(any(), any()) } returns "/"
 
             operationExecutor.run()
 
@@ -270,10 +270,10 @@ class SshRemoteProviderTest : StringSpec() {
             every { executor.start(*anyVararg()) } returns process
 
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties=emptyMap()))
+                providers.metadata.createRepository(Repository(name = "repo", properties = emptyMap()))
                 val vs = providers.metadata.createVolumeSet("repo", true)
-                providers.metadata.createVolume(vs, Volume(name="v0", properties=emptyMap()))
-                providers.metadata.createVolume(vs, Volume(name="v1", properties=mapOf("path" to "/volume")))
+                providers.metadata.createVolume(vs, Volume(name = "v0", properties = emptyMap()))
+                providers.metadata.createVolume(vs, Volume(name = "v1", properties = mapOf("path" to "/volume")))
             }
 
             every { zfsStorageProvider.mountOperationVolumes(any(), any(), any()) } returns
@@ -283,7 +283,7 @@ class SshRemoteProviderTest : StringSpec() {
             every { zfsStorageProvider.createOperation("repo", any(), any()) } just Runs
             every { zfsStorageProvider.createOperationScratch("repo", any()) } returns ""
             every { zfsStorageProvider.destroyOperationScratch("repo", any()) } just Runs
-            every { zfsStorageProvider.getVolumeMountpoint(any(), any())} returns "/"
+            every { zfsStorageProvider.getVolumeMountpoint(any(), any()) } returns "/"
 
             operationExecutor.run()
 

--- a/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/ssh/SshRemoteProviderTest.kt
@@ -234,13 +234,14 @@ class SshRemoteProviderTest : StringSpec() {
             every { zfsStorageProvider.createOperation("repo", any(), any()) } just Runs
             every { zfsStorageProvider.createOperationScratch("repo", any()) } returns ""
             every { zfsStorageProvider.destroyOperationScratch("repo", any()) } just Runs
+            every { zfsStorageProvider.getVolumeMountpoint(any(), any())} returns "/"
 
             operationExecutor.run()
 
             val progress = operationExecutor.getProgress()
             progress.size shouldBe 7
             progress[0].type shouldBe ProgressEntry.Type.START
-            progress[0].message shouldBe "Syncing v0"
+            progress[0].message shouldBe "Syncing repo/v0"
             progress[1].type shouldBe ProgressEntry.Type.PROGRESS
             progress[2].type shouldBe ProgressEntry.Type.END
             progress[3].type shouldBe ProgressEntry.Type.START
@@ -282,6 +283,7 @@ class SshRemoteProviderTest : StringSpec() {
             every { zfsStorageProvider.createOperation("repo", any(), any()) } just Runs
             every { zfsStorageProvider.createOperationScratch("repo", any()) } returns ""
             every { zfsStorageProvider.destroyOperationScratch("repo", any()) } just Runs
+            every { zfsStorageProvider.getVolumeMountpoint(any(), any())} returns "/"
 
             operationExecutor.run()
 

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsOperationTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsOperationTest.kt
@@ -244,8 +244,8 @@ class ZfsOperationTest : StringSpec() {
             every { executor.exec("mkdir", "-p", "/var/lib/test/mnt/id/two") } returns ""
             every { executor.exec("mount", "-t", "zfs",
                     "test/repo/foo/id/two", "/var/lib/test/mnt/id/two") } returns ""
-            val result = provider.mountOperationVolumes("foo", "id", listOf(Volume(name="one", properties=mapOf("a" to "b")),
-                    Volume(name="two", properties=mapOf("c" to "d"))))
+            val result = provider.mountOperationVolumes("foo", "id", listOf(Volume(name = "one", properties = mapOf("a" to "b")),
+                    Volume(name = "two", properties = mapOf("c" to "d"))))
             result shouldBe "/var/lib/test/mnt/id"
 
             verify {
@@ -260,8 +260,8 @@ class ZfsOperationTest : StringSpec() {
             mockOperation()
             every { executor.exec("umount", "/var/lib/test/mnt/id/one") } returns ""
             every { executor.exec("umount", "/var/lib/test/mnt/id/two") } returns ""
-            provider.unmountOperationVolumes("foo", "id", listOf(Volume(name="one", properties=mapOf("a" to "b")),
-                    Volume(name="two", properties=mapOf("c" to "d"))))
+            provider.unmountOperationVolumes("foo", "id", listOf(Volume(name = "one", properties = mapOf("a" to "b")),
+                    Volume(name = "two", properties = mapOf("c" to "d"))))
 
             verify {
                 executor.exec("umount", "/var/lib/test/mnt/id/one")

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsVolumeTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsVolumeTest.kt
@@ -7,8 +7,6 @@ package io.titandata.storage.zfs
 import io.kotlintest.TestCase
 import io.kotlintest.TestCaseOrder
 import io.kotlintest.TestResult
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
 import io.mockk.MockKAnnotations
@@ -47,19 +45,19 @@ class ZfsVolumeTest : StringSpec() {
     init {
         "create volume fails with invalid repo name" {
             shouldThrow<IllegalArgumentException> {
-                provider.createVolume("not/ok", "guid", Volume(name="ok", properties=emptyMap()))
+                provider.createVolume("not/ok", "guid", Volume(name = "ok", properties = emptyMap()))
             }
         }
 
         "create volume fails with invalid volume name" {
             shouldThrow<IllegalArgumentException> {
-                provider.createVolume("ok", "guid", Volume(name="not/ok", properties=emptyMap()))
+                provider.createVolume("ok", "guid", Volume(name = "not/ok", properties = emptyMap()))
             }
         }
 
         "create volume fails with leading unsore in volume name" {
             shouldThrow<IllegalArgumentException> {
-                provider.createVolume("ok", "guid", Volume(name="_vol", properties=emptyMap()))
+                provider.createVolume("ok", "guid", Volume(name = "_vol", properties = emptyMap()))
             }
         }
 
@@ -68,7 +66,7 @@ class ZfsVolumeTest : StringSpec() {
                     "io.titan-data:metadata={\"a\":\"b\"}", "test/repo/foo/guid/vol") } throws
                     CommandException("", 1, "already exists")
             shouldThrow<ObjectExistsException> {
-                provider.createVolume("foo", "guid", Volume(name="vol", properties=mapOf("a" to "b")))
+                provider.createVolume("foo", "guid", Volume(name = "vol", properties = mapOf("a" to "b")))
             }
         }
 
@@ -78,7 +76,7 @@ class ZfsVolumeTest : StringSpec() {
             every { executor.exec("zfs", "snapshot", "test/repo/foo/guid/vol@initial") } returns ""
             every { executor.exec("mkdir", "-p", "/var/lib/test/mnt/foo/vol") } returns ""
 
-            provider.createVolume("foo", "guid", Volume(name="vol", properties=mapOf("a" to "b")))
+            provider.createVolume("foo", "guid", Volume(name = "vol", properties = mapOf("a" to "b")))
 
             verifySequence {
                 executor.exec("zfs", "create", "-o",
@@ -122,13 +120,13 @@ class ZfsVolumeTest : StringSpec() {
 
         "mount volume fails with invalid repo name" {
             shouldThrow<IllegalArgumentException> {
-                provider.mountVolume("not/ok", "guid", Volume(name="ok", properties=emptyMap()))
+                provider.mountVolume("not/ok", "guid", Volume(name = "ok", properties = emptyMap()))
             }
         }
 
         "mount volume fails with invalid volume name" {
             shouldThrow<IllegalArgumentException> {
-                provider.mountVolume("ok", "guid", Volume(name="not/ok", properties=emptyMap()))
+                provider.mountVolume("ok", "guid", Volume(name = "not/ok", properties = emptyMap()))
             }
         }
 
@@ -137,7 +135,7 @@ class ZfsVolumeTest : StringSpec() {
                     "test/repo/foo/guid/vol") } returns "{}"
             every { executor.exec("mount", "-t", "zfs", "test/repo/foo/guid/vol",
                     "/var/lib/test/mnt/foo/vol") } returns ""
-            provider.mountVolume("foo", "guid", Volume(name="vol", properties=emptyMap()))
+            provider.mountVolume("foo", "guid", Volume(name = "vol", properties = emptyMap()))
             verifySequence {
                 executor.exec("mount", "-t", "zfs", "test/repo/foo/guid/vol",
                         "/var/lib/test/mnt/foo/vol")

--- a/server/src/test/kotlin/io/titandata/storage/zfs/ZfsVolumeTest.kt
+++ b/server/src/test/kotlin/io/titandata/storage/zfs/ZfsVolumeTest.kt
@@ -139,8 +139,6 @@ class ZfsVolumeTest : StringSpec() {
                     "/var/lib/test/mnt/foo/vol") } returns ""
             provider.mountVolume("foo", "guid", Volume(name="vol", properties=emptyMap()))
             verifySequence {
-                executor.exec("zfs", "list", "-Ho", "io.titan-data:metadata",
-                        "test/repo/foo/guid/vol")
                 executor.exec("mount", "-t", "zfs", "test/repo/foo/guid/vol",
                         "/var/lib/test/mnt/foo/vol")
             }


### PR DESCRIPTION
This is the next step in moving content into the metadata layer, this time with volumes. As with the other migrations, this has exposed plenty of oddities in the APIs and interactions between the layers. We really should have a generic titan Volume model that is different from the docker API, and volumes are cloned within the storage provider layer but then created after the fact, etc. But until the metadata layer migration is complete, I don't want to muck with the core storage / orchestrator flow. I'll come back and fix up these oddities once the core metadata layer migration is complete.

## Testing

Gradle build / test / integrationTest, and endtoendTest (minus engine tests).