### PR TITLE
k8s create/delete volumes and commits

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     compile("org.jetbrains.exposed:exposed:0.17.7")
     compile("org.postgresql:postgresql:42.2.8")
     compile("com.zaxxer:HikariCP:3.4.1")
+    compile("io.kubernetes:client-java:6.0.1")
 
     // Remotes
     compile("io.titandata:remote-sdk:0.1.0")

--- a/server/src/endtoend-test/kotlin/io/titandata/docker/DockerVolumeApi.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/docker/DockerVolumeApi.kt
@@ -2,7 +2,7 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata
+package io.titandata.docker
 
 import io.titandata.client.infrastructure.ApiClient
 import io.titandata.client.infrastructure.ClientException

--- a/server/src/endtoend-test/kotlin/io/titandata/docker/DockerVolumeTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/docker/DockerVolumeTest.kt
@@ -2,13 +2,14 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata
+package io.titandata.docker
 
 import io.kotlintest.Spec
 import io.kotlintest.matchers.string.shouldStartWith
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
+import io.titandata.EndToEndTest
 import io.titandata.client.infrastructure.ClientException
 import io.titandata.models.Commit
 import io.titandata.models.Repository

--- a/server/src/endtoend-test/kotlin/io/titandata/docker/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/docker/LocalWorkflowTest.kt
@@ -2,13 +2,14 @@
 * Copyright The Titan Project Contributors.
  */
 
-package io.titandata
+package io.titandata.docker
 
 import io.kotlintest.Spec
 import io.kotlintest.matchers.string.shouldStartWith
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
+import io.titandata.EndToEndTest
 import io.titandata.client.infrastructure.ClientException
 import io.titandata.models.Commit
 import io.titandata.models.Operation

--- a/server/src/endtoend-test/kotlin/io/titandata/docker/TeardownTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/docker/TeardownTest.kt
@@ -2,11 +2,12 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata
+package io.titandata.docker
 
 import io.kotlintest.Spec
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
+import io.titandata.EndToEndTest
 import io.titandata.client.infrastructure.ClientException
 import io.titandata.models.Repository
 

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
@@ -1,0 +1,48 @@
+package io.titandata.kubernetes
+
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.StringSpec
+import io.kubernetes.client.ApiException
+import io.kubernetes.client.apis.CoreV1Api
+import io.titandata.context.kubernetes.KubernetesCsiContext
+import java.util.UUID
+
+/**
+ * This test suite is a little different from the other endtoend tests in that it's not connecting to a fully
+ * instantiated titan server. Rather, it's testing the internals of the KubernetesContext driver with a real
+ * k8s environment (hence the reason for it being an end2end test).
+ */
+class KubernetesContextTest : StringSpec() {
+
+    private val context = KubernetesCsiContext()
+    private val coreApi: CoreV1Api = CoreV1Api()
+    private val vs = UUID.randomUUID().toString()
+    private val namespace = "default"
+
+    private lateinit var volumeConfig: Map<String, Any>
+
+    // TODO - clean up any partially created resources "vs-"
+
+    init {
+        "create volume succeeds" {
+            volumeConfig = context.createVolume(vs, "test")
+            volumeConfig["pvc"] shouldBe "$vs-test"
+            var phase = "Pending"
+            while (phase == "Pending") {
+                val result = coreApi.readNamespacedPersistentVolumeClaimStatus("$vs-test", namespace, null)
+                phase = result.status.phase
+                Thread.sleep(1000)
+            }
+            phase shouldBe "Bound"
+        }
+
+        "delete volume succeeds" {
+            context.deleteVolume(vs, "test", volumeConfig)
+            val exception = shouldThrow<ApiException> {
+                coreApi.readNamespacedPersistentVolumeClaimStatus("$vs-test", namespace, null)
+            }
+            exception.code shouldBe 404
+        }
+    }
+}

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
@@ -1,6 +1,5 @@
 package io.titandata.kubernetes
 
-import com.google.gson.GsonBuilder
 import com.google.gson.JsonParser
 import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
@@ -23,42 +22,67 @@ class KubernetesContextTest : StringSpec() {
     private val context = KubernetesCsiContext()
     private val coreApi: CoreV1Api = CoreV1Api()
     private val vs = UUID.randomUUID().toString()
+    private val vs2 = UUID.randomUUID().toString()
     private val namespace = "default"
     private val executor = CommandExecutor()
-    private val gson = GsonBuilder().create()
 
     private lateinit var volumeConfig: Map<String, Any>
+    private lateinit var cloneConfig: Map<String, Any>
 
     // TODO - clean up any partially created resources "vs-"
+
+    private fun waitForVolume(name: String) {
+        var phase = "Pending"
+        while (phase == "Pending") {
+            val result = coreApi.readNamespacedPersistentVolumeClaimStatus(name, namespace, null)
+            phase = result.status.phase
+            if (phase == "Pending") {
+                Thread.sleep(1000)
+            }
+        }
+        phase shouldBe "Bound"
+    }
+
+    private fun waitForSnapshot(name: String) {
+        var ready = "false"
+        while (ready == "false") {
+            val output = executor.exec("kubectl", "get", "volumesnapshot", name, "-o", "json")
+            val json = JsonParser.parseString(output)
+            val status = json.asJsonObject.getAsJsonObject("status")
+            if (status != null) {
+                ready = status.get("readyToUse").asString
+                val error = status.getAsJsonObject("error")?.get("message")?.asString
+                error shouldBe null
+            }
+            if (ready == "false") {
+                Thread.sleep(1000)
+            }
+        }
+    }
 
     init {
         "create volume succeeds" {
             volumeConfig = context.createVolume(vs, "test")
             volumeConfig["pvc"] shouldBe "$vs-test"
-            var phase = "Pending"
-            while (phase == "Pending") {
-                val result = coreApi.readNamespacedPersistentVolumeClaimStatus("$vs-test", namespace, null)
-                phase = result.status.phase
-                Thread.sleep(1000)
-            }
-            phase shouldBe "Bound"
+            waitForVolume("$vs-test")
         }
 
         "create commit succeeds" {
             context.commitVolume(vs, "id", "test", volumeConfig)
-            val name = "$vs-test-id"
-            var ready = "false"
-            while (ready == "false") {
-                val output = executor.exec("kubectl", "get", "volumesnapshot", name, "-o", "json")
-                val json = JsonParser.parseString(output)
-                val status = json.asJsonObject.getAsJsonObject("status")
-                if (status != null) {
-                    ready = status.get("readyToUse").asString
-                    val error = status.getAsJsonObject("error")?.get("message")?.asString
-                    error shouldBe null
-                }
-                Thread.sleep(1000)
+            waitForSnapshot("$vs-test-id")
+        }
+
+        "clone volume succeeds" {
+            cloneConfig = context.cloneVolume(vs, "id", vs2, "test", volumeConfig)
+            waitForVolume("$vs2-test")
+        }
+
+        "delete clone succeeds" {
+            context.deleteVolume(vs2, "test", cloneConfig)
+            val exception = shouldThrow<ApiException> {
+                coreApi.readNamespacedPersistentVolumeClaimStatus("$vs2-test", namespace, null)
             }
+            exception.code shouldBe 404
         }
 
         "delete commit succeeds" {

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
@@ -1,11 +1,16 @@
 package io.titandata.kubernetes
 
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonParser
+import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
 import io.kubernetes.client.ApiException
 import io.kubernetes.client.apis.CoreV1Api
 import io.titandata.context.kubernetes.KubernetesCsiContext
+import io.titandata.shell.CommandException
+import io.titandata.shell.CommandExecutor
 import java.util.UUID
 
 /**
@@ -19,6 +24,8 @@ class KubernetesContextTest : StringSpec() {
     private val coreApi: CoreV1Api = CoreV1Api()
     private val vs = UUID.randomUUID().toString()
     private val namespace = "default"
+    private val executor = CommandExecutor()
+    private val gson = GsonBuilder().create()
 
     private lateinit var volumeConfig: Map<String, Any>
 
@@ -37,12 +44,45 @@ class KubernetesContextTest : StringSpec() {
             phase shouldBe "Bound"
         }
 
+        "create commit succeeds" {
+            context.commitVolume(vs, "id", "test", volumeConfig)
+            val name = "$vs-test-id"
+            var ready = "false"
+            while (ready == "false") {
+                val output = executor.exec("kubectl", "get", "volumesnapshot", name, "-o", "json")
+                val json = JsonParser.parseString(output)
+                val status = json.asJsonObject.getAsJsonObject("status")
+                if (status != null) {
+                    ready = status.get("readyToUse").asString
+                    val error = status.getAsJsonObject("error")?.get("message")?.asString
+                    error shouldBe null
+                }
+                Thread.sleep(1000)
+            }
+        }
+
+        "delete commit succeeds" {
+            context.deleteVolumeCommit(vs, "id", "test")
+            val exception = shouldThrow<CommandException> {
+                executor.exec("kubectl", "get", "volumesnapshot", "$vs-test-id")
+            }
+            exception.output shouldContain "NotFound"
+        }
+
+        "delete of non-existent commit succeeds" {
+            context.deleteVolumeCommit(vs, "id", "test")
+        }
+
         "delete volume succeeds" {
             context.deleteVolume(vs, "test", volumeConfig)
             val exception = shouldThrow<ApiException> {
                 coreApi.readNamespacedPersistentVolumeClaimStatus("$vs-test", namespace, null)
             }
             exception.code shouldBe 404
+        }
+
+        "delete of non-existent volume succeeds" {
+            context.deleteVolume(vs, "test", volumeConfig)
         }
     }
 }

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
@@ -2,10 +2,11 @@
 * Copyright The Titan Project Contributors.
  */
 
-package io.titandata
+package io.titandata.kubernetes
 
 import io.kotlintest.Spec
 import io.kotlintest.matchers.string.shouldStartWith
+import io.titandata.EndToEndTest
 
 class KubernetesWorkflowTest : EndToEndTest() {
 

--- a/server/src/integration-test/kotlin/io/titandata/CommitsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/CommitsApiTest.kt
@@ -241,7 +241,8 @@ class CommitsApiTest : StringSpec() {
         }
 
         "create commit succeeds" {
-            every { context.createCommit(any(), any(), any()) } just Runs
+            every { context.commitVolumeSet(any(), any()) } just Runs
+            every { context.commitVolume(any(), any(), any(), any()) } just Runs
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/foo/commits") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody("{\"id\":\"hash\",\"properties\":{\"a\":\"b\",\"timestamp\":\"2019-04-28T23:04:06Z\"}}")
@@ -250,7 +251,7 @@ class CommitsApiTest : StringSpec() {
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
                 response.content shouldBe "{\"id\":\"hash\",\"properties\":{\"a\":\"b\",\"timestamp\":\"2019-04-28T23:04:06Z\"}}"
                 verify {
-                    context.createCommit(vs, "hash", emptyList())
+                    context.commitVolumeSet(vs, "hash")
                 }
             }
         }
@@ -273,7 +274,7 @@ class CommitsApiTest : StringSpec() {
             }
 
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
-            every { context.cloneVolume(any(), any(), any(), any()) } returns emptyMap()
+            every { context.cloneVolume(any(), any(), any(), any(), any()) } returns emptyMap()
 
             with(engine.handleRequest(HttpMethod.Post, "/v1/repositories/foo/commits/hash/checkout")) {
                 response.status() shouldBe HttpStatusCode.NoContent

--- a/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
@@ -226,7 +226,7 @@ class OperationsApiTest : StringSpec() {
             }
 
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
-            every { context.cloneVolume(any(), any(), any(), any()) } returns emptyMap()
+            every { context.cloneVolume(any(), any(), any(), any(), any()) } returns emptyMap()
 
             val result = engine.handleRequest(HttpMethod.Post, "/v1/repositories/foo/remotes/remote/commits/commit/push") {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -13,12 +13,13 @@ interface RuntimeContext {
     fun deleteVolumeSet(volumeSet: String)
     fun getVolumeStatus(volumeSet: String, volume: String): RepositoryVolumeStatus
 
-    fun createCommit(volumeSet: String, commitId: String, volumeNames: List<String>)
+    fun commitVolumeSet(volumeSet: String, commitId: String)
     fun getCommitStatus(volumeSet: String, commitId: String, volumeNames: List<String>): CommitStatus
     fun deleteCommit(volumeSet: String, commitId: String, volumeNames: List<String>)
 
     fun createVolume(volumeSet: String, volumeName: String): Map<String, Any>
-    fun cloneVolume(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeName: String): Map<String, Any>
+    fun cloneVolume(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeName: String, sourceConfig: Map<String, Any>): Map<String, Any>
+    fun commitVolume(volumeSet: String, commitId: String, volumeName: String, config: Map<String, Any>)
     fun deleteVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
     fun activateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
     fun deactivateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -12,10 +12,10 @@ interface RuntimeContext {
     fun cloneVolumeSet(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String)
     fun deleteVolumeSet(volumeSet: String)
     fun getVolumeStatus(volumeSet: String, volume: String): RepositoryVolumeStatus
-
+    fun deleteVolumeSetCommit(volumeSet: String, commitId: String)
     fun commitVolumeSet(volumeSet: String, commitId: String)
+
     fun getCommitStatus(volumeSet: String, commitId: String, volumeNames: List<String>): CommitStatus
-    fun deleteCommit(volumeSet: String, commitId: String, volumeNames: List<String>)
 
     fun createVolume(volumeSet: String, volumeName: String): Map<String, Any>
     fun cloneVolume(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeName: String, sourceConfig: Map<String, Any>): Map<String, Any>
@@ -23,4 +23,5 @@ interface RuntimeContext {
     fun deleteVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
     fun activateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
     fun deactivateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
+    fun deleteVolumeCommit(volumeSet: String, commitId: String, volumeName: String)
 }

--- a/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
@@ -53,7 +53,13 @@ class DockerZfsContext(
      * Clone an individual volume. Here's where we actually do the work of cloning the volume, and then making sure
      * we pass back an updated config with the proper mountpoint.
      */
-    override fun cloneVolume(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeName: String): Map<String, Any> {
+    override fun cloneVolume(
+        sourceVolumeSet: String,
+        sourceCommit: String,
+        newVolumeSet: String,
+        volumeName: String,
+        sourceConfig: Map<String, Any>
+    ): Map<String, Any> {
         executor.exec("zfs", "clone", "$poolName/data/$sourceVolumeSet/$volumeName@$sourceCommit",
                 "$poolName/data/$newVolumeSet/$volumeName")
         return mapOf("mountpoint" to "/var/lib/$poolName/mnt/$newVolumeSet/$volumeName")
@@ -100,7 +106,7 @@ class DockerZfsContext(
      * Create a new commit. Since we keep all volumes underneath the volume set, we can just do a recursive snapshot
      * of the set.
      */
-    override fun createCommit(volumeSet: String, commitId: String, volumeNames: List<String>) {
+    override fun commitVolumeSet(volumeSet: String, commitId: String) {
         executor.exec("zfs", "snapshot", "-r", "$poolName/data/$volumeSet@$commitId")
     }
 
@@ -146,6 +152,12 @@ class DockerZfsContext(
     override fun createVolume(volumeSet: String, volumeName: String): Map<String, Any> {
         executor.exec("zfs", "create", "$poolName/data/$volumeSet/$volumeName")
         return mapOf("mountpoint" to "/var/lib/$poolName/mnt/$volumeSet/$volumeName")
+    }
+
+    /**
+     * Commits are done at the volumeset level, so nothing to do for a volume.
+     */
+    override fun commitVolume(volumeSet: String, commitId: String, volumeName: String, config: Map<String, Any>) {
     }
 
     /**

--- a/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
@@ -135,7 +135,7 @@ class DockerZfsContext(
      * Delete a commit. The reaper will have ensured that any clones have been deleted prior to invoking this. We
      * can just recursively delete the snapshot at the level of the volume set.
      */
-    override fun deleteCommit(volumeSet: String, commitId: String, volumeNames: List<String>) {
+    override fun deleteVolumeSetCommit(volumeSet: String, commitId: String) {
         try {
             executor.exec("zfs", "destroy", "-r", "$poolName/data/$volumeSet@$commitId")
         } catch (e: CommandException) {
@@ -152,12 +152,6 @@ class DockerZfsContext(
     override fun createVolume(volumeSet: String, volumeName: String): Map<String, Any> {
         executor.exec("zfs", "create", "$poolName/data/$volumeSet/$volumeName")
         return mapOf("mountpoint" to "/var/lib/$poolName/mnt/$volumeSet/$volumeName")
-    }
-
-    /**
-     * Commits are done at the volumeset level, so nothing to do for a volume.
-     */
-    override fun commitVolume(volumeSet: String, commitId: String, volumeName: String, config: Map<String, Any>) {
     }
 
     /**
@@ -217,5 +211,17 @@ class DockerZfsContext(
             }
             throw e
         }
+    }
+
+    /**
+     * Commits are done at the volumeset level, so nothing to do for a volume.
+     */
+    override fun deleteVolumeCommit(volumeSet: String, commitId: String, volumeName: String) {
+    }
+
+    /**
+     * Commits are done at the volumeset level, so nothing to do for a volume.
+     */
+    override fun commitVolume(volumeSet: String, commitId: String, volumeName: String, config: Map<String, Any>) {
     }
 }

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -13,6 +13,8 @@ import io.kubernetes.client.util.Config
 import io.titandata.context.RuntimeContext
 import io.titandata.models.CommitStatus
 import io.titandata.models.RepositoryVolumeStatus
+import io.titandata.shell.CommandException
+import io.titandata.shell.CommandExecutor
 import org.slf4j.LoggerFactory
 
 /**
@@ -22,7 +24,8 @@ import org.slf4j.LoggerFactory
  */
 class KubernetesCsiContext : RuntimeContext {
     private var coreApi: CoreV1Api
-    private val namespace = "default"
+    private val defaultNamespace = "default"
+    private val executor = CommandExecutor()
 
     companion object {
         val log = LoggerFactory.getLogger(KubernetesCsiContext::class.java)
@@ -50,8 +53,13 @@ class KubernetesCsiContext : RuntimeContext {
         // Nothing to do
     }
 
+    override fun deleteVolumeSetCommit(volumeSet: String, commitId: String) {
+        // Nothing to do
+    }
+
     override fun createVolume(volumeSet: String, volumeName: String): Map<String, Any> {
         val name = "$volumeSet-$volumeName"
+        val size = "1Gi"
         val request = V1PersistentVolumeClaimBuilder()
                 .withMetadata(
                         V1ObjectMetaBuilder()
@@ -64,18 +72,23 @@ class KubernetesCsiContext : RuntimeContext {
                                 .withAccessModes("ReadWriteOnce")
                                 .withResources(
                                         V1ResourceRequirementsBuilder()
-                                                .withRequests(mapOf("storage" to Quantity.fromString("1Gi")))
+                                                .withRequests(mapOf("storage" to Quantity.fromString(size)))
                                                 .build()
                                 )
                                 .build())
                 .build()
-        val claim = coreApi.createNamespacedPersistentVolumeClaim(namespace, request, null, null, null)
+        val claim = coreApi.createNamespacedPersistentVolumeClaim(defaultNamespace, request, null, null, null)
         log.info("Created PersistentVolumeClaim '$name', status = ${claim.status.phase}")
-        return mapOf("pvc" to name)
+        return mapOf(
+                "pvc" to name,
+                "namespace" to defaultNamespace,
+                "size" to size)
     }
 
     override fun deleteVolume(volumeSet: String, volumeName: String, config: Map<String, Any>) {
         val pvc = config["pvc"] as? String ?: throw IllegalStateException("missing or invalid pvc name in volume config")
+        val namespace = config["namespace"] as? String ?: throw IllegalStateException("missing or invalid namespace in volume config")
+
         /*
          * Delete will always fail parsing the response, due to a limitation of  the swagger-generated client:
          *
@@ -84,21 +97,65 @@ class KubernetesCsiContext : RuntimeContext {
          * There's not much we can do other than to catch the error and then query the PVC to see if it still remains.
          */
         try {
-            coreApi.deleteNamespacedPersistentVolumeClaim(pvc, namespace, null, null, null, null, null, null)
-        } catch (e: JsonSyntaxException) {
-            // Ignore
-        }
+            try {
+                coreApi.deleteNamespacedPersistentVolumeClaim(pvc, namespace, null, null, null, null, null, null)
+            } catch (e: JsonSyntaxException) {
+                // Ignore
+            }
 
-        try {
             val result = coreApi.readNamespacedPersistentVolumeClaimStatus(pvc, namespace, null)
             throw IllegalStateException("Unable to delete PersistentVolumeClaim '$pvc', status = ${result.status.phase}")
         } catch (e: ApiException) {
+            // Deletion is idempotent, so this is designed to ignore not found errors from the original pvc deletion
             if (e.code != 404) {
                 throw e
             }
         }
 
         log.info("Deleted PersistentVolumeClaim '$pvc'")
+    }
+
+    /**
+     * The VolumeSnapshot APIs are currently in alpha and not part of the published REST API (even using
+     * StorageV1alpha1), so we have to invoke kubectl in order to manage them. This should be updated to use the native
+     * API when it is available.
+     */
+    override fun commitVolume(volumeSet: String, commitId: String, volumeName: String, config: Map<String, Any>) {
+        val pvc = config["pvc"] as? String ?: throw IllegalStateException("missing or invalid pvc name in volume config")
+        val size = config["size"] as? String ?: throw IllegalStateException("missing or invalid size in volume config")
+        val name = "$pvc-$commitId"
+
+        val file = createTempFile()
+        try {
+            file.writeText("apiVersion: snapshot.storage.k8s.io/v1alpha1\n" +
+                    "kind: VolumeSnapshot\n" +
+                    "metadata:\n" +
+                    "  name: $name\n" +
+                    "  labels:\n" +
+                    "    titanVolume: $volumeName\n" +
+                    "    titanCommit: $commitId\n" +
+                    "    titanSize: $size\n" +
+                    "spec:\n" +
+                    "  source:\n" +
+                    "    kind: PersistentVolumeClaim\n" +
+                    "    name: $pvc\n"
+            )
+
+            executor.exec("kubectl", "apply", "-f", file.path)
+        } finally {
+            file.delete()
+        }
+    }
+
+    override fun deleteVolumeCommit(volumeSet: String, commitId: String, volumeName: String) {
+        try {
+            executor.exec("kubectl", "delete", "volumesnapshot", "$volumeSet-$volumeName-$commitId")
+        } catch (e: CommandException) {
+            // Deletion is idempotent, so ignore errors if it doesn't exist
+            if (!e.output.contains("NotFound")) {
+                throw e
+            }
+        }
     }
 
     override fun cloneVolume(
@@ -116,14 +173,6 @@ class KubernetesCsiContext : RuntimeContext {
     }
 
     override fun getCommitStatus(volumeSet: String, commitId: String, volumeNames: List<String>): CommitStatus {
-        TODO("not implemented")
-    }
-
-    override fun commitVolume(volumeSet: String, commitId: String, volumeName: String, config: Map<String, Any>) {
-        TODO("not implemented")
-    }
-
-    override fun deleteCommit(volumeSet: String, commitId: String, volumeNames: List<String>) {
         TODO("not implemented")
     }
 

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -1,19 +1,102 @@
 package io.titandata.context.kubernetes
 
+import com.google.gson.JsonSyntaxException
+import io.kubernetes.client.ApiException
+import io.kubernetes.client.Configuration.setDefaultApiClient
+import io.kubernetes.client.apis.CoreV1Api
+import io.kubernetes.client.custom.Quantity
+import io.kubernetes.client.models.V1ObjectMetaBuilder
+import io.kubernetes.client.models.V1PersistentVolumeClaimBuilder
+import io.kubernetes.client.models.V1PersistentVolumeClaimSpecBuilder
+import io.kubernetes.client.models.V1ResourceRequirementsBuilder
+import io.kubernetes.client.util.Config
 import io.titandata.context.RuntimeContext
 import io.titandata.models.CommitStatus
 import io.titandata.models.RepositoryVolumeStatus
+import org.slf4j.LoggerFactory
 
+/**
+ * Kubernetes runtime context. In a k8s environment, we leverage CSI (Container Storage Interface) drivers to do
+ * snapshot and cloning of data for us. Each volume is a PersistentVolumeClaim, while every commit is a
+ * VolumeSnapshot.
+ */
 class KubernetesCsiContext : RuntimeContext {
+    private var coreApi: CoreV1Api
+    private val namespace = "default"
+
+    companion object {
+        val log = LoggerFactory.getLogger(KubernetesCsiContext::class.java)
+    }
+
+    init {
+        val client = Config.defaultClient()
+        setDefaultApiClient(client)
+        coreApi = CoreV1Api()
+    }
+
     override fun createVolumeSet(volumeSet: String) {
-        TODO("not implemented")
+        // Nothing to do
     }
 
     override fun cloneVolumeSet(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String) {
-        TODO("not implemented")
+        // Nothing to do
     }
 
     override fun deleteVolumeSet(volumeSet: String) {
+        // Nothing to do
+    }
+
+    override fun createVolume(volumeSet: String, volumeName: String): Map<String, Any> {
+        val name = "$volumeSet-$volumeName"
+        val request = V1PersistentVolumeClaimBuilder()
+                .withMetadata(
+                        V1ObjectMetaBuilder()
+                                .withName(name)
+                                .withLabels(mapOf("titanVolume" to volumeName))
+                                .build()
+                )
+                .withSpec(
+                        V1PersistentVolumeClaimSpecBuilder()
+                                .withAccessModes("ReadWriteOnce")
+                                .withResources(
+                                        V1ResourceRequirementsBuilder()
+                                                .withRequests(mapOf("storage" to Quantity.fromString("1Gi")))
+                                                .build()
+                                )
+                                .build())
+                .build()
+        val claim = coreApi.createNamespacedPersistentVolumeClaim(namespace, request, null, null, null)
+        log.info("Created PersistentVolumeClaim '$name', status = ${claim.status.phase}")
+        return mapOf("pvc" to name)
+    }
+
+    override fun deleteVolume(volumeSet: String, volumeName: String, config: Map<String, Any>) {
+        val pvc = config["pvc"] as? String ?: throw IllegalStateException("missing or invalid pvc name in volume config")
+        /*
+         * Delete will always fail parsing the response, due to a limitation of  the swagger-generated client:
+         *
+         *      https://github.com/kubernetes-client/java/issues/86
+         *
+         * There's not much we can do other than to catch the error and then query the PVC to see if it still remains.
+         */
+        try {
+            coreApi.deleteNamespacedPersistentVolumeClaim(pvc, namespace, null, null, null, null, null, null)
+        } catch (e: JsonSyntaxException) {
+            // Ignore
+        }
+        try {
+            val result = coreApi.readNamespacedPersistentVolumeClaimStatus(pvc, namespace, null)
+            throw IllegalStateException("Unable to delete PersistentVolumeClaim '$pvc', status = ${result.status.phase}")
+        } catch (e: ApiException) {
+            if (e.code != 404) {
+                throw e
+            }
+        }
+
+        log.info("Deleted PersistentVolumeClaim '$pvc'")
+    }
+
+    override fun cloneVolume(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeName: String): Map<String, Any> {
         TODO("not implemented")
     }
 
@@ -30,18 +113,6 @@ class KubernetesCsiContext : RuntimeContext {
     }
 
     override fun deleteCommit(volumeSet: String, commitId: String, volumeNames: List<String>) {
-        TODO("not implemented")
-    }
-
-    override fun createVolume(volumeSet: String, volumeName: String): Map<String, Any> {
-        TODO("not implemented")
-    }
-
-    override fun cloneVolume(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeName: String): Map<String, Any> {
-        TODO("not implemented")
-    }
-
-    override fun deleteVolume(volumeSet: String, volumeName: String, config: Map<String, Any>) {
         TODO("not implemented")
     }
 

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -46,6 +46,10 @@ class KubernetesCsiContext : RuntimeContext {
         // Nothing to do
     }
 
+    override fun commitVolumeSet(volumeSet: String, commitId: String) {
+        // Nothing to do
+    }
+
     override fun createVolume(volumeSet: String, volumeName: String): Map<String, Any> {
         val name = "$volumeSet-$volumeName"
         val request = V1PersistentVolumeClaimBuilder()
@@ -84,6 +88,7 @@ class KubernetesCsiContext : RuntimeContext {
         } catch (e: JsonSyntaxException) {
             // Ignore
         }
+
         try {
             val result = coreApi.readNamespacedPersistentVolumeClaimStatus(pvc, namespace, null)
             throw IllegalStateException("Unable to delete PersistentVolumeClaim '$pvc', status = ${result.status.phase}")
@@ -96,7 +101,13 @@ class KubernetesCsiContext : RuntimeContext {
         log.info("Deleted PersistentVolumeClaim '$pvc'")
     }
 
-    override fun cloneVolume(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeName: String): Map<String, Any> {
+    override fun cloneVolume(
+        sourceVolumeSet: String,
+        sourceCommit: String,
+        newVolumeSet: String,
+        volumeName: String,
+        sourceConfig: Map<String, Any>
+    ): Map<String, Any> {
         TODO("not implemented")
     }
 
@@ -104,11 +115,11 @@ class KubernetesCsiContext : RuntimeContext {
         TODO("not implemented")
     }
 
-    override fun createCommit(volumeSet: String, commitId: String, volumeNames: List<String>) {
+    override fun getCommitStatus(volumeSet: String, commitId: String, volumeNames: List<String>): CommitStatus {
         TODO("not implemented")
     }
 
-    override fun getCommitStatus(volumeSet: String, commitId: String, volumeNames: List<String>): CommitStatus {
+    override fun commitVolume(volumeSet: String, commitId: String, volumeName: String, config: Map<String, Any>) {
         TODO("not implemented")
     }
 

--- a/server/src/main/kotlin/io/titandata/orchestrator/CommitOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/CommitOrchestrator.kt
@@ -42,7 +42,10 @@ class CommitOrchestrator(val services: ServiceLocator) {
             services.metadata.listVolumes(volumeSet)
         }
 
-        services.context.createCommit(volumeSet, newCommit.id, volumes.map { it.name })
+        services.context.commitVolumeSet(volumeSet, newCommit.id)
+        for (v in volumes) {
+            services.context.commitVolume(volumeSet, newCommit.id, v.name, v.config)
+        }
         return newCommit
     }
 
@@ -95,14 +98,14 @@ class CommitOrchestrator(val services: ServiceLocator) {
         }
 
         val volumes = transaction {
-            services.metadata.listVolumes(newVolumeSet).map { it.name }
+            services.metadata.listVolumes(newVolumeSet)
         }
 
         services.context.cloneVolumeSet(sourceVolumeSet, commit, newVolumeSet)
         for (v in volumes) {
-            val config = services.context.cloneVolume(sourceVolumeSet, commit, newVolumeSet, v)
+            val config = services.context.cloneVolume(sourceVolumeSet, commit, newVolumeSet, v.name, v.config)
             transaction {
-                services.metadata.updateVolumeConfig(newVolumeSet, v, config)
+                services.metadata.updateVolumeConfig(newVolumeSet, v.name, config)
             }
         }
 

--- a/server/src/main/kotlin/io/titandata/orchestrator/OperationOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/OperationOrchestrator.kt
@@ -161,13 +161,13 @@ class OperationOrchestrator(val services: ServiceLocator) {
         } else {
             val (sourceVolumeSet, volumes) = transaction {
                 val vs = services.metadata.getCommit(repo, commit).first
-                Pair(vs, services.metadata.listVolumes(vs).map { it.name })
+                Pair(vs, services.metadata.listVolumes(vs))
             }
             services.context.cloneVolumeSet(sourceVolumeSet, commit, volumeSet)
             for (v in volumes) {
-                val config = services.context.cloneVolume(sourceVolumeSet, commit, volumeSet, v)
+                val config = services.context.cloneVolume(sourceVolumeSet, commit, volumeSet, v.name, v.config)
                 transaction {
-                    services.metadata.updateVolumeConfig(volumeSet, v, config)
+                    services.metadata.updateVolumeConfig(volumeSet, v.name, config)
                 }
             }
         }

--- a/server/src/main/kotlin/io/titandata/orchestrator/Reaper.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/Reaper.kt
@@ -74,10 +74,13 @@ class Reaper(val services: ServiceLocator) : Runnable {
         var ret = false
         for (c in commits) {
             val volumes = transaction {
-                services.metadata.listVolumes(c.volumeSet).map { it.name }
+                services.metadata.listVolumes(c.volumeSet)
             }
             try {
-                services.context.deleteCommit(c.volumeSet, c.guid, volumes)
+                services.context.deleteVolumeSetCommit(c.volumeSet, c.guid)
+                for (v in volumes) {
+                    services.context.deleteVolumeCommit(c.volumeSet, c.guid, v.name)
+                }
                 transaction {
                     services.metadata.deleteCommit(c)
                 }

--- a/server/src/scripts/run
+++ b/server/src/scripts/run
@@ -16,6 +16,13 @@
 #                   in any docker environment even if kernel ZFS support isn't present.
 #
 
+function log_error {
+  local ts=$(timestamp)
+  local msg=$1
+  echo "$ts $log_delimiter ERROR $msg"
+  exit 1
+}
+
 #
 # Mount the database filesystem for the titan server.
 #

--- a/server/src/scripts/util.sh
+++ b/server/src/scripts/util.sh
@@ -71,7 +71,7 @@ function log_begin {
 
 #
 # Log the beginning of a step. This will be picked up by the CLI and displayed while the
-# subsequent code is running, When a TITAN END message is received, then the CLI will display
+# subsequent code is running, when a titan end message is received, then the cli will display
 # the step as completed and move on.
 #
 function log_start {

--- a/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
+++ b/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
@@ -139,9 +139,9 @@ class DockerZfsContextTest : StringSpec() {
             }
         }
 
-        "delete commit succeeds" {
+        "delete volumeset commit succeeds" {
             every { executor.exec(*anyVararg()) } returns ""
-            provider.deleteCommit("vs", "commit", listOf("one", "two"))
+            provider.deleteVolumeSetCommit("vs", "commit")
             verifyAll {
                 executor.exec("zfs", "destroy", "-r", "test/data/vs@commit")
             }
@@ -149,10 +149,14 @@ class DockerZfsContextTest : StringSpec() {
 
         "delete commit ignores no snapshot exception" {
             every { executor.exec(*anyVararg()) } throws CommandException("", 1, "could not find any snapshots to destroy")
-            provider.deleteCommit("vs", "commit", listOf("one", "two"))
+            provider.deleteVolumeSetCommit("vs", "commit")
             verifyAll {
                 executor.exec("zfs", "destroy", "-r", "test/data/vs@commit")
             }
+        }
+
+        "delete volume commit succeeds" {
+            provider.deleteVolumeCommit("vs", "commit", "volume")
         }
 
         "create volume succeeds" {

--- a/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
+++ b/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
@@ -63,7 +63,7 @@ class DockerZfsContextTest : StringSpec() {
 
         "clone volume clones dataset" {
             every { executor.exec(*anyVararg()) } returns ""
-            provider.cloneVolume("source", "commit", "dest", "vol")
+            provider.cloneVolume("source", "commit", "dest", "vol", emptyMap())
             verifyAll {
                 executor.exec("zfs", "clone", "test/data/source/vol@commit", "test/data/dest/vol")
             }
@@ -113,12 +113,16 @@ class DockerZfsContextTest : StringSpec() {
             }
         }
 
-        "create commit succeeds" {
+        "commit volumeset succeeds" {
             every { executor.exec(*anyVararg()) } returns ""
-            provider.createCommit("vs", "commit", listOf("one", "two"))
+            provider.commitVolumeSet("vs", "commit")
             verifyAll {
                 executor.exec("zfs", "snapshot", "-r", "test/data/vs@commit")
             }
+        }
+
+        "commit volume succeeds" {
+            provider.commitVolume("vs", "commit", "volume", emptyMap())
         }
 
         "get commit sums volume sizes" {

--- a/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
@@ -62,7 +62,8 @@ class OperationExecutorTest : StringSpec() {
         }
         val ret = MockKAnnotations.init(this)
         services.setRemoteProvider("nop", nopProvider)
-        every { context.createCommit(any(), any(), any()) } just Runs
+        every { context.commitVolumeSet(any(), any()) } just Runs
+        every { context.commitVolume(any(), any(), any(), any()) } just Runs
         return ret
     }
 
@@ -249,7 +250,8 @@ class OperationExecutorTest : StringSpec() {
 
             verify {
                 nopProvider.syncVolume(any(), "volume", "volume", "/mountpoint", "/scratch")
-                context.createCommit(data.operation.id, "id", listOf("volume"))
+                context.commitVolumeSet(data.operation.id, "id")
+                context.commitVolume(data.operation.id, "id", "volume", mapOf("mountpoint" to "/mountpoint"))
             }
         }
 

--- a/server/src/test/kotlin/io/titandata/orchestrator/CommitOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/CommitOrchestratorTest.kt
@@ -59,7 +59,8 @@ class CommitOrchestratorTest : StringSpec() {
             services.metadata.createVolume(vs, Volume("vol2"))
         }
         val ret = MockKAnnotations.init(this)
-        every { context.createCommit(any(), any(), any()) } just Runs
+        every { context.commitVolumeSet(any(), any()) } just Runs
+        every { context.commitVolume(any(), any(), any(), any()) } just Runs
         return ret
     }
 
@@ -103,7 +104,9 @@ class CommitOrchestratorTest : StringSpec() {
             volumeSet shouldBe vs
             commit.id shouldBe "id"
             verify {
-                context.createCommit(vs, "id", listOf("vol1", "vol2"))
+                context.commitVolumeSet(vs, "id")
+                context.commitVolume(vs, "id", "vol1", emptyMap())
+                context.commitVolume(vs, "id", "vol2", emptyMap())
             }
         }
 
@@ -113,7 +116,7 @@ class CommitOrchestratorTest : StringSpec() {
             }
             services.commits.createCommit("foo", Commit(id = "id", properties = mapOf("a" to "b")), vs2)
             verify {
-                context.createCommit(vs2, "id", listOf())
+                context.commitVolumeSet(vs2, "id")
             }
         }
 
@@ -237,7 +240,7 @@ class CommitOrchestratorTest : StringSpec() {
 
         "checkout commit succeeds" {
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
-            every { context.cloneVolume(any(), any(), any(), any()) } returns emptyMap()
+            every { context.cloneVolume(any(), any(), any(), any(), any()) } returns emptyMap()
             every { context.createVolume(any(), any()) } returns emptyMap()
             every { reaper.signal() } just Runs
             services.commits.createCommit("foo", Commit("id"))
@@ -256,8 +259,8 @@ class CommitOrchestratorTest : StringSpec() {
             verify {
                 reaper.signal()
                 context.cloneVolumeSet(vs, "id", vs2)
-                context.cloneVolume(vs, "id", vs2, "vol1")
-                context.cloneVolume(vs, "id", vs2, "vol2")
+                context.cloneVolume(vs, "id", vs2, "vol1", emptyMap())
+                context.cloneVolume(vs, "id", vs2, "vol2", emptyMap())
             }
         }
 

--- a/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
@@ -343,7 +343,7 @@ class OperationOrchestratorTest : StringSpec() {
 
         "create storage with existing commit clones volume set" {
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
-            every { context.cloneVolume(any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint2")
+            every { context.cloneVolume(any(), any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint2")
 
             val (commitVs, commit) = transaction {
                 val cvs = services.metadata.createVolumeSet("foo")
@@ -367,7 +367,7 @@ class OperationOrchestratorTest : StringSpec() {
 
             verify {
                 context.cloneVolumeSet(commitVs, commit.id, newVs)
-                context.cloneVolume(commitVs, commit.id, newVs, "volume")
+                context.cloneVolume(commitVs, commit.id, newVs, "volume", emptyMap())
             }
         }
 
@@ -448,7 +448,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { context.deactivateVolume(any(), any(), any()) } just Runs
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
             every { context.deleteVolume(any(), any(), any()) } just Runs
-            every { context.createCommit(any(), any(), any()) } just Runs
+            every { context.commitVolumeSet(any(), any()) } just Runs
+            every { context.commitVolume(any(), any(), any(), any()) } just Runs
             every { context.createVolumeSet(any()) } just Runs
             every { nopProvider.syncVolume(any(), any(), any(), any(), any()) } just Runs
 
@@ -531,7 +532,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { context.deactivateVolume(any(), any(), any()) } just Runs
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
             every { context.deleteVolume(any(), any(), any()) } just Runs
-            every { context.createCommit(any(), any(), any()) } just Runs
+            every { context.commitVolumeSet(any(), any()) } just Runs
+            every { context.commitVolume(any(), any(), any(), any()) } just Runs
             every { context.createVolumeSet(any()) } just Runs
 
             var op = services.operations.startPull("foo", "remote", "commit", params)
@@ -550,9 +552,10 @@ class OperationOrchestratorTest : StringSpec() {
             every { context.deactivateVolume(any(), any(), any()) } just Runs
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
             every { context.deleteVolume(any(), any(), any()) } just Runs
-            every { context.createCommit(any(), any(), any()) } just Runs
+            every { context.commitVolumeSet(any(), any()) } just Runs
+            every { context.commitVolume(any(), any(), any(), any()) } just Runs
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
-            every { context.cloneVolume(any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
+            every { context.cloneVolume(any(), any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
 
             var op = services.operations.startPush("foo", "remote", "id", params)
             op.commitId shouldBe "id"
@@ -580,7 +583,7 @@ class OperationOrchestratorTest : StringSpec() {
                 services.metadata.createCommit("foo", vs, Commit("id"))
             }
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
-            every { context.cloneVolume(any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
+            every { context.cloneVolume(any(), any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
             every { nopProvider.startOperation(any()) } throws Exception("error")
 
             var op = services.operations.startPush("foo", "remote", "id", params)
@@ -603,7 +606,7 @@ class OperationOrchestratorTest : StringSpec() {
                 services.metadata.createCommit("foo", vs, Commit("id"))
             }
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
-            every { context.cloneVolume(any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
+            every { context.cloneVolume(any(), any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
             every { nopProvider.startOperation(any()) } throws InterruptedException()
 
             var op = services.operations.startPush("foo", "remote", "id", params)
@@ -641,9 +644,10 @@ class OperationOrchestratorTest : StringSpec() {
             every { context.deactivateVolume(any(), any(), any()) } just Runs
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
             every { context.deleteVolume(any(), any(), any()) } just Runs
-            every { context.createCommit(any(), any(), any()) } just Runs
+            every { context.commitVolumeSet(any(), any()) } just Runs
+            every { context.commitVolume(any(), any(), any(), any()) } just Runs
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
-            every { context.cloneVolume(any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
+            every { context.cloneVolume(any(), any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
 
             var op = services.operations.startPush("foo", "remote", "id", params)
             services.operations.getExecutor("foo", op.id).join()
@@ -662,9 +666,10 @@ class OperationOrchestratorTest : StringSpec() {
             every { context.deactivateVolume(any(), any(), any()) } just Runs
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
             every { context.deleteVolume(any(), any(), any()) } just Runs
-            every { context.createCommit(any(), any(), any()) } just Runs
+            every { context.commitVolumeSet(any(), any()) } just Runs
+            every { context.commitVolume(any(), any(), any(), any()) } just Runs
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
-            every { context.cloneVolume(any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
+            every { context.cloneVolume(any(), any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
 
             services.operations.loadState()
             services.operations.getExecutor("foo", vs).join()

--- a/server/src/test/kotlin/io/titandata/orchestrator/ReaperTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/ReaperTest.kt
@@ -236,10 +236,12 @@ class ReaperTest : StringSpec() {
                 services.metadata.markCommitDeleting("foo", "id")
                 vs
             }
-            every { context.deleteCommit(any(), any(), any()) } just Runs
+            every { context.deleteVolumeSetCommit(any(), any()) } just Runs
+            every { context.deleteVolumeCommit(any(), any(), any()) } just Runs
             services.reaper.reapCommits() shouldBe true
             verify {
-                context.deleteCommit(vs, "id", listOf("volume"))
+                context.deleteVolumeSetCommit(vs, "id")
+                context.deleteVolumeCommit(vs, "id", "volume")
             }
             transaction {
                 services.metadata.listDeletingCommits().shouldBeEmpty()

--- a/server/src/test/kotlin/io/titandata/orchestrator/RepositoryOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/RepositoryOrchestratorTest.kt
@@ -164,7 +164,8 @@ class RepositoryOrchestratorTest : StringSpec() {
             every { context.createVolume(any(), any()) } returns emptyMap()
             services.volumes.createVolume("foo", Volume("vol1"))
             services.volumes.createVolume("foo", Volume("vol2"))
-            every { context.createCommit(any(), any(), any()) } just Runs
+            every { context.commitVolumeSet(any(), any()) } just Runs
+            every { context.commitVolume(any(), any(), any(), any()) } just Runs
             services.commits.createCommit("foo", Commit(id = "id"))
             every { context.getVolumeStatus(any(), any()) } returns RepositoryVolumeStatus(
                 name = "vol", logicalSize = 20, actualSize = 10)


### PR DESCRIPTION
## Proposed Changes

This adds k8s implementation for create and delete volume. In the process, I rejiggered some of the packages for endtoend tests. Note that there are some big questions about how we manage volume configuration unique to k8s, most notably volume sizes (which don't exist in ZFS), but also things like non-default k8s configurations and storage classes. For now I'm just hard-coding everything (including a 1GiB size for all volumes) through the alpha.

## Testing

`gradle rebuild test integrationTest endtoeendTest` including k8s endtoend tests.