### PR TITLE
fixes for 0.6.0 regressions

### DIFF
--- a/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/LocalWorkflowTest.kt
@@ -232,6 +232,12 @@ class LocalWorkflowTest : EndToEndTest() {
             result shouldBe "Hello\n"
         }
 
+        "volume is mounted at a new location" {
+            val vol = volumeApi.getVolume("foo", "vol")
+            vol.config["mountpoint"] shouldNotBe volumeMountpoint
+            volumeMountpoint = vol.config["mountpoint"] as String
+        }
+
         "get repository status indicates source commit" {
             val status = repoApi.getRepositoryStatus("foo")
             status.sourceCommit shouldBe "id"

--- a/server/src/integration-test/kotlin/io/titandata/CommitsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/CommitsApiTest.kt
@@ -271,7 +271,8 @@ class CommitsApiTest : StringSpec() {
                 providers.metadata.createCommit("foo", vs, Commit("hash"))
             }
 
-            every { zfsStorageProvider.cloneVolumeSet(any(), any(), any(), any()) } just Runs
+            every { zfsStorageProvider.cloneVolumeSet(any(), any(), any()) } just Runs
+            every { zfsStorageProvider.cloneVolume(any(), any(), any(), any()) } returns emptyMap()
 
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/foo/commits/hash/checkout")) {
                 response.status() shouldBe HttpStatusCode.NoContent
@@ -280,7 +281,7 @@ class CommitsApiTest : StringSpec() {
                 }
                 activeVs shouldNotBe vs
                 verify {
-                    zfsStorageProvider.cloneVolumeSet(vs, "hash", activeVs, emptyList())
+                    zfsStorageProvider.cloneVolumeSet(vs, "hash", activeVs)
                 }
             }
         }

--- a/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
@@ -226,7 +226,8 @@ class OperationsApiTest : StringSpec() {
                 providers.metadata.createCommit("foo", vs1, Commit("commit"))
             }
 
-            every { zfsStorageProvider.cloneVolumeSet(any(), any(), any(), any()) } just Runs
+            every { zfsStorageProvider.cloneVolumeSet(any(), any(), any()) } just Runs
+            every { zfsStorageProvider.cloneVolume(any(), any(), any(), any()) } returns emptyMap()
 
             val result = engine.handleRequest(HttpMethod.Post, "/v1/repositories/foo/remotes/remote/commits/commit/push") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())

--- a/server/src/main/kotlin/io/titandata/orchestrator/CommitOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/CommitOrchestrator.kt
@@ -98,7 +98,13 @@ class CommitOrchestrator(val providers: ProviderModule) {
             providers.metadata.listVolumes(newVolumeSet).map { it.name }
         }
 
-        providers.storage.cloneVolumeSet(sourceVolumeSet, commit, newVolumeSet, volumes)
+        providers.storage.cloneVolumeSet(sourceVolumeSet, commit, newVolumeSet)
+        for (v in volumes) {
+            val config = providers.storage.cloneVolume(sourceVolumeSet, commit, newVolumeSet, v)
+            transaction {
+                providers.metadata.updateVolumeConfig(newVolumeSet, v, config)
+            }
+        }
 
         transaction {
             providers.metadata.activateVolumeSet(repo, newVolumeSet)

--- a/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/StorageProvider.kt
@@ -9,7 +9,7 @@ import io.titandata.models.RepositoryVolumeStatus
 
 interface StorageProvider {
     fun createVolumeSet(volumeSet: String)
-    fun cloneVolumeSet(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeNames: List<String>)
+    fun cloneVolumeSet(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String)
     fun deleteVolumeSet(volumeSet: String)
     fun getVolumeStatus(volumeSet: String, volume: String): RepositoryVolumeStatus
 
@@ -18,6 +18,7 @@ interface StorageProvider {
     fun deleteCommit(volumeSet: String, commitId: String, volumeNames: List<String>)
 
     fun createVolume(volumeSet: String, volumeName: String): Map<String, Any>
+    fun cloneVolume(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeName: String): Map<String, Any>
     fun deleteVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
     fun activateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
     fun deactivateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -162,9 +162,17 @@ class ZfsStorageProvider(
                 throw e
             }
         }
-        // A partially constructed volume will not have any config
+
         if (config.containsKey("mountpoint")) {
-            executor.exec("rmdir", config["mountpoint"] as String)
+            // A partially constructed volume will not have any config, ignore cases with no mountpoint
+            try {
+                executor.exec("rmdir", config["mountpoint"] as String)
+            } catch (e: CommandException) {
+                // Deletion should be idempotent, ignore errors if the directory doesn't exist
+                if (!e.output.contains("No such file or directory")) {
+                    throw e
+                }
+            }
         }
     }
 

--- a/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
+++ b/server/src/main/kotlin/io/titandata/storage/zfs/ZfsStorageProvider.kt
@@ -35,31 +35,42 @@ class ZfsStorageProvider(
      * Create a new volume set. This is simply an empty placeholder volumeset.
      */
     override fun createVolumeSet(volumeSet: String) {
-        executor.exec("zfs", "create", "-o", "mountpoint=legacy", "$poolName/data/$volumeSet")
+        executor.exec("zfs", "create", "$poolName/data/$volumeSet")
     }
 
     /**
-     * Clone a volumeset from an existing commit. We create the plain volume set, and then go about cloning each
-     * volume from the old volumeset into the new space.
+     * Clone a volumeset from an existing commit. We create the plain dataset that will contain the volumes.
      */
     override fun cloneVolumeSet(
         sourceVolumeSet: String,
         sourceCommit: String,
-        newVolumeSet: String,
-        volumeNames: List<String>
+        newVolumeSet: String
     ) {
         createVolumeSet(newVolumeSet)
-        for (vol in volumeNames) {
-            executor.exec("zfs", "clone", "$poolName/data/$sourceVolumeSet/$vol@$sourceCommit",
-                    "$poolName/data/$newVolumeSet/$vol")
-        }
+    }
+
+    /**
+     * Clone an individual volume. Here's where we actually do the work of cloning the volume, and then making sure
+     * we pass back an updated config with the proper mountpoint.
+     */
+    override fun cloneVolume(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeName: String): Map<String, Any> {
+        executor.exec("zfs", "clone", "$poolName/data/$sourceVolumeSet/$volumeName@$sourceCommit",
+                "$poolName/data/$newVolumeSet/$volumeName")
+        return mapOf("mountpoint" to "/var/lib/$poolName/mnt/$newVolumeSet/$volumeName")
     }
 
     /**
      * Delete a volume set. This should only be invoked from the reaper after all volumes have been deleted.
      */
     override fun deleteVolumeSet(volumeSet: String) {
-        executor.exec("zfs", "destroy", "$poolName/data/$volumeSet")
+        try {
+            executor.exec("zfs", "destroy", "$poolName/data/$volumeSet")
+        } catch (e: CommandException) {
+            // Deletion should be idempotent, ignore errors if this object doens't exist
+            if (!e.output.contains("dataset does not exist")) {
+                throw e
+            }
+        }
 
         // Try to delete the directory, but it may not exist if no volumes have been created
         try {
@@ -119,7 +130,14 @@ class ZfsStorageProvider(
      * can just recursively delete the snapshot at the level of the volume set.
      */
     override fun deleteCommit(volumeSet: String, commitId: String, volumeNames: List<String>) {
-        executor.exec("zfs", "destroy", "-r", "$poolName/data/$volumeSet@$commitId")
+        try {
+            executor.exec("zfs", "destroy", "-r", "$poolName/data/$volumeSet@$commitId")
+        } catch (e: CommandException) {
+            // Deletion should be idempotent, ignore errors if this object doens't exist
+            if (!e.output.contains("could not find any snapshots to destroy")) {
+                throw e
+            }
+        }
     }
 
     /**
@@ -136,8 +154,18 @@ class ZfsStorageProvider(
      * that has had volumes removed in the middle of its lifecycle.
      */
     override fun deleteVolume(volumeSet: String, volumeName: String, config: Map<String, Any>) {
-        executor.exec("zfs", "destroy", "$poolName/data/$volumeSet/$volumeName")
-        executor.exec("rmdir", config["mountpoint"] as String)
+        try {
+            executor.exec("zfs", "destroy", "$poolName/data/$volumeSet/$volumeName")
+        } catch (e: CommandException) {
+            // Deletion should be idempotent, ignore errors if this object doens't exist
+            if (!e.output.contains("dataset does not exist")) {
+                throw e
+            }
+        }
+        // A partially constructed volume will not have any config
+        if (config.containsKey("mountpoint")) {
+            executor.exec("rmdir", config["mountpoint"] as String)
+        }
     }
 
     /**

--- a/server/src/scripts/zfs.sh
+++ b/server/src/scripts/zfs.sh
@@ -184,8 +184,8 @@ function create_pool() {
   local mountpoint=$3
   local cachefile=$4
   zpool create -m $mountpoint -o cachefile=$cachefile $pool $data
-  zfs create -o mountpoint=none -o compression=lz4 $pool/data
-  zfs create -o mountpoint=none $pool/db
+  zfs create -o mountpoint=legacy -o compression=lz4 $pool/data
+  zfs create -o mountpoint=legacy $pool/db
 }
 
 #
@@ -199,9 +199,9 @@ function update_pool() {
   # As part of migrating away from repositories and just to volumesets, we got rid of the repo namespace
   zfs list $pool/repo > /dev/null 2>&1 && zfs destroy -R $pool/repo
   # Create the data filesystem (replacing repo) if it doesn't exist
-  zfs list $pool/data > /dev/null 2>&1 || zfs create -o mountpoint=none $pool/data
+  zfs list $pool/data > /dev/null 2>&1 || zfs create -o mountpoint=legacy $pool/data
   # Create the db filesystem if it doesn't exist
-  zfs list $pool/db > /dev/null 2>&1 || zfs create -o mountpoint=none $pool/db
+  zfs list $pool/db > /dev/null 2>&1 || zfs create -o mountpoint=legacy $pool/db
 }
 
 #

--- a/server/src/test/kotlin/io/titandata/orchestrator/CommitOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/CommitOrchestratorTest.kt
@@ -235,7 +235,8 @@ class CommitOrchestratorTest : StringSpec() {
         }
 
         "checkout commit succeeds" {
-            every { zfsStorageProvider.cloneVolumeSet(any(), any(), any(), any()) } just Runs
+            every { zfsStorageProvider.cloneVolumeSet(any(), any(), any()) } just Runs
+            every { zfsStorageProvider.cloneVolume(any(), any(), any(), any()) } returns emptyMap()
             every { zfsStorageProvider.createVolume(any(), any()) } returns emptyMap()
             every { reaper.signal() } just Runs
             providers.commits.createCommit("foo", Commit("id"))
@@ -253,7 +254,9 @@ class CommitOrchestratorTest : StringSpec() {
 
             verify {
                 reaper.signal()
-                zfsStorageProvider.cloneVolumeSet(vs, "id", vs2, listOf("vol1", "vol2"))
+                zfsStorageProvider.cloneVolumeSet(vs, "id", vs2)
+                zfsStorageProvider.cloneVolume(vs, "id", vs2, "vol1")
+                zfsStorageProvider.cloneVolume(vs, "id", vs2, "vol2")
             }
         }
 


### PR DESCRIPTION
## Proposed Changes

This addresses a number of recent regression int he 6.0 release:

- We created a dataset for the postgres DB on persistent storage but set the mountpoint incorrectly so it was never properly mounted
- Within the reaper, if we ever end up with metadata but no data (possible in various scenarios), we'd never clean up the metadata. Storage deletion should be idempotent
- When creating or cloning volumes for operations, we failed to update the provider-based ocnfig, resulting in re-using of mountpoints

## Testing

` gradle build test integrationTest endtoendTest`. Also ran titan binary from mcred, verified that datasets were being properly deleted on the backend.