### PR TITLE
restore missing publish tasks

### DIFF
--- a/server/gradle/docker.gradle.kts
+++ b/server/gradle/docker.gradle.kts
@@ -43,3 +43,22 @@ tasks.named("rebuild").configure {
     dependsOn(rebuildDockerServer)
     dependsOn(tagLocalDockerServer)
 }
+
+var publishDockerVersion = tasks.register<Exec>("publishDockerVersion") {
+    group = "Publishing"
+    description = "Publish versioned docker server image to docker hub"
+    commandLine("docker", "push", "$imageName:${project.version}")
+    mustRunAfter(tasks.named("tagDockerServer"))
+}
+
+var publishDockerLatest = tasks.register<Exec>("publishDockerLatest") {
+    group = "Publishing"
+    description = "Publish latest docker server image to docker hub"
+    commandLine("docker", "push", "$imageName:latest")
+    mustRunAfter(tasks.named("publishDockerVersion"))
+}
+
+tasks.named("publish").configure {
+    dependsOn(publishDockerVersion)
+    dependsOn(publishDockerLatest)
+}


### PR DESCRIPTION
## Proposed Changes

When I switched over to using the published sshtest, I apparently deleted too much of the build file. This restores the missing tasks to publish docker images.

