### PR TITLE
rename zfs storage provider

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -25,16 +25,14 @@ found at:
 
   * `io.titandata.apis.*` - Entry points for the remote APIs. Very thin layer that translates
     from JSON into native models and then invokes the appropriate backend model.
-  * `io.titandata.storage.*` - Provider for storage and metadata persistence. While there is
-    an abstraction layer, there is only one provider for ZFS. See `ZfsStorageProvider` for more
-    information.
+  * `io.titandata.metadata.*` - Metadata persistence layer. We run a PostgreSQL database within
+    the server container.
+  * `io.titandata.context.*` - Provider for context-specific operations, such as managing storage
+    and running operations that requires access to storage.
   * `io.titandata.operation.*` - Handlers for asynchronous push and pull operations. The actual
     operations are run through the remote providers, but the generic operations framework handles
     starting and stopping operations, reporting back to the APIs, etc. For more information,
     see `OperationProvider`
-  * `io.titandata.remote.*` - Per-remote handlers for push and pull operations. These handle the
-    work of pushing and pulling, within the context set up by the operations provider.
-  * `io.titandata.sync.*` - Common mechanisms for syncing data between hosts, such as `rsync`.
   
 The titan client is built from `client/src`, and creates a separate JAR that is then published
 to an artifact repository for the CLI to use. It is not much more than a framework to marshall

--- a/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
@@ -31,6 +31,8 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
 import io.mockk.just
+import io.titandata.context.docker.DockerZfsContext
+import io.titandata.metadata.OperationData
 import io.titandata.models.Commit
 import io.titandata.models.Error
 import io.titandata.models.Operation
@@ -38,8 +40,6 @@ import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
 import io.titandata.models.Repository
-import io.titandata.storage.OperationData
-import io.titandata.storage.zfs.ZfsStorageProvider
 import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -50,7 +50,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 class OperationsApiTest : StringSpec() {
 
     @MockK
-    var zfsStorageProvider = ZfsStorageProvider("test")
+    var dockerZfsContext = DockerZfsContext("test")
 
     lateinit var vs1: String
     lateinit var vs2: String
@@ -224,8 +224,8 @@ class OperationsApiTest : StringSpec() {
                 providers.metadata.createCommit("foo", vs1, Commit("commit"))
             }
 
-            every { zfsStorageProvider.cloneVolumeSet(any(), any(), any()) } just Runs
-            every { zfsStorageProvider.cloneVolume(any(), any(), any(), any()) } returns emptyMap()
+            every { dockerZfsContext.cloneVolumeSet(any(), any(), any()) } just Runs
+            every { dockerZfsContext.cloneVolume(any(), any(), any(), any()) } returns emptyMap()
 
             val result = engine.handleRequest(HttpMethod.Post, "/v1/repositories/foo/remotes/remote/commits/commit/push") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -243,7 +243,7 @@ class OperationsApiTest : StringSpec() {
         }
 
         "pull starts operation" {
-            every { zfsStorageProvider.createVolumeSet(any()) } just Runs
+            every { dockerZfsContext.createVolumeSet(any()) } just Runs
 
             val result = engine.handleRequest(HttpMethod.Post, "/v1/repositories/foo/remotes/remote/commits/commit/pull") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())

--- a/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
@@ -29,11 +29,11 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
 import io.mockk.just
+import io.titandata.context.docker.DockerZfsContext
 import io.titandata.models.Error
 import io.titandata.models.Repository
 import io.titandata.models.RepositoryVolumeStatus
 import io.titandata.models.Volume
-import io.titandata.storage.zfs.ZfsStorageProvider
 import java.util.concurrent.TimeUnit
 import org.jetbrains.exposed.sql.transactions.transaction
 
@@ -41,7 +41,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 class RepositoriesApiTest : StringSpec() {
 
     @MockK
-    var zfsStorageProvider = ZfsStorageProvider("test")
+    var dockerZfsContext = DockerZfsContext("test")
 
     @InjectMockKs
     @OverrideMockKs
@@ -128,7 +128,7 @@ class RepositoriesApiTest : StringSpec() {
                 val vs = providers.metadata.createVolumeSet("foo", null, true)
                 providers.metadata.createVolume(vs, Volume(name = "volume", properties = mapOf("path" to "/var/a")))
             }
-            every { zfsStorageProvider.getVolumeStatus(any(), any()) } returns RepositoryVolumeStatus(name = "volume", logicalSize = 5, actualSize = 10)
+            every { dockerZfsContext.getVolumeStatus(any(), any()) } returns RepositoryVolumeStatus(name = "volume", logicalSize = 5, actualSize = 10)
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/foo/status")) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -156,7 +156,7 @@ class RepositoriesApiTest : StringSpec() {
         }
 
         "create repository succeeds" {
-            every { zfsStorageProvider.createVolumeSet(any()) } just Runs
+            every { dockerZfsContext.createVolumeSet(any()) } just Runs
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody("{\"name\":\"repo\",\"properties\":{\"a\":\"b\"}}")

--- a/server/src/main/kotlin/io/titandata/Application.kt
+++ b/server/src/main/kotlin/io/titandata/Application.kt
@@ -34,6 +34,8 @@ import io.titandata.apis.OperationsApi
 import io.titandata.apis.RemotesApi
 import io.titandata.apis.RepositoriesApi
 import io.titandata.apis.VolumesApi
+import io.titandata.context.RuntimeContext
+import io.titandata.context.docker.DockerZfsContext
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
 import io.titandata.metadata.MetadataProvider
@@ -46,8 +48,6 @@ import io.titandata.orchestrator.RemoteOrchestrator
 import io.titandata.orchestrator.RepositoryOrchestrator
 import io.titandata.orchestrator.VolumeOrchestrator
 import io.titandata.remote.RemoteServer
-import io.titandata.storage.StorageProvider
-import io.titandata.storage.zfs.ZfsStorageProvider
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.ServiceLoader
@@ -81,7 +81,7 @@ class ProviderModule(pool: String, inMemory: Boolean = true) {
         remoteProviders = providers
     }
 
-    private val zfsStorageProvider = ZfsStorageProvider(pool)
+    private val dockerZfsContext = DockerZfsContext(pool)
 
     val metadata = MetadataProvider(inMemory)
     val commits = CommitOrchestrator(this)
@@ -93,17 +93,9 @@ class ProviderModule(pool: String, inMemory: Boolean = true) {
 
     val gson = GsonBuilder().create()
 
-    // Return the default storage provider
-    val storage: StorageProvider
-        get() = zfsStorageProvider
-
-    // Get a storage provider by name (only ZFS is supported)
-    fun storage(type: String): StorageProvider {
-        if (type != "zfs") {
-            throw IllegalArgumentException("unknown storage provider '$type'")
-        }
-        return zfsStorageProvider
-    }
+    // Return the default runtime context
+    val context: RuntimeContext
+        get() = dockerZfsContext
 
     // Get a remote provider by name
     fun remoteProvider(type: String): RemoteServer {

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -2,12 +2,12 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.storage
+package io.titandata.context
 
 import io.titandata.models.CommitStatus
 import io.titandata.models.RepositoryVolumeStatus
 
-interface StorageProvider {
+interface RuntimeContext {
     fun createVolumeSet(volumeSet: String)
     fun cloneVolumeSet(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String)
     fun deleteVolumeSet(volumeSet: String)

--- a/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
@@ -2,13 +2,13 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.storage.zfs
+package io.titandata.context.docker
 
+import io.titandata.context.RuntimeContext
 import io.titandata.models.CommitStatus
 import io.titandata.models.RepositoryVolumeStatus
 import io.titandata.shell.CommandException
 import io.titandata.shell.CommandExecutor
-import io.titandata.storage.StorageProvider
 import org.slf4j.LoggerFactory
 
 /**
@@ -21,12 +21,12 @@ import org.slf4j.LoggerFactory
  *      pool/data/volumeSet@commit      Recursive snapshot of a particular commit
  *      pool/data/volumeSet/volume      Volume within a volume set
  */
-class ZfsStorageProvider(
+class DockerZfsContext(
     val poolName: String = "titan"
-) : StorageProvider {
+) : RuntimeContext {
 
     companion object {
-        val log = LoggerFactory.getLogger(ZfsStorageProvider::class.java)
+        val log = LoggerFactory.getLogger(DockerZfsContext::class.java)
     }
 
     internal val executor = CommandExecutor()

--- a/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/MetadataProvider.kt
@@ -21,7 +21,6 @@ import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
 import io.titandata.models.Repository
 import io.titandata.models.Volume
-import io.titandata.storage.OperationData
 import java.util.UUID
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Database

--- a/server/src/main/kotlin/io/titandata/metadata/OperationData.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/OperationData.kt
@@ -2,7 +2,7 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.storage
+package io.titandata.metadata
 
 import io.titandata.models.Operation
 import io.titandata.models.RemoteParameters

--- a/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
+++ b/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
@@ -130,25 +130,25 @@ class OperationExecutor(
                 providers.metadata.createVolume(operation.id, Volume("_scratch"))
                 vols
             }
-        val scratchConfig = providers.storage.createVolume(operation.id, "_scratch")
+        val scratchConfig = providers.context.createVolume(operation.id, "_scratch")
         transaction {
             providers.metadata.updateVolumeConfig(operationId, "_scratch", scratchConfig)
         }
         try {
-            providers.storage.activateVolume(operationId, "_scratch", scratchConfig)
+            providers.context.activateVolume(operationId, "_scratch", scratchConfig)
             val scratch = scratchConfig["mountpoint"] as String
             for (volume in volumes) {
-                providers.storage.activateVolume(operationId, volume.name, volume.config)
+                providers.context.activateVolume(operationId, volume.name, volume.config)
                 val mountpoint = volume.config["mountpoint"] as String
                 try {
                     provider.syncVolume(data, volume.name, getVolumeDesc(volume), mountpoint, scratch)
                 } finally {
-                    providers.storage.deactivateVolume(operationId, volume.name, volume.config)
+                    providers.context.deactivateVolume(operationId, volume.name, volume.config)
                 }
             }
         } finally {
-            providers.storage.deactivateVolume(operationId, "_scratch", scratchConfig)
-            providers.storage.deleteVolume(operationId, "_scratch", scratchConfig)
+            providers.context.deactivateVolume(operationId, "_scratch", scratchConfig)
+            providers.context.deleteVolume(operationId, "_scratch", scratchConfig)
             transaction {
                 providers.metadata.deleteVolume(operationId, "_scratch")
             }

--- a/server/src/main/kotlin/io/titandata/orchestrator/CommitOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/CommitOrchestrator.kt
@@ -42,7 +42,7 @@ class CommitOrchestrator(val providers: ProviderModule) {
             providers.metadata.listVolumes(volumeSet)
         }
 
-        providers.storage.createCommit(volumeSet, newCommit.id, volumes.map { it.name })
+        providers.context.createCommit(volumeSet, newCommit.id, volumes.map { it.name })
         return newCommit
     }
 
@@ -61,7 +61,7 @@ class CommitOrchestrator(val providers: ProviderModule) {
             val vs = providers.metadata.getCommit(repo, id).first
             Pair(vs, providers.metadata.listVolumes(vs).map { it.name })
         }
-        return providers.storage.getCommitStatus(vs, id, volumes)
+        return providers.context.getCommitStatus(vs, id, volumes)
     }
 
     fun listCommits(repo: String, tags: List<String>? = null): List<Commit> {
@@ -98,9 +98,9 @@ class CommitOrchestrator(val providers: ProviderModule) {
             providers.metadata.listVolumes(newVolumeSet).map { it.name }
         }
 
-        providers.storage.cloneVolumeSet(sourceVolumeSet, commit, newVolumeSet)
+        providers.context.cloneVolumeSet(sourceVolumeSet, commit, newVolumeSet)
         for (v in volumes) {
-            val config = providers.storage.cloneVolume(sourceVolumeSet, commit, newVolumeSet, v)
+            val config = providers.context.cloneVolume(sourceVolumeSet, commit, newVolumeSet, v)
             transaction {
                 providers.metadata.updateVolumeConfig(newVolumeSet, v, config)
             }

--- a/server/src/main/kotlin/io/titandata/orchestrator/OperationOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/OperationOrchestrator.kt
@@ -7,13 +7,13 @@ package io.titandata.orchestrator
 import io.titandata.ProviderModule
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
+import io.titandata.metadata.OperationData
 import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
 import io.titandata.models.Volume
 import io.titandata.operation.OperationExecutor
-import io.titandata.storage.OperationData
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.LoggerFactory
 
@@ -151,9 +151,9 @@ class OperationOrchestrator(val providers: ProviderModule) {
                 val vs = providers.metadata.getActiveVolumeSet(repo)
                 providers.metadata.listVolumes(vs)
             }
-            providers.storage.createVolumeSet(volumeSet)
+            providers.context.createVolumeSet(volumeSet)
             for (v in volumes) {
-                val config = providers.storage.createVolume(volumeSet, v.name)
+                val config = providers.context.createVolume(volumeSet, v.name)
                 transaction {
                     providers.metadata.updateVolumeConfig(volumeSet, v.name, config)
                 }
@@ -163,9 +163,9 @@ class OperationOrchestrator(val providers: ProviderModule) {
                 val vs = providers.metadata.getCommit(repo, commit).first
                 Pair(vs, providers.metadata.listVolumes(vs).map { it.name })
             }
-            providers.storage.cloneVolumeSet(sourceVolumeSet, commit, volumeSet)
+            providers.context.cloneVolumeSet(sourceVolumeSet, commit, volumeSet)
             for (v in volumes) {
-                val config = providers.storage.cloneVolume(sourceVolumeSet, commit, volumeSet, v)
+                val config = providers.context.cloneVolume(sourceVolumeSet, commit, volumeSet, v)
                 transaction {
                     providers.metadata.updateVolumeConfig(volumeSet, v, config)
                 }

--- a/server/src/main/kotlin/io/titandata/orchestrator/Reaper.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/Reaper.kt
@@ -77,7 +77,7 @@ class Reaper(val providers: ProviderModule) : Runnable {
                 providers.metadata.listVolumes(c.volumeSet).map { it.name }
             }
             try {
-                providers.storage.deleteCommit(c.volumeSet, c.guid, volumes)
+                providers.context.deleteCommit(c.volumeSet, c.guid, volumes)
                 transaction {
                     providers.metadata.deleteCommit(c)
                 }
@@ -119,12 +119,12 @@ class Reaper(val providers: ProviderModule) : Runnable {
                     providers.metadata.listVolumes(vs)
                 }
                 for (vol in volumes) {
-                    providers.storage.deleteVolume(vs, vol.name, vol.config)
+                    providers.context.deleteVolume(vs, vol.name, vol.config)
                     transaction {
                         providers.metadata.deleteVolume(vs, vol.name)
                     }
                 }
-                providers.storage.deleteVolumeSet(vs)
+                providers.context.deleteVolumeSet(vs)
                 transaction {
                     providers.metadata.deleteVolumeSet(vs)
                 }
@@ -145,7 +145,7 @@ class Reaper(val providers: ProviderModule) : Runnable {
         var ret = false
         for ((vs, vol) in volumes) {
             try {
-                providers.storage.deleteVolume(vs, vol.name, vol.config)
+                providers.context.deleteVolume(vs, vol.name, vol.config)
                 transaction {
                     providers.metadata.deleteVolume(vs, vol.name)
                 }

--- a/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
@@ -15,7 +15,7 @@ class RepositoryOrchestrator(val providers: ProviderModule) {
             val vs = providers.metadata.createVolumeSet(repo.name, null, true)
             vs
         }
-        providers.storage.createVolumeSet(volumeSet)
+        providers.context.createVolumeSet(volumeSet)
     }
 
     fun listRepositories(): List<Repository> {
@@ -38,7 +38,7 @@ class RepositoryOrchestrator(val providers: ProviderModule) {
             Pair(vs, providers.metadata.listVolumes(vs))
         }
         val volumeStatus = volumes.map {
-            val rawStatus = providers.storage.getVolumeStatus(volumeSet, it.name)
+            val rawStatus = providers.context.getVolumeStatus(volumeSet, it.name)
             RepositoryVolumeStatus(
                     name = it.name,
                     logicalSize = rawStatus.logicalSize,

--- a/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
@@ -15,7 +15,7 @@ class VolumeOrchestrator(val providers: ProviderModule) {
             providers.metadata.createVolume(vs, volume)
             vs
         }
-        val config = providers.storage.createVolume(vs, volume.name)
+        val config = providers.context.createVolume(vs, volume.name)
         return transaction {
             providers.metadata.updateVolumeConfig(vs, volume.name, config)
             providers.metadata.getVolume(vs, volume.name)
@@ -51,7 +51,7 @@ class VolumeOrchestrator(val providers: ProviderModule) {
             val vs = providers.metadata.getActiveVolumeSet(repo)
             Pair(vs, providers.metadata.getVolume(vs, name))
         }
-        providers.storage.activateVolume(vs, name, volume.config)
+        providers.context.activateVolume(vs, name, volume.config)
     }
 
     fun deactivateVolume(repo: String, name: String) {
@@ -61,7 +61,7 @@ class VolumeOrchestrator(val providers: ProviderModule) {
             val vs = providers.metadata.getActiveVolumeSet(repo)
             Pair(vs, providers.metadata.getVolume(vs, name))
         }
-        providers.storage.deactivateVolume(vs, name, volume.config)
+        providers.context.deactivateVolume(vs, name, volume.config)
     }
 
     fun listVolumes(repo: String): List<Volume> {

--- a/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
+++ b/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
@@ -2,7 +2,7 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.storage.zfs
+package io.titandata.context.docker
 
 import io.kotlintest.TestCase
 import io.kotlintest.TestCaseOrder
@@ -20,14 +20,14 @@ import io.mockk.verifyAll
 import io.titandata.shell.CommandException
 import io.titandata.shell.CommandExecutor
 
-class ZfsStorageProviderTest : StringSpec() {
+class DockerZfsContextTest : StringSpec() {
 
     @MockK
     lateinit var executor: CommandExecutor
 
     @InjectMockKs
     @OverrideMockKs
-    var provider = ZfsStorageProvider("test")
+    var provider = DockerZfsContext("test")
 
     override fun beforeTest(testCase: TestCase) {
         return MockKAnnotations.init(this)
@@ -41,7 +41,7 @@ class ZfsStorageProviderTest : StringSpec() {
 
     init {
         "provider defaults to titan as pool name" {
-            val defaultProvider = ZfsStorageProvider()
+            val defaultProvider = DockerZfsContext()
             defaultProvider.poolName shouldBe "titan"
         }
 

--- a/server/src/test/kotlin/io/titandata/metadata/OperationMetadataTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/OperationMetadataTest.kt
@@ -9,7 +9,6 @@ import io.titandata.exception.NoSuchObjectException
 import io.titandata.models.Operation
 import io.titandata.models.RemoteParameters
 import io.titandata.models.Repository
-import io.titandata.storage.OperationData
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class OperationMetadataTest : StringSpec() {

--- a/server/src/test/kotlin/io/titandata/metadata/ProgressEntryMetadataTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/ProgressEntryMetadataTest.kt
@@ -8,7 +8,6 @@ import io.titandata.models.Operation
 import io.titandata.models.ProgressEntry
 import io.titandata.models.RemoteParameters
 import io.titandata.models.Repository
-import io.titandata.storage.OperationData
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class ProgressEntryMetadataTest : StringSpec() {

--- a/server/src/test/kotlin/io/titandata/orchestrator/ReaperTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/ReaperTest.kt
@@ -23,20 +23,20 @@ import io.mockk.impl.annotations.OverrideMockKs
 import io.mockk.just
 import io.mockk.verify
 import io.titandata.ProviderModule
+import io.titandata.context.docker.DockerZfsContext
 import io.titandata.exception.NoSuchObjectException
+import io.titandata.metadata.OperationData
 import io.titandata.models.Commit
 import io.titandata.models.Operation
 import io.titandata.models.RemoteParameters
 import io.titandata.models.Repository
 import io.titandata.models.Volume
-import io.titandata.storage.OperationData
-import io.titandata.storage.zfs.ZfsStorageProvider
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class ReaperTest : StringSpec() {
 
     @MockK
-    lateinit var zfsStorageProvider: ZfsStorageProvider
+    lateinit var dockerZfsContext: DockerZfsContext
 
     @InjectMockKs
     @OverrideMockKs
@@ -83,10 +83,10 @@ class ReaperTest : StringSpec() {
                 providers.metadata.markVolumeDeleting(vs, "volume")
                 vs
             }
-            every { zfsStorageProvider.deleteVolume(any(), any(), any()) } just Runs
+            every { dockerZfsContext.deleteVolume(any(), any(), any()) } just Runs
             providers.reaper.reapVolumes() shouldBe true
             verify {
-                zfsStorageProvider.deleteVolume(vs, "volume", emptyMap())
+                dockerZfsContext.deleteVolume(vs, "volume", emptyMap())
             }
             shouldThrow<NoSuchObjectException> {
                 transaction {
@@ -125,14 +125,14 @@ class ReaperTest : StringSpec() {
                 providers.metadata.markVolumeSetDeleting(vs)
                 vs
             }
-            every { zfsStorageProvider.deleteVolume(any(), any(), any()) } just Runs
-            every { zfsStorageProvider.deleteVolumeSet(any()) } just Runs
+            every { dockerZfsContext.deleteVolume(any(), any(), any()) } just Runs
+            every { dockerZfsContext.deleteVolumeSet(any()) } just Runs
 
             providers.reaper.reapVolumeSets() shouldBe true
 
             verify {
-                zfsStorageProvider.deleteVolume(vs, "volume", emptyMap())
-                zfsStorageProvider.deleteVolumeSet(vs)
+                dockerZfsContext.deleteVolume(vs, "volume", emptyMap())
+                dockerZfsContext.deleteVolumeSet(vs)
             }
 
             transaction {
@@ -235,10 +235,10 @@ class ReaperTest : StringSpec() {
                 providers.metadata.markCommitDeleting("foo", "id")
                 vs
             }
-            every { zfsStorageProvider.deleteCommit(any(), any(), any()) } just Runs
+            every { dockerZfsContext.deleteCommit(any(), any(), any()) } just Runs
             providers.reaper.reapCommits() shouldBe true
             verify {
-                zfsStorageProvider.deleteCommit(vs, "id", listOf("volume"))
+                dockerZfsContext.deleteCommit(vs, "id", listOf("volume"))
             }
             transaction {
                 providers.metadata.listDeletingCommits().shouldBeEmpty()

--- a/server/src/test/kotlin/io/titandata/orchestrator/RemoteOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/RemoteOrchestratorTest.kt
@@ -16,7 +16,6 @@ import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
-import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.OverrideMockKs
 import io.mockk.impl.annotations.SpyK
 import io.mockk.slot
@@ -28,15 +27,11 @@ import io.titandata.models.RemoteParameters
 import io.titandata.models.Repository
 import io.titandata.remote.nop.server.NopRemoteServer
 import io.titandata.remote.ssh.server.SshRemoteServer
-import io.titandata.storage.zfs.ZfsStorageProvider
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class RemoteOrchestratorTest : StringSpec() {
 
     val params = RemoteParameters("nop")
-
-    @MockK
-    lateinit var zfsStorageProvider: ZfsStorageProvider
 
     @SpyK
     var nopProvider = NopRemoteServer()

--- a/server/src/test/kotlin/io/titandata/orchestrator/VolumeOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/VolumeOrchestratorTest.kt
@@ -22,16 +22,16 @@ import io.mockk.just
 import io.mockk.verify
 import io.mockk.verifyAll
 import io.titandata.ProviderModule
+import io.titandata.context.docker.DockerZfsContext
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.models.Repository
 import io.titandata.models.Volume
-import io.titandata.storage.zfs.ZfsStorageProvider
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class VolumeOrchestratorTest : StringSpec() {
 
     @MockK
-    lateinit var zfsStorageProvider: ZfsStorageProvider
+    lateinit var dockerZfsContext: DockerZfsContext
 
     @MockK
     lateinit var reaper: Reaper
@@ -62,7 +62,7 @@ class VolumeOrchestratorTest : StringSpec() {
     override fun testCaseOrder() = TestCaseOrder.Random
 
     fun createVolume(): Volume {
-        every { zfsStorageProvider.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
+        every { dockerZfsContext.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
         return providers.volumes.createVolume("foo", Volume("vol", mapOf("a" to "b")))
     }
 
@@ -73,7 +73,7 @@ class VolumeOrchestratorTest : StringSpec() {
             vol.config["mountpoint"] shouldBe "/mountpoint"
             vol.properties["a"] shouldBe "b"
             verifyAll {
-                zfsStorageProvider.createVolume(vs, "vol")
+                dockerZfsContext.createVolume(vs, "vol")
             }
         }
 
@@ -162,11 +162,11 @@ class VolumeOrchestratorTest : StringSpec() {
         }
 
         "activate volume succeeds" {
-            every { zfsStorageProvider.activateVolume(any(), any(), any()) } just Runs
+            every { dockerZfsContext.activateVolume(any(), any(), any()) } just Runs
             createVolume()
             providers.volumes.activateVolume("foo", "vol")
             verify {
-                zfsStorageProvider.activateVolume(vs, "vol", mapOf("mountpoint" to "/mountpoint"))
+                dockerZfsContext.activateVolume(vs, "vol", mapOf("mountpoint" to "/mountpoint"))
             }
         }
 
@@ -195,11 +195,11 @@ class VolumeOrchestratorTest : StringSpec() {
         }
 
         "inactivate volume succeeds" {
-            every { zfsStorageProvider.deactivateVolume(any(), any(), any()) } just Runs
+            every { dockerZfsContext.deactivateVolume(any(), any(), any()) } just Runs
             createVolume()
             providers.volumes.deactivateVolume("foo", "vol")
             verify {
-                zfsStorageProvider.deactivateVolume(vs, "vol", mapOf("mountpoint" to "/mountpoint"))
+                dockerZfsContext.deactivateVolume(vs, "vol", mapOf("mountpoint" to "/mountpoint"))
             }
         }
 


### PR DESCRIPTION
## Proposed Changes

This is a large but rename-only PR. In the future, we're going to have to support different ways of running operations. This will be tied to how the storage is managed, so rather than having the notion of a "storage provider", we'll be moving to a more general notion of a "runtime context". This PR just lays the groundwork for the renaming, and contains no logic changes.

## Testing

`gradle build test integrationTest endtoendTest`