### PR TITLE
rename service locator

### DIFF
--- a/server/src/integration-test/kotlin/io/titandata/DockerVolumesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/DockerVolumesApiTest.kt
@@ -45,15 +45,15 @@ class DockerVolumesApiTest : StringSpec() {
 
     @InjectMockKs
     @OverrideMockKs
-    var providers = ProviderModule("test")
+    var services = ServiceLocator("test")
 
     var engine = TestApplicationEngine(createTestEnvironment())
 
     override fun beforeSpec(spec: Spec) {
         with(engine) {
             start()
-            providers.metadata.init()
-            application.mainProvider(providers)
+            services.metadata.init()
+            application.mainProvider(services)
         }
     }
 
@@ -62,10 +62,10 @@ class DockerVolumesApiTest : StringSpec() {
     }
 
     override fun beforeTest(testCase: TestCase) {
-        providers.metadata.clear()
+        services.metadata.clear()
         vs = transaction {
-            providers.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
-            providers.metadata.createVolumeSet("foo", null, true)
+            services.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
+            services.metadata.createVolumeSet("foo", null, true)
         }
         return MockKAnnotations.init(this)
     }
@@ -132,7 +132,7 @@ class DockerVolumesApiTest : StringSpec() {
 
         "remove volume succeeds" {
             transaction {
-                providers.metadata.createVolume(vs, Volume("vol"))
+                services.metadata.createVolume(vs, Volume("vol"))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Remove") {
                 setBody("{\"Name\":\"foo/vol\"}")
@@ -145,7 +145,7 @@ class DockerVolumesApiTest : StringSpec() {
 
         "mount volume succeeds" {
             transaction {
-                providers.metadata.createVolume(vs, Volume(name = "vol", config = mapOf("mountpoint" to "/mountpoint")))
+                services.metadata.createVolume(vs, Volume(name = "vol", config = mapOf("mountpoint" to "/mountpoint")))
             }
             every { dockerZfsContext.activateVolume(any(), any(), any()) } just Runs
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Mount") {
@@ -163,7 +163,7 @@ class DockerVolumesApiTest : StringSpec() {
 
         "unmount volume succeeds" {
             transaction {
-                providers.metadata.createVolume(vs, Volume("vol"))
+                services.metadata.createVolume(vs, Volume("vol"))
             }
             every { dockerZfsContext.deactivateVolume(any(), any(), any()) } just Runs
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Unmount") {
@@ -181,7 +181,7 @@ class DockerVolumesApiTest : StringSpec() {
 
         "get path succeeds" {
             transaction {
-                providers.metadata.createVolume(vs, Volume(name = "vol", config = mapOf("mountpoint" to "/mountpoint")))
+                services.metadata.createVolume(vs, Volume(name = "vol", config = mapOf("mountpoint" to "/mountpoint")))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Path") {
                 setBody("{\"Name\":\"foo/vol\"}")
@@ -194,7 +194,7 @@ class DockerVolumesApiTest : StringSpec() {
 
         "get volume succeeds" {
             transaction {
-                providers.metadata.createVolume(vs, Volume(name = "vol", properties = mapOf("a" to "b"), config = mapOf("mountpoint" to "/mountpoint")))
+                services.metadata.createVolume(vs, Volume(name = "vol", properties = mapOf("a" to "b"), config = mapOf("mountpoint" to "/mountpoint")))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Get") {
                 setBody("{\"Name\":\"foo/vol\"}")
@@ -213,8 +213,8 @@ class DockerVolumesApiTest : StringSpec() {
 
         "list volumes succeeds" {
             transaction {
-                providers.metadata.createVolume(vs, Volume(name = "one", properties = mapOf("a" to "b"), config = mapOf("mountpoint" to "/mountpoint")))
-                providers.metadata.createVolume(vs, Volume(name = "two", properties = mapOf("c" to "d"), config = mapOf("mountpoint" to "/mountpoint")))
+                services.metadata.createVolume(vs, Volume(name = "one", properties = mapOf("a" to "b"), config = mapOf("mountpoint" to "/mountpoint")))
+                services.metadata.createVolume(vs, Volume(name = "two", properties = mapOf("c" to "d"), config = mapOf("mountpoint" to "/mountpoint")))
             }
 
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.List")) {

--- a/server/src/integration-test/kotlin/io/titandata/RemotesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RemotesApiTest.kt
@@ -34,15 +34,15 @@ class RemotesApiTest : StringSpec() {
 
     @InjectMockKs
     @OverrideMockKs
-    var providers = ProviderModule("test")
+    var services = ServiceLocator("test")
 
     var engine = TestApplicationEngine(createTestEnvironment())
 
     override fun beforeSpec(spec: Spec) {
         with(engine) {
             start()
-            providers.metadata.init()
-            application.mainProvider(providers)
+            services.metadata.init()
+            application.mainProvider(services)
         }
     }
 
@@ -51,7 +51,7 @@ class RemotesApiTest : StringSpec() {
     }
 
     override fun beforeTest(testCase: TestCase) {
-        providers.metadata.clear()
+        services.metadata.clear()
         return MockKAnnotations.init(this)
     }
 
@@ -68,7 +68,7 @@ class RemotesApiTest : StringSpec() {
     init {
         "get empty remote list succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
             }
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/repo/remotes")) {
                 response.status() shouldBe HttpStatusCode.OK
@@ -79,9 +79,9 @@ class RemotesApiTest : StringSpec() {
 
         "get remote list succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
-                providers.metadata.addRemote("repo", Remote("nop", "foo"))
-                providers.metadata.addRemote("repo", Remote("engine", "bar", mapOf("address" to "a", "username" to "u", "password" to "p", "repository" to "r")))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.addRemote("repo", Remote("nop", "foo"))
+                services.metadata.addRemote("repo", Remote("engine", "bar", mapOf("address" to "a", "username" to "u", "password" to "p", "repository" to "r")))
             }
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/repo/remotes")) {
                 response.status() shouldBe HttpStatusCode.OK
@@ -94,7 +94,7 @@ class RemotesApiTest : StringSpec() {
 
         "create remote succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
             }
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/repo/remotes") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -107,8 +107,8 @@ class RemotesApiTest : StringSpec() {
 
         "add duplicate remote fails" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
-                providers.metadata.addRemote("repo", Remote("nop", "a"))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.addRemote("repo", Remote("nop", "a"))
             }
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/repo/remotes") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -120,7 +120,7 @@ class RemotesApiTest : StringSpec() {
 
         "update non-existent remote fails" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
             }
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/repo/remotes/foo") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -132,9 +132,9 @@ class RemotesApiTest : StringSpec() {
 
         "update remote succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
-                providers.metadata.addRemote("repo", Remote("nop", "foo"))
-                providers.metadata.addRemote("repo", Remote("engine", "bar", mapOf("address" to "a", "username" to "u", "password" to "p", "repository" to "r")))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.addRemote("repo", Remote("nop", "foo"))
+                services.metadata.addRemote("repo", Remote("engine", "bar", mapOf("address" to "a", "username" to "u", "password" to "p", "repository" to "r")))
             }
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/repo/remotes/bar") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -149,9 +149,9 @@ class RemotesApiTest : StringSpec() {
 
         "rename remote succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
-                providers.metadata.addRemote("repo", Remote("nop", "foo"))
-                providers.metadata.addRemote("repo", Remote("nop", "bar"))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.addRemote("repo", Remote("nop", "foo"))
+                services.metadata.addRemote("repo", Remote("nop", "bar"))
             }
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/repo/remotes/bar") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -163,9 +163,9 @@ class RemotesApiTest : StringSpec() {
 
         "rename remote to existing name fails" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
-                providers.metadata.addRemote("repo", Remote("nop", "foo"))
-                providers.metadata.addRemote("repo", Remote("nop", "bar"))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.addRemote("repo", Remote("nop", "foo"))
+                services.metadata.addRemote("repo", Remote("nop", "bar"))
             }
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/repo/remotes/bar") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -177,9 +177,9 @@ class RemotesApiTest : StringSpec() {
 
         "delete remote succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
-                providers.metadata.addRemote("repo", Remote("nop", "foo"))
-                providers.metadata.addRemote("repo", Remote("nop", "bar"))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.addRemote("repo", Remote("nop", "foo"))
+                services.metadata.addRemote("repo", Remote("nop", "bar"))
             }
             with(engine.handleRequest(HttpMethod.Delete, "/v1/repositories/repo/remotes/bar")) {
                 response.status() shouldBe HttpStatusCode.NoContent
@@ -188,8 +188,8 @@ class RemotesApiTest : StringSpec() {
 
         "list remote commits succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
-                providers.metadata.addRemote("repo", Remote("nop", "foo"))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.addRemote("repo", Remote("nop", "foo"))
             }
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/repo/remotes/foo/commits") {
                 addHeader("titan-remote-parameters", "{\"provider\":\"nop\",\"properties\":{}}")
@@ -202,8 +202,8 @@ class RemotesApiTest : StringSpec() {
 
         "get remote commit succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
-                providers.metadata.addRemote("repo", Remote("nop", "foo"))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf()))
+                services.metadata.addRemote("repo", Remote("nop", "foo"))
             }
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/repo/remotes/foo/commits/c") {
                 addHeader("titan-remote-parameters", "{\"provider\":\"nop\",\"properties\":{}}")

--- a/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
@@ -45,15 +45,15 @@ class RepositoriesApiTest : StringSpec() {
 
     @InjectMockKs
     @OverrideMockKs
-    var providers = ProviderModule("test")
+    var services = ServiceLocator("test")
 
     var engine = TestApplicationEngine(createTestEnvironment())
 
     override fun beforeSpec(spec: Spec) {
         with(engine) {
             start()
-            providers.metadata.init()
-            application.mainProvider(providers)
+            services.metadata.init()
+            application.mainProvider(services)
         }
     }
 
@@ -62,7 +62,7 @@ class RepositoriesApiTest : StringSpec() {
     }
 
     override fun beforeTest(testCase: TestCase) {
-        providers.metadata.clear()
+        services.metadata.clear()
         return MockKAnnotations.init(this)
     }
 
@@ -83,8 +83,8 @@ class RepositoriesApiTest : StringSpec() {
 
         "list repositories succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo1", properties = mapOf("a" to "b")))
-                providers.metadata.createRepository(Repository(name = "repo2", properties = mapOf()))
+                services.metadata.createRepository(Repository(name = "repo1", properties = mapOf("a" to "b")))
+                services.metadata.createRepository(Repository(name = "repo2", properties = mapOf()))
             }
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories")) {
                 response.status() shouldBe HttpStatusCode.OK
@@ -95,7 +95,7 @@ class RepositoriesApiTest : StringSpec() {
 
         "get repository succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo", properties = mapOf("a" to "b")))
+                services.metadata.createRepository(Repository(name = "repo", properties = mapOf("a" to "b")))
             }
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/repo")) {
                 response.status() shouldBe HttpStatusCode.OK
@@ -124,9 +124,9 @@ class RepositoriesApiTest : StringSpec() {
 
         "get repository status succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
-                val vs = providers.metadata.createVolumeSet("foo", null, true)
-                providers.metadata.createVolume(vs, Volume(name = "volume", properties = mapOf("path" to "/var/a")))
+                services.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
+                val vs = services.metadata.createVolumeSet("foo", null, true)
+                services.metadata.createVolume(vs, Volume(name = "volume", properties = mapOf("path" to "/var/a")))
             }
             every { dockerZfsContext.getVolumeStatus(any(), any()) } returns RepositoryVolumeStatus(name = "volume", logicalSize = 5, actualSize = 10)
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/foo/status")) {
@@ -138,7 +138,7 @@ class RepositoriesApiTest : StringSpec() {
 
         "delete repository succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository("repo"))
+                services.metadata.createRepository(Repository("repo"))
             }
             with(engine.handleRequest(HttpMethod.Delete, "/v1/repositories/repo")) {
                 response.status() shouldBe HttpStatusCode.NoContent
@@ -192,7 +192,7 @@ class RepositoriesApiTest : StringSpec() {
 
         "update repository succeeds" {
             transaction {
-                providers.metadata.createRepository(Repository(name = "repo1", properties = mapOf("a" to "b")))
+                services.metadata.createRepository(Repository(name = "repo1", properties = mapOf("a" to "b")))
             }
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/repo1") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())

--- a/server/src/main/kotlin/io/titandata/Application.kt
+++ b/server/src/main/kotlin/io/titandata/Application.kt
@@ -67,7 +67,7 @@ fun exceptionToError(request: ApplicationRequest, t: Throwable): Any {
     }
 }
 
-class ProviderModule(pool: String, inMemory: Boolean = true) {
+class ServiceLocator(pool: String, inMemory: Boolean = true) {
     private val loader = ServiceLoader.load(RemoteServer::class.java)
     private val remoteProviders: MutableMap<String, RemoteServer>
 
@@ -123,15 +123,15 @@ internal fun ApplicationCompressionConfiguration(): Compression.Configuration.()
 
 @KtorExperimentalAPI
 fun Application.main() {
-    val providers = ProviderModule(System.getenv("TITAN_POOL") ?: "titan", false)
-    providers.metadata.init()
-    Thread(providers.reaper).start()
-    providers.operations.loadState()
-    mainProvider(providers)
+    val services = ServiceLocator(System.getenv("TITAN_POOL") ?: "titan", false)
+    services.metadata.init()
+    Thread(services.reaper).start()
+    services.operations.loadState()
+    mainProvider(services)
 }
 
 @KtorExperimentalAPI
-fun Application.mainProvider(providers: ProviderModule) {
+fun Application.mainProvider(services: ServiceLocator) {
     install(DefaultHeaders)
     val gsonConverter = GsonConverter(GsonBuilder().create())
     install(ContentNegotiation) {
@@ -145,12 +145,12 @@ fun Application.mainProvider(providers: ProviderModule) {
     }
     install(Compression, ApplicationCompressionConfiguration())
     install(Routing) {
-        CommitsApi(providers)
-        DockerVolumeApi(providers)
-        OperationsApi(providers)
-        RemotesApi(providers)
-        RepositoriesApi(providers)
-        VolumesApi(providers)
+        CommitsApi(services)
+        DockerVolumeApi(services)
+        OperationsApi(services)
+        RemotesApi(services)
+        RepositoriesApi(services)
+        VolumesApi(services)
     }
     install(StatusPages) {
         exception<NoSuchObjectException> { cause ->

--- a/server/src/main/kotlin/io/titandata/apis/CommitsApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/CommitsApi.kt
@@ -13,26 +13,26 @@ import io.ktor.routing.delete
 import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.route
-import io.titandata.ProviderModule
+import io.titandata.ServiceLocator
 import io.titandata.models.Commit
 
 /**
  * Handler for all commit related APIs. These are simplistic wrappers around the underlying storage
  * provider.
  */
-fun Route.CommitsApi(providers: ProviderModule) {
+fun Route.CommitsApi(services: ServiceLocator) {
     route("/v1/repositories/{repositoryName}/commits") {
         post {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val commit = call.receive(Commit::class)
-            val created = providers.commits.createCommit(repo, commit)
+            val created = services.commits.createCommit(repo, commit)
             call.respond(HttpStatusCode.Created, created)
         }
 
         get {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val tags = call.request.queryParameters.getAll("tag")
-            call.respond(providers.commits.listCommits(repo, tags))
+            call.respond(services.commits.listCommits(repo, tags))
         }
     }
 
@@ -40,14 +40,14 @@ fun Route.CommitsApi(providers: ProviderModule) {
         delete {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val commit = call.parameters["commitId"] ?: throw IllegalArgumentException("missing commit id parameter")
-            providers.commits.deleteCommit(repo, commit)
+            services.commits.deleteCommit(repo, commit)
             call.respond(HttpStatusCode.NoContent)
         }
 
         get {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val commit = call.parameters["commitId"] ?: throw IllegalArgumentException("missing commit id parameter")
-            call.respond(providers.commits.getCommit(repo, commit))
+            call.respond(services.commits.getCommit(repo, commit))
         }
 
         post {
@@ -55,7 +55,7 @@ fun Route.CommitsApi(providers: ProviderModule) {
             val commitId = call.parameters["commitId"] ?: throw IllegalArgumentException("missing commit id parameter")
             val commit = call.receive(Commit::class)
             commit.id = commitId
-            providers.commits.updateCommit(repo, commit)
+            services.commits.updateCommit(repo, commit)
             call.respond(commit)
         }
     }
@@ -64,7 +64,7 @@ fun Route.CommitsApi(providers: ProviderModule) {
         get {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val commit = call.parameters["commitId"] ?: throw IllegalArgumentException("missing commit id parameter")
-            call.respond(providers.commits.getCommitStatus(repo, commit))
+            call.respond(services.commits.getCommitStatus(repo, commit))
         }
     }
 
@@ -72,7 +72,7 @@ fun Route.CommitsApi(providers: ProviderModule) {
         post {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val commit = call.parameters["commitId"] ?: throw IllegalArgumentException("missing commit id parameter")
-            providers.commits.checkoutCommit(repo, commit)
+            services.commits.checkoutCommit(repo, commit)
             call.respond(HttpStatusCode.NoContent)
         }
     }

--- a/server/src/main/kotlin/io/titandata/apis/OperationsApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/OperationsApi.kt
@@ -13,15 +13,15 @@ import io.ktor.routing.delete
 import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.route
-import io.titandata.ProviderModule
+import io.titandata.ServiceLocator
 import io.titandata.models.RemoteParameters
 
-fun Route.OperationsApi(@Suppress("UNUSED_PARAMETER") providers: ProviderModule) {
+fun Route.OperationsApi(services: ServiceLocator) {
 
     route("/v1/repositories/{repositoryName}/operations") {
         get {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
-            call.respond(providers.operations.listOperations(repo))
+            call.respond(services.operations.listOperations(repo))
         }
     }
 
@@ -29,14 +29,14 @@ fun Route.OperationsApi(@Suppress("UNUSED_PARAMETER") providers: ProviderModule)
         delete {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val operation = call.parameters["operationId"] ?: throw IllegalArgumentException("missing operation id parameter")
-            providers.operations.abortOperation(repo, operation)
+            services.operations.abortOperation(repo, operation)
             call.respond(HttpStatusCode.NoContent)
         }
 
         get {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val operation = call.parameters["operationId"] ?: throw IllegalArgumentException("missing operation id parameter")
-            call.respond(providers.operations.getOperation(repo, operation))
+            call.respond(services.operations.getOperation(repo, operation))
         }
     }
 
@@ -44,7 +44,7 @@ fun Route.OperationsApi(@Suppress("UNUSED_PARAMETER") providers: ProviderModule)
         get {
             val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val operation = call.parameters["operationId"] ?: throw IllegalArgumentException("missing operation id parameter")
-            call.respond(providers.operations.getProgress(repo, operation))
+            call.respond(services.operations.getProgress(repo, operation))
         }
     }
 
@@ -59,7 +59,7 @@ fun Route.OperationsApi(@Suppress("UNUSED_PARAMETER") providers: ProviderModule)
             } else {
                 false
             }
-            call.respond(providers.operations.startPull(repo, remote, commitId, params, metadataOnly))
+            call.respond(services.operations.startPull(repo, remote, commitId, params, metadataOnly))
         }
     }
 
@@ -74,7 +74,7 @@ fun Route.OperationsApi(@Suppress("UNUSED_PARAMETER") providers: ProviderModule)
             } else {
                 false
             }
-            call.respond(providers.operations.startPush(repo, remote, commitId, params, metadataOnly))
+            call.respond(services.operations.startPush(repo, remote, commitId, params, metadataOnly))
         }
     }
 }

--- a/server/src/main/kotlin/io/titandata/apis/RemotesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/RemotesApi.kt
@@ -14,7 +14,7 @@ import io.ktor.routing.delete
 import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.route
-import io.titandata.ProviderModule
+import io.titandata.ServiceLocator
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
 
@@ -25,7 +25,7 @@ import io.titandata.models.RemoteParameters
  * complexity of managing different remotes by name down to the storage provider is not really
  * worth it.
  */
-fun Route.RemotesApi(providers: ProviderModule) {
+fun Route.RemotesApi(services: ServiceLocator) {
 
     fun getRepoName(call: ApplicationCall): String {
         return call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repositoryName parameter")
@@ -41,13 +41,13 @@ fun Route.RemotesApi(providers: ProviderModule) {
 
     route("/v1/repositories/{repositoryName}/remotes") {
         get {
-            call.respond(providers.remotes.listRemotes(getRepoName(call)))
+            call.respond(services.remotes.listRemotes(getRepoName(call)))
         }
 
         post {
             val repo = getRepoName(call)
             val remote = call.receive(Remote::class)
-            providers.remotes.addRemote(repo, remote)
+            services.remotes.addRemote(repo, remote)
             call.respond(HttpStatusCode.Created, remote)
         }
     }
@@ -56,13 +56,13 @@ fun Route.RemotesApi(providers: ProviderModule) {
         get {
             val repo = getRepoName(call)
             val remoteName = getRemoteName(call)
-            call.respond(providers.remotes.getRemote(repo, remoteName))
+            call.respond(services.remotes.getRemote(repo, remoteName))
         }
 
         delete {
             val repo = getRepoName(call)
             val remoteName = getRemoteName(call)
-            providers.remotes.removeRemote(repo, remoteName)
+            services.remotes.removeRemote(repo, remoteName)
             call.respond(HttpStatusCode.NoContent)
         }
 
@@ -70,7 +70,7 @@ fun Route.RemotesApi(providers: ProviderModule) {
             val repo = getRepoName(call)
             val remoteName = getRemoteName(call)
             val remote = call.receive(Remote::class)
-            providers.remotes.updateRemote(repo, remoteName, remote)
+            services.remotes.updateRemote(repo, remoteName, remote)
             call.respond(remote)
         }
     }
@@ -79,10 +79,10 @@ fun Route.RemotesApi(providers: ProviderModule) {
         get {
             val repo = getRepoName(call)
             val remoteName = getRemoteName(call)
-            val params = providers.gson.fromJson(call.request.headers["titan-remote-parameters"],
+            val params = services.gson.fromJson(call.request.headers["titan-remote-parameters"],
                     RemoteParameters::class.java)
             val tags = call.request.queryParameters.getAll("tag")
-            call.respond(providers.remotes.listRemoteCommits(repo, remoteName, params, tags))
+            call.respond(services.remotes.listRemoteCommits(repo, remoteName, params, tags))
         }
     }
 
@@ -91,9 +91,9 @@ fun Route.RemotesApi(providers: ProviderModule) {
             val repo = getRepoName(call)
             val remoteName = getRemoteName(call)
             val commitId = getCommitId(call)
-            val params = providers.gson.fromJson(call.request.headers["titan-remote-parameters"],
+            val params = services.gson.fromJson(call.request.headers["titan-remote-parameters"],
                     RemoteParameters::class.java)
-            call.respond(providers.remotes.getRemoteCommit(repo, remoteName, params, commitId))
+            call.respond(services.remotes.getRemoteCommit(repo, remoteName, params, commitId))
         }
     }
 }

--- a/server/src/main/kotlin/io/titandata/apis/RepositoriesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/RepositoriesApi.kt
@@ -13,38 +13,38 @@ import io.ktor.routing.delete
 import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.route
-import io.titandata.ProviderModule
+import io.titandata.ServiceLocator
 import io.titandata.models.Repository
 
-fun Route.RepositoriesApi(providers: ProviderModule) {
+fun Route.RepositoriesApi(services: ServiceLocator) {
     route("/v1/repositories") {
         post {
             val repo = call.receive(Repository::class)
-            providers.repositories.createRepository(repo)
+            services.repositories.createRepository(repo)
             call.respond(HttpStatusCode.Created, repo)
         }
 
         get {
-            call.respond(providers.repositories.listRepositories())
+            call.respond(services.repositories.listRepositories())
         }
     }
 
     route("/v1/repositories/{repositoryName}") {
         get {
             val name = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repositoryName parameter")
-            call.respond(providers.repositories.getRepository(name))
+            call.respond(services.repositories.getRepository(name))
         }
 
         post {
             val name = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repositoryName parameter")
             val repo = call.receive(Repository::class)
-            providers.repositories.updateRepository(name, repo)
+            services.repositories.updateRepository(name, repo)
             call.respond(repo)
         }
 
         delete {
             val name = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repositoryName parameter")
-            providers.repositories.deleteRepository(name)
+            services.repositories.deleteRepository(name)
             call.respond(HttpStatusCode.NoContent)
         }
     }
@@ -52,7 +52,7 @@ fun Route.RepositoriesApi(providers: ProviderModule) {
     route("/v1/repositories/{repositoryName}/status") {
         get {
             val name = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repositoryName parameter")
-            call.respond(providers.repositories.getRepositoryStatus(name))
+            call.respond(services.repositories.getRepositoryStatus(name))
         }
     }
 }

--- a/server/src/main/kotlin/io/titandata/apis/VolumesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/VolumesApi.kt
@@ -14,10 +14,10 @@ import io.ktor.routing.delete
 import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.route
-import io.titandata.ProviderModule
+import io.titandata.ServiceLocator
 import io.titandata.models.Volume
 
-fun Route.VolumesApi(providers: ProviderModule) {
+fun Route.VolumesApi(services: ServiceLocator) {
 
     fun getRepoName(call: ApplicationCall): String {
         return call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repositoryName parameter")
@@ -29,13 +29,13 @@ fun Route.VolumesApi(providers: ProviderModule) {
 
     route("/v1/repositories/{repositoryName}/volumes") {
         get {
-            call.respond(providers.volumes.listVolumes(getRepoName(call)))
+            call.respond(services.volumes.listVolumes(getRepoName(call)))
         }
 
         post {
             val repo = getRepoName(call)
             val volume = call.receive(Volume::class)
-            val result = providers.volumes.createVolume(repo, volume)
+            val result = services.volumes.createVolume(repo, volume)
             call.respond(HttpStatusCode.Created, result)
         }
     }
@@ -44,13 +44,13 @@ fun Route.VolumesApi(providers: ProviderModule) {
         get {
             val repo = getRepoName(call)
             val volumeName = getVolumeName(call)
-            call.respond(providers.volumes.getVolume(repo, volumeName))
+            call.respond(services.volumes.getVolume(repo, volumeName))
         }
 
         delete {
             val repo = getRepoName(call)
             val volumeName = getVolumeName(call)
-            providers.volumes.deleteVolume(repo, volumeName)
+            services.volumes.deleteVolume(repo, volumeName)
             call.respond(HttpStatusCode.NoContent)
         }
     }
@@ -59,7 +59,7 @@ fun Route.VolumesApi(providers: ProviderModule) {
         post {
             val repo = getRepoName(call)
             val volumeName = getVolumeName(call)
-            providers.volumes.activateVolume(repo, volumeName)
+            services.volumes.activateVolume(repo, volumeName)
             call.respond(HttpStatusCode.OK)
         }
     }
@@ -68,7 +68,7 @@ fun Route.VolumesApi(providers: ProviderModule) {
         post {
             val repo = getRepoName(call)
             val volumeName = getVolumeName(call)
-            providers.volumes.deactivateVolume(repo, volumeName)
+            services.volumes.deactivateVolume(repo, volumeName)
             call.respond(HttpStatusCode.OK)
         }
     }

--- a/server/src/main/kotlin/io/titandata/orchestrator/CommitOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/CommitOrchestrator.kt
@@ -1,6 +1,6 @@
 package io.titandata.orchestrator
 
-import io.titandata.ProviderModule
+import io.titandata.ServiceLocator
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Commit
@@ -9,7 +9,7 @@ import java.time.Instant
 import java.time.format.DateTimeFormatter
 import org.jetbrains.exposed.sql.transactions.transaction
 
-class CommitOrchestrator(val providers: ProviderModule) {
+class CommitOrchestrator(val services: ServiceLocator) {
 
     /*
      * To create a new commit, we fetch the active volume set, and then inform the storage provider to create a commit
@@ -17,7 +17,7 @@ class CommitOrchestrator(val providers: ProviderModule) {
      */
     fun createCommit(repo: String, commit: Commit, existingVolumeSet: String? = null): Commit {
         NameUtil.validateCommitId(commit.id)
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
 
         // Set the creation timestamp in metadata if it doesn't already exists
         val props = commit.properties.toMutableMap()
@@ -28,96 +28,96 @@ class CommitOrchestrator(val providers: ProviderModule) {
 
         val volumeSet = transaction {
             try {
-                providers.metadata.getCommit(repo, commit.id)
+                services.metadata.getCommit(repo, commit.id)
                 throw ObjectExistsException("commit '${commit.id}' already exists in repository '$repo'")
             } catch (e: NoSuchObjectException) {
                 // Ignore
             }
-            val vs = if (existingVolumeSet != null) { existingVolumeSet } else { providers.metadata.getActiveVolumeSet(repo) }
-            providers.metadata.createCommit(repo, vs, newCommit)
+            val vs = if (existingVolumeSet != null) { existingVolumeSet } else { services.metadata.getActiveVolumeSet(repo) }
+            services.metadata.createCommit(repo, vs, newCommit)
             vs
         }
 
         val volumes = transaction {
-            providers.metadata.listVolumes(volumeSet)
+            services.metadata.listVolumes(volumeSet)
         }
 
-        providers.context.createCommit(volumeSet, newCommit.id, volumes.map { it.name })
+        services.context.createCommit(volumeSet, newCommit.id, volumes.map { it.name })
         return newCommit
     }
 
     fun getCommit(repo: String, id: String): Commit {
         NameUtil.validateCommitId(id)
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
         return transaction {
-            providers.metadata.getCommit(repo, id).second
+            services.metadata.getCommit(repo, id).second
         }
     }
 
     fun getCommitStatus(repo: String, id: String): CommitStatus {
         NameUtil.validateCommitId(id)
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
         val (vs, volumes) = transaction {
-            val vs = providers.metadata.getCommit(repo, id).first
-            Pair(vs, providers.metadata.listVolumes(vs).map { it.name })
+            val vs = services.metadata.getCommit(repo, id).first
+            Pair(vs, services.metadata.listVolumes(vs).map { it.name })
         }
-        return providers.context.getCommitStatus(vs, id, volumes)
+        return services.context.getCommitStatus(vs, id, volumes)
     }
 
     fun listCommits(repo: String, tags: List<String>? = null): List<Commit> {
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
         return transaction {
-            providers.metadata.listCommits(repo, tags)
+            services.metadata.listCommits(repo, tags)
         }
     }
 
     fun deleteCommit(repo: String, commit: String) {
         NameUtil.validateCommitId(commit)
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
 
         transaction {
-            providers.metadata.markCommitDeleting(repo, commit)
+            services.metadata.markCommitDeleting(repo, commit)
         }
-        providers.reaper.signal()
+        services.reaper.signal()
     }
 
     fun checkoutCommit(repo: String, commit: String) {
         NameUtil.validateCommitId(commit)
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
         val (sourceVolumeSet, newVolumeSet) = transaction {
-            val vs = providers.metadata.getCommit(repo, commit).first
-            val newVolumeSet = providers.metadata.createVolumeSet(repo, commit)
-            val volumes = providers.metadata.listVolumes(vs)
+            val vs = services.metadata.getCommit(repo, commit).first
+            val newVolumeSet = services.metadata.createVolumeSet(repo, commit)
+            val volumes = services.metadata.listVolumes(vs)
             for (v in volumes) {
-                providers.metadata.createVolume(newVolumeSet, v)
+                services.metadata.createVolume(newVolumeSet, v)
             }
             Pair(vs, newVolumeSet)
         }
 
         val volumes = transaction {
-            providers.metadata.listVolumes(newVolumeSet).map { it.name }
+            services.metadata.listVolumes(newVolumeSet).map { it.name }
         }
 
-        providers.context.cloneVolumeSet(sourceVolumeSet, commit, newVolumeSet)
+        services.context.cloneVolumeSet(sourceVolumeSet, commit, newVolumeSet)
         for (v in volumes) {
-            val config = providers.context.cloneVolume(sourceVolumeSet, commit, newVolumeSet, v)
+            val config = services.context.cloneVolume(sourceVolumeSet, commit, newVolumeSet, v)
             transaction {
-                providers.metadata.updateVolumeConfig(newVolumeSet, v, config)
+                services.metadata.updateVolumeConfig(newVolumeSet, v, config)
             }
         }
 
         transaction {
-            providers.metadata.activateVolumeSet(repo, newVolumeSet)
+            services.metadata.activateVolumeSet(repo, newVolumeSet)
         }
-        providers.reaper.signal()
+        services.reaper.signal()
     }
 
     fun updateCommit(repo: String, commit: Commit) {
         NameUtil.validateCommitId(commit.id)
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
 
         transaction {
-            providers.metadata.updateCommit(repo, commit)
+            services.metadata.updateCommit(repo, commit)
         }
     }
 }

--- a/server/src/main/kotlin/io/titandata/orchestrator/RemoteOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/RemoteOrchestrator.kt
@@ -1,13 +1,13 @@
 package io.titandata.orchestrator
 
-import io.titandata.ProviderModule
+import io.titandata.ServiceLocator
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.models.Commit
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
 import org.jetbrains.exposed.sql.transactions.transaction
 
-class RemoteOrchestrator(val providers: ProviderModule) {
+class RemoteOrchestrator(val services: ServiceLocator) {
 
     internal fun getTags(tags: List<String>?): List<Pair<String, String?>> {
         if (tags == null) {
@@ -28,54 +28,54 @@ class RemoteOrchestrator(val providers: ProviderModule) {
         return Remote(
                 provider = remote.provider,
                 name = remote.name,
-                properties = providers.remoteProvider(remote.provider).validateRemote(remote.properties)
+                properties = services.remoteProvider(remote.provider).validateRemote(remote.properties)
         )
     }
 
     fun validateParameters(parameters: RemoteParameters): RemoteParameters {
         return RemoteParameters(
                 provider = parameters.provider,
-                properties = providers.remoteProvider(parameters.provider).validateParameters(parameters.properties)
+                properties = services.remoteProvider(parameters.provider).validateParameters(parameters.properties)
         )
     }
 
     fun listRemotes(repo: String): List<Remote> {
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
         return transaction {
-            providers.metadata.listRemotes(repo)
+            services.metadata.listRemotes(repo)
         }
     }
 
     fun addRemote(repo: String, remote: Remote) {
         NameUtil.validateRemoteName(remote.name)
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
         transaction {
-            providers.metadata.addRemote(repo, validateRemote(remote))
+            services.metadata.addRemote(repo, validateRemote(remote))
         }
     }
 
     fun getRemote(repo: String, remoteName: String): Remote {
         NameUtil.validateRemoteName(remoteName)
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
         return transaction {
-            validateRemote(providers.metadata.getRemote(repo, remoteName))
+            validateRemote(services.metadata.getRemote(repo, remoteName))
         }
     }
 
     fun removeRemote(repo: String, remoteName: String) {
         NameUtil.validateRemoteName(remoteName)
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
         transaction {
-            providers.metadata.removeRemote(repo, remoteName)
+            services.metadata.removeRemote(repo, remoteName)
         }
     }
 
     fun updateRemote(repo: String, remoteName: String, remote: Remote) {
         NameUtil.validateRemoteName(remoteName)
         NameUtil.validateRemoteName(remote.name)
-        providers.repositories.getRepository(repo)
+        services.repositories.getRepository(repo)
         transaction {
-            providers.metadata.updateRemote(repo, remoteName, validateRemote(remote))
+            services.metadata.updateRemote(repo, remoteName, validateRemote(remote))
         }
     }
 
@@ -84,7 +84,7 @@ class RemoteOrchestrator(val providers: ProviderModule) {
         if (params.provider != remote.provider) {
             throw IllegalArgumentException("invalid remote parameter type '${params.provider}' for remote type '${remote.provider}")
         }
-        val commits = providers.remoteProvider(remote.provider).listCommits(remote.properties,
+        val commits = services.remoteProvider(remote.provider).listCommits(remote.properties,
                 validateParameters(params).properties, getTags(tags))
         return commits.map { Commit(id = it.first, properties = it.second) }
     }
@@ -94,7 +94,7 @@ class RemoteOrchestrator(val providers: ProviderModule) {
         if (params.provider != remote.provider) {
             throw IllegalArgumentException("invalid remote parameter type '${params.provider}' for remote type '${remote.provider}")
         }
-        val commit = providers.remoteProvider(remote.provider).getCommit(remote.properties,
+        val commit = services.remoteProvider(remote.provider).getCommit(remote.properties,
                 validateParameters(params).properties, commitId)
         if (commit == null) {
             throw NoSuchObjectException("no such commit '$commitId' in remote '$remoteName'")

--- a/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/RepositoryOrchestrator.kt
@@ -1,44 +1,44 @@
 package io.titandata.orchestrator
 
-import io.titandata.ProviderModule
+import io.titandata.ServiceLocator
 import io.titandata.models.Repository
 import io.titandata.models.RepositoryStatus
 import io.titandata.models.RepositoryVolumeStatus
 import org.jetbrains.exposed.sql.transactions.transaction
 
-class RepositoryOrchestrator(val providers: ProviderModule) {
+class RepositoryOrchestrator(val services: ServiceLocator) {
 
     fun createRepository(repo: Repository) {
         NameUtil.validateRepoName(repo.name)
         val volumeSet = transaction {
-            providers.metadata.createRepository(repo)
-            val vs = providers.metadata.createVolumeSet(repo.name, null, true)
+            services.metadata.createRepository(repo)
+            val vs = services.metadata.createVolumeSet(repo.name, null, true)
             vs
         }
-        providers.context.createVolumeSet(volumeSet)
+        services.context.createVolumeSet(volumeSet)
     }
 
     fun listRepositories(): List<Repository> {
         return transaction {
-            providers.metadata.listRepositories()
+            services.metadata.listRepositories()
         }
     }
 
     fun getRepository(name: String): Repository {
         NameUtil.validateRepoName(name)
         return transaction {
-            providers.metadata.getRepository(name)
+            services.metadata.getRepository(name)
         }
     }
 
     fun getRepositoryStatus(name: String): RepositoryStatus {
         NameUtil.validateRepoName(name)
         val (volumeSet, volumes) = transaction {
-            val vs = providers.metadata.getActiveVolumeSet(name)
-            Pair(vs, providers.metadata.listVolumes(vs))
+            val vs = services.metadata.getActiveVolumeSet(name)
+            Pair(vs, services.metadata.listVolumes(vs))
         }
         val volumeStatus = volumes.map {
-            val rawStatus = providers.context.getVolumeStatus(volumeSet, it.name)
+            val rawStatus = services.context.getVolumeStatus(volumeSet, it.name)
             RepositoryVolumeStatus(
                     name = it.name,
                     logicalSize = rawStatus.logicalSize,
@@ -49,8 +49,8 @@ class RepositoryOrchestrator(val providers: ProviderModule) {
         val status = transaction {
             RepositoryStatus(
                     volumeStatus = volumeStatus,
-                    lastCommit = providers.metadata.getLastCommit(name),
-                    sourceCommit = providers.metadata.getCommitSource(volumeSet)
+                    lastCommit = services.metadata.getLastCommit(name),
+                    sourceCommit = services.metadata.getCommitSource(volumeSet)
             )
         }
         return status
@@ -60,16 +60,16 @@ class RepositoryOrchestrator(val providers: ProviderModule) {
         NameUtil.validateRepoName(name)
         NameUtil.validateRepoName(repo.name)
         transaction {
-            providers.metadata.updateRepository(name, repo)
+            services.metadata.updateRepository(name, repo)
         }
     }
 
     fun deleteRepository(name: String) {
         NameUtil.validateRepoName(name)
         transaction {
-            providers.metadata.markAllVolumeSetsDeleting(name)
-            providers.metadata.deleteRepository(name)
+            services.metadata.markAllVolumeSetsDeleting(name)
+            services.metadata.deleteRepository(name)
         }
-        providers.reaper.signal()
+        services.reaper.signal()
     }
 }

--- a/server/src/test/kotlin/io/titandata/orchestrator/RemoteOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/RemoteOrchestratorTest.kt
@@ -19,7 +19,7 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.OverrideMockKs
 import io.mockk.impl.annotations.SpyK
 import io.mockk.slot
-import io.titandata.ProviderModule
+import io.titandata.ServiceLocator
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Remote
@@ -41,20 +41,20 @@ class RemoteOrchestratorTest : StringSpec() {
 
     @InjectMockKs
     @OverrideMockKs
-    var providers = ProviderModule("test")
+    var services = ServiceLocator("test")
 
     override fun beforeSpec(spec: Spec) {
-        providers.metadata.init()
+        services.metadata.init()
     }
 
     override fun beforeTest(testCase: TestCase) {
-        providers.metadata.clear()
+        services.metadata.clear()
         transaction {
-            providers.metadata.createRepository(Repository(name = "foo"))
+            services.metadata.createRepository(Repository(name = "foo"))
         }
         MockKAnnotations.init(this)
-        providers.setRemoteProvider("nop", nopProvider)
-        providers.setRemoteProvider("ssh", sshProvider)
+        services.setRemoteProvider("nop", nopProvider)
+        services.setRemoteProvider("ssh", sshProvider)
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {
@@ -65,35 +65,35 @@ class RemoteOrchestratorTest : StringSpec() {
 
     init {
         "add remote succeeds" {
-            providers.remotes.addRemote("foo", Remote("nop", "origin"))
+            services.remotes.addRemote("foo", Remote("nop", "origin"))
         }
 
         "add remote fails with invalid properties" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.addRemote("foo", Remote("nop", "origin", mapOf("foo" to "bar")))
+                services.remotes.addRemote("foo", Remote("nop", "origin", mapOf("foo" to "bar")))
             }
         }
 
         "add remote with invalid repo name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.addRemote("bad/repo", Remote("nop", "origin"))
+                services.remotes.addRemote("bad/repo", Remote("nop", "origin"))
             }
         }
         "add remote with invalid name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.addRemote("foo", Remote("nop", "bad/remote"))
+                services.remotes.addRemote("foo", Remote("nop", "bad/remote"))
             }
         }
 
         "add remote to non-existent repo fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.addRemote("bar", Remote("nop", "origin"))
+                services.remotes.addRemote("bar", Remote("nop", "origin"))
             }
         }
 
         "get remote succeeds" {
-            providers.remotes.addRemote("foo", Remote("s3", "origin", mapOf("bucket" to "bucket")))
-            val remote = providers.remotes.getRemote("foo", "origin")
+            services.remotes.addRemote("foo", Remote("s3", "origin", mapOf("bucket" to "bucket")))
+            val remote = services.remotes.getRemote("foo", "origin")
             remote.provider shouldBe "s3"
             remote.name shouldBe "origin"
             remote.properties["bucket"] shouldBe "bucket"
@@ -101,26 +101,26 @@ class RemoteOrchestratorTest : StringSpec() {
 
         "get remote with invalid repo name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.getRemote("bad/repo", "origin")
+                services.remotes.getRemote("bad/repo", "origin")
             }
         }
 
         "get remote with invalid name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.getRemote("foo", "bad/remote")
+                services.remotes.getRemote("foo", "bad/remote")
             }
         }
 
         "get remote from non-existent repo fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.getRemote("foo", "origin")
+                services.remotes.getRemote("foo", "origin")
             }
         }
 
         "list remotes succeeds" {
-            providers.remotes.addRemote("foo", Remote("nop", "one"))
-            providers.remotes.addRemote("foo", Remote("nop", "two"))
-            val remotes = providers.remotes.listRemotes("foo").sortedBy { it.name }
+            services.remotes.addRemote("foo", Remote("nop", "one"))
+            services.remotes.addRemote("foo", Remote("nop", "two"))
+            val remotes = services.remotes.listRemotes("foo").sortedBy { it.name }
             remotes.size shouldBe 2
             remotes[0].name shouldBe "one"
             remotes[1].name shouldBe "two"
@@ -128,53 +128,53 @@ class RemoteOrchestratorTest : StringSpec() {
 
         "list remotes with invalid repo name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.listRemotes("bad/repo")
+                services.remotes.listRemotes("bad/repo")
             }
         }
 
         "list remotes from non-existent repo fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.listRemotes("bar")
+                services.remotes.listRemotes("bar")
             }
         }
 
         "remove remote succeeds" {
-            providers.remotes.addRemote("foo", Remote("nop", "origin"))
-            providers.remotes.removeRemote("foo", "origin")
+            services.remotes.addRemote("foo", Remote("nop", "origin"))
+            services.remotes.removeRemote("foo", "origin")
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.getRemote("foo", "origin")
+                services.remotes.getRemote("foo", "origin")
             }
         }
 
         "remove remote with invalid repo name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.removeRemote("bad/repo", "origin")
+                services.remotes.removeRemote("bad/repo", "origin")
             }
         }
 
         "remove remote with invalid name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.removeRemote("foo", "bad/remote")
+                services.remotes.removeRemote("foo", "bad/remote")
             }
         }
 
         "remove remote from non-existent repo fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.removeRemote("bar", "origin")
+                services.remotes.removeRemote("bar", "origin")
             }
         }
 
         "remove non-existent remote fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.removeRemote("foo", "origin")
+                services.remotes.removeRemote("foo", "origin")
             }
         }
 
         "update remote succeeds" {
-            providers.remotes.addRemote("foo", Remote("nop", "origin"))
-            providers.remotes.updateRemote("foo", "origin", Remote("s3", "origin2", mapOf("bucket" to "bucket")))
-            providers.remotes.listRemotes("foo").size shouldBe 1
-            val remote = providers.remotes.getRemote("foo", "origin2")
+            services.remotes.addRemote("foo", Remote("nop", "origin"))
+            services.remotes.updateRemote("foo", "origin", Remote("s3", "origin2", mapOf("bucket" to "bucket")))
+            services.remotes.listRemotes("foo").size shouldBe 1
+            val remote = services.remotes.getRemote("foo", "origin2")
             remote.provider shouldBe "s3"
             remote.name shouldBe "origin2"
             remote.properties["bucket"] shouldBe "bucket"
@@ -182,54 +182,54 @@ class RemoteOrchestratorTest : StringSpec() {
 
         "update remote with invalid repo name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.updateRemote("bad/repo", "origin", Remote("nop", "origin"))
+                services.remotes.updateRemote("bad/repo", "origin", Remote("nop", "origin"))
             }
         }
 
         "update remote with invalid repo rpoerties fails" {
-            providers.remotes.addRemote("foo", Remote("nop", "origin"))
+            services.remotes.addRemote("foo", Remote("nop", "origin"))
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.updateRemote("foo", "origin", Remote("nop", "origin", mapOf("foo" to "bar")))
+                services.remotes.updateRemote("foo", "origin", Remote("nop", "origin", mapOf("foo" to "bar")))
             }
         }
 
         "update remote with invalid name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.updateRemote("foo", "bad/repo", Remote("nop", "origin"))
+                services.remotes.updateRemote("foo", "bad/repo", Remote("nop", "origin"))
             }
         }
 
         "update remote with invalid new name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.updateRemote("foo", "origin", Remote("nop", "bad/repo"))
+                services.remotes.updateRemote("foo", "origin", Remote("nop", "bad/repo"))
             }
         }
 
         "update remote from non-existent repo fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.updateRemote("bar", "origin", Remote("nop", "origin"))
+                services.remotes.updateRemote("bar", "origin", Remote("nop", "origin"))
             }
         }
 
         "update non-existent remote fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.updateRemote("foo", "origin", Remote("nop", "origin"))
+                services.remotes.updateRemote("foo", "origin", Remote("nop", "origin"))
             }
         }
 
         "update remote to existing name fails" {
-            providers.remotes.addRemote("foo", Remote("nop", "one"))
-            providers.remotes.addRemote("foo", Remote("nop", "two"))
+            services.remotes.addRemote("foo", Remote("nop", "one"))
+            services.remotes.addRemote("foo", Remote("nop", "two"))
             shouldThrow<ObjectExistsException> {
-                providers.remotes.updateRemote("foo", "one", Remote("nop", "two"))
+                services.remotes.updateRemote("foo", "one", Remote("nop", "two"))
             }
         }
 
         "list remote commits succeeds" {
             every { nopProvider.listCommits(any(), any(), any()) } returns
                     listOf("one" to emptyMap(), "two" to emptyMap())
-            providers.remotes.addRemote("foo", Remote("nop", "origin"))
-            val result = providers.remotes.listRemoteCommits("foo", "origin", params, null)
+            services.remotes.addRemote("foo", Remote("nop", "origin"))
+            val result = services.remotes.listRemoteCommits("foo", "origin", params, null)
             result.size shouldBe 2
             result[0].id shouldBe "one"
             result[1].id shouldBe "two"
@@ -238,50 +238,50 @@ class RemoteOrchestratorTest : StringSpec() {
         "list remote commits fails with invalid parameters" {
             every { nopProvider.listCommits(any(), any(), any()) } returns
                     listOf("one" to emptyMap(), "two" to emptyMap())
-            providers.remotes.addRemote("foo", Remote("nop", "origin"))
+            services.remotes.addRemote("foo", Remote("nop", "origin"))
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.listRemoteCommits("foo", "origin", RemoteParameters("nop", mapOf("foo" to "bar")), null)
+                services.remotes.listRemoteCommits("foo", "origin", RemoteParameters("nop", mapOf("foo" to "bar")), null)
             }
         }
 
         "list remote commits with invalid repo name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.listRemoteCommits("bad/repo", "origin", params, null)
+                services.remotes.listRemoteCommits("bad/repo", "origin", params, null)
             }
         }
 
         "list remote commits with invalid remote name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.listRemoteCommits("foo", "bad/remote", params, null)
+                services.remotes.listRemoteCommits("foo", "bad/remote", params, null)
             }
         }
 
         "list remote commits for non-existent repo fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.listRemoteCommits("bar", "origin", params, null)
+                services.remotes.listRemoteCommits("bar", "origin", params, null)
             }
         }
 
         "list remote commits for non-existent remote fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.listRemoteCommits("foo", "origin", params, null)
+                services.remotes.listRemoteCommits("foo", "origin", params, null)
             }
         }
 
         "mismatched remote parameter types fail on list" {
-            providers.remotes.addRemote("foo", Remote("ssh", "origin", mapOf("address" to "host", "username" to "user",
+            services.remotes.addRemote("foo", Remote("ssh", "origin", mapOf("address" to "host", "username" to "user",
                     "path" to "/path")))
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.listRemoteCommits("foo", "origin", params, null)
+                services.remotes.listRemoteCommits("foo", "origin", params, null)
             }
         }
 
         "list remote commits converts remote port" {
-            providers.remotes.addRemote("foo", Remote("ssh", "origin", mapOf("address" to "host", "username" to "user",
+            services.remotes.addRemote("foo", Remote("ssh", "origin", mapOf("address" to "host", "username" to "user",
                     "path" to "/path", "port" to 8022)))
             val slot = slot<Map<String, Any>>()
             every { sshProvider.listCommits(capture(slot), any(), any()) } returns emptyList()
-            val result = providers.remotes.listRemoteCommits("foo", "origin", RemoteParameters("ssh", mapOf("password" to "pass")), null)
+            val result = services.remotes.listRemoteCommits("foo", "origin", RemoteParameters("ssh", mapOf("password" to "pass")), null)
             result.size shouldBe 0
             slot.captured["port"] shouldBe 8022
             slot.captured["port"].shouldBeInstanceOf<Int>()
@@ -289,25 +289,25 @@ class RemoteOrchestratorTest : StringSpec() {
 
         "get remote commit succeeds" {
             every { nopProvider.getCommit(any(), any(), any()) } returns emptyMap()
-            providers.remotes.addRemote("foo", Remote("nop", "origin"))
-            val result = providers.remotes.getRemoteCommit("foo", "origin", params, "id")
+            services.remotes.addRemote("foo", Remote("nop", "origin"))
+            val result = services.remotes.getRemoteCommit("foo", "origin", params, "id")
             result.id shouldBe "id"
         }
 
         "mismatched remote parameter types fail on get" {
-            providers.remotes.addRemote("foo", Remote("ssh", "origin", mapOf("address" to "host", "username" to "user",
+            services.remotes.addRemote("foo", Remote("ssh", "origin", mapOf("address" to "host", "username" to "user",
                     "path" to "/path")))
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.getRemoteCommit("foo", "origin", params, "id")
+                services.remotes.getRemoteCommit("foo", "origin", params, "id")
             }
         }
 
         "get remote commit converts remote port" {
-            providers.remotes.addRemote("foo", Remote("ssh", "origin", mapOf("address" to "host", "username" to "user",
+            services.remotes.addRemote("foo", Remote("ssh", "origin", mapOf("address" to "host", "username" to "user",
                     "path" to "/path", "port" to 8022)))
             val slot = slot<Map<String, Any>>()
             every { sshProvider.getCommit(capture(slot), any(), any()) } returns emptyMap()
-            val result = providers.remotes.getRemoteCommit("foo", "origin", RemoteParameters("ssh", mapOf("password" to "pass")), "id")
+            val result = services.remotes.getRemoteCommit("foo", "origin", RemoteParameters("ssh", mapOf("password" to "pass")), "id")
             result.id shouldBe "id"
             slot.captured["port"] shouldBe 8022
             slot.captured["port"].shouldBeInstanceOf<Int>()
@@ -315,33 +315,33 @@ class RemoteOrchestratorTest : StringSpec() {
 
         "get remote commit fails with invalid parameters" {
             every { nopProvider.getCommit(any(), any(), any()) } returns emptyMap()
-            providers.remotes.addRemote("foo", Remote("nop", "origin"))
+            services.remotes.addRemote("foo", Remote("nop", "origin"))
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.getRemoteCommit("foo", "origin", RemoteParameters("nop", mapOf("a" to "b")), "id")
+                services.remotes.getRemoteCommit("foo", "origin", RemoteParameters("nop", mapOf("a" to "b")), "id")
             }
         }
 
         "get remote commit with invalid repo name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.getRemoteCommit("bad/repo", "origin", params, "id")
+                services.remotes.getRemoteCommit("bad/repo", "origin", params, "id")
             }
         }
 
         "get remote commit with invalid remote name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.remotes.getRemoteCommit("foo", "bad/remote", params, "id")
+                services.remotes.getRemoteCommit("foo", "bad/remote", params, "id")
             }
         }
 
         "get remote commit for non-existent repo fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.getRemoteCommit("bar", "origin", params, "id")
+                services.remotes.getRemoteCommit("bar", "origin", params, "id")
             }
         }
 
         "get remote commit for non-existent remote fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.remotes.getRemoteCommit("foo", "origin", params, "id")
+                services.remotes.getRemoteCommit("foo", "origin", params, "id")
             }
         }
     }

--- a/server/src/test/kotlin/io/titandata/orchestrator/RepositoryOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/RepositoryOrchestratorTest.kt
@@ -21,7 +21,7 @@ import io.mockk.impl.annotations.OverrideMockKs
 import io.mockk.just
 import io.mockk.verify
 import io.mockk.verifyAll
-import io.titandata.ProviderModule
+import io.titandata.ServiceLocator
 import io.titandata.context.docker.DockerZfsContext
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
@@ -41,14 +41,14 @@ class RepositoryOrchestratorTest : StringSpec() {
 
     @InjectMockKs
     @OverrideMockKs
-    var providers = ProviderModule("test")
+    var services = ServiceLocator("test")
 
     override fun beforeSpec(spec: Spec) {
-        providers.metadata.init()
+        services.metadata.init()
     }
 
     override fun beforeTest(testCase: TestCase) {
-        providers.metadata.clear()
+        services.metadata.clear()
         return MockKAnnotations.init(this)
     }
 
@@ -60,14 +60,14 @@ class RepositoryOrchestratorTest : StringSpec() {
 
     fun createRepository() {
         every { dockerZfsContext.createVolumeSet(any()) } just Runs
-        providers.repositories.createRepository(Repository(name = "foo", properties = mapOf("a" to "b")))
+        services.repositories.createRepository(Repository(name = "foo", properties = mapOf("a" to "b")))
     }
 
     init {
         "create repository succeeds" {
             createRepository()
             val vs = transaction {
-                providers.metadata.getActiveVolumeSet("foo")
+                services.metadata.getActiveVolumeSet("foo")
             }
             verifyAll {
                 dockerZfsContext.createVolumeSet(vs)
@@ -76,33 +76,33 @@ class RepositoryOrchestratorTest : StringSpec() {
 
         "create repository with invalid name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.repositories.createRepository(Repository(name = "a".repeat(65)))
+                services.repositories.createRepository(Repository(name = "a".repeat(65)))
             }
         }
 
         "get repository succeeds" {
             createRepository()
-            val repo = providers.repositories.getRepository("foo")
+            val repo = services.repositories.getRepository("foo")
             repo.name shouldBe "foo"
             repo.properties["a"] shouldBe "b"
         }
 
         "get repository with invalid name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.repositories.getRepository("bad/repo")
+                services.repositories.getRepository("bad/repo")
             }
         }
 
         "get non-existent repository fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.repositories.getRepository("bar")
+                services.repositories.getRepository("bar")
             }
         }
 
         "list repositories succeeds" {
             createRepository()
-            providers.repositories.createRepository(Repository(name = "bar"))
-            val repos = providers.repositories.listRepositories().sortedBy { it.name }
+            services.repositories.createRepository(Repository(name = "bar"))
+            val repos = services.repositories.listRepositories().sortedBy { it.name }
             repos.size shouldBe 2
             repos[0].name shouldBe "bar"
             repos[1].name shouldBe "foo"
@@ -110,48 +110,48 @@ class RepositoryOrchestratorTest : StringSpec() {
 
         "update repository succeeds" {
             createRepository()
-            providers.repositories.updateRepository("foo", Repository(name = "bar", properties = mapOf("b" to "c")))
-            val repo = providers.repositories.getRepository("bar")
+            services.repositories.updateRepository("foo", Repository(name = "bar", properties = mapOf("b" to "c")))
+            val repo = services.repositories.getRepository("bar")
             repo.name shouldBe "bar"
             repo.properties["b"] shouldBe "c"
             shouldThrow<NoSuchObjectException> {
-                providers.repositories.getRepository("foo")
+                services.repositories.getRepository("foo")
             }
         }
 
         "update repository with invalid source name fails" {
             shouldThrow<IllegalArgumentException> {
-                providers.repositories.updateRepository("bad/repo", Repository(name = "foo"))
+                services.repositories.updateRepository("bad/repo", Repository(name = "foo"))
             }
         }
 
         "update repository with invalid new name fails" {
             createRepository()
             shouldThrow<IllegalArgumentException> {
-                providers.repositories.updateRepository("foo", Repository(name = "bad/repo"))
+                services.repositories.updateRepository("foo", Repository(name = "bad/repo"))
             }
         }
 
         "update non-existent repository fails" {
             shouldThrow<NoSuchObjectException> {
-                providers.repositories.updateRepository("foo", Repository(name = "foo"))
+                services.repositories.updateRepository("foo", Repository(name = "foo"))
             }
         }
 
         "rename to conflicting repo fails" {
             createRepository()
-            providers.repositories.createRepository(Repository(name = "bar"))
+            services.repositories.createRepository(Repository(name = "bar"))
             shouldThrow<ObjectExistsException> {
-                providers.repositories.updateRepository("foo", Repository(name = "bar"))
+                services.repositories.updateRepository("foo", Repository(name = "bar"))
             }
         }
 
         "delete repository succeeds" {
             every { reaper.signal() } just Runs
             createRepository()
-            providers.repositories.deleteRepository("foo")
+            services.repositories.deleteRepository("foo")
             shouldThrow<NoSuchObjectException> {
-                providers.repositories.getRepository("foo")
+                services.repositories.getRepository("foo")
             }
             verify {
                 reaper.signal()
@@ -161,13 +161,13 @@ class RepositoryOrchestratorTest : StringSpec() {
         "get repository status succeeds" {
             createRepository()
             every { dockerZfsContext.createVolume(any(), any()) } returns emptyMap()
-            providers.volumes.createVolume("foo", Volume("vol1"))
-            providers.volumes.createVolume("foo", Volume("vol2"))
+            services.volumes.createVolume("foo", Volume("vol1"))
+            services.volumes.createVolume("foo", Volume("vol2"))
             every { dockerZfsContext.createCommit(any(), any(), any()) } just Runs
-            providers.commits.createCommit("foo", Commit(id = "id"))
+            services.commits.createCommit("foo", Commit(id = "id"))
             every { dockerZfsContext.getVolumeStatus(any(), any()) } returns RepositoryVolumeStatus(
                 name = "vol", logicalSize = 20, actualSize = 10)
-            val status = providers.repositories.getRepositoryStatus("foo")
+            val status = services.repositories.getRepositoryStatus("foo")
             status.lastCommit shouldBe "id"
             status.sourceCommit shouldBe "id"
             status.volumeStatus.size shouldBe 2


### PR DESCRIPTION
## Proposed Changes

It's been bugging me for a while that we've had this thing called a `ProviderModule` that dates back from the dawn of building the ktor app, but it's really a service locator. We should rename it now, as we're going to be doing some surgery to it to support multiple runtime contexts. There are no logic changes involved.

## Testing

`gradle build test integrationTest endtoendTest`