### PR TITLE
fix validation for remote operations

### DIFF
--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -214,6 +214,7 @@ class DockerUtil(
     }
 
     fun getSshUri(): String {
-        return "ssh://root:root@${getSshHost()}"
+        // We explicitly add the port even though it's superfluous, as it helps validate serialization
+        return "ssh://root:root@${getSshHost()}:22"
     }
 }

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
@@ -80,7 +80,7 @@ class SshWorkflowTest : EndToEndTest() {
             remote.properties["address"] shouldBe dockerUtil.getSshHost()
             remote.properties["password"] shouldBe "root"
             remote.properties["username"] shouldBe "root"
-            remote.properties["port"] shouldBe null
+            remote.properties["port"] shouldBe 22
             remote.name shouldBe "origin"
 
             remoteApi.createRemote("foo", remote)

--- a/server/src/main/kotlin/io/titandata/orchestrator/RemoteOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/RemoteOrchestrator.kt
@@ -45,7 +45,7 @@ class RemoteOrchestrator(val providers: ProviderModule) {
         NameUtil.validateRemoteName(remoteName)
         providers.repositories.getRepository(repo)
         return transaction {
-            providers.metadata.getRemote(repo, remoteName)
+            validateRemote(providers.metadata.getRemote(repo, remoteName))
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

The previous validation fix worked for the calls that take in remotes and remote parameters, but neglected the cases where we were looking them up from the metadata store. This caused tests to fail because we'd deserialize to a double. The fix is to validate on read, even for internal operations.

## Testing

`gradle build test integrationTest`