### PR TITLE
run endtoend tests nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,6 @@
 #
 # Nightly, we do a full build and run a more complex set of end to end
 # tests that take longer to run (and may require secrets like S3 credentials).
-# End to end tests are still TBD, so for now this is just a full build
-# (including the docker build, which is not done in PR context).
 #
 name: Nightly Tests
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,17 +1,18 @@
 #
-# On each push, we do a full build and run a more complex set of end to end
+# Nightly, we do a full build and run a more complex set of end to end
 # tests that take longer to run (and may require secrets like S3 credentials).
 # End to end tests are still TBD, so for now this is just a full build
 # (including the docker build, which is not done in PR context).
 #
-name: Push
+name: Nightly Tests
 
-on: push
+on:
+  schedule:
+    - cron: '30 3 * * *'
 
 jobs:
   build:
     name: Build and test
-    if: startsWith(github.ref, 'refs/heads/')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Titan Docker Server
 
+![](https://github.com/titan-data/titan-server/workflows/Nightly%20Tests/badge.svg)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/titan-data/titan-server)
+
 This repository contains the docker container that is used by the
 [Titan](https://github.com/titan-data/titan) data management tool. This docker container
 provides all the repository operations necessary to support titan-powered containers, along with 


### PR DESCRIPTION
## Proposed Changes

I previously set up the end to end tests to run with every push. This was always likely overkill, and now is probably the time to move to a nightly model. We also add some badges to the README.