### PR TITLE
k8s status

### DIFF
--- a/client/src/main/kotlin/io/titandata/client/apis/VolumesApi.kt
+++ b/client/src/main/kotlin/io/titandata/client/apis/VolumesApi.kt
@@ -12,6 +12,7 @@ import io.titandata.client.infrastructure.ResponseType
 import io.titandata.client.infrastructure.ServerException
 import io.titandata.client.infrastructure.Success
 import io.titandata.models.Volume
+import io.titandata.models.VolumeStatus
 
 class VolumesApi(basePath: String = "http://localhost:5001") : ApiClient(basePath) {
 
@@ -55,6 +56,29 @@ class VolumesApi(basePath: String = "http://localhost:5001") : ApiClient(basePat
 
         return when (response.responseType) {
             ResponseType.Success -> (response as Success<*>).data as Volume
+            ResponseType.ClientError -> throw ClientException.fromResponse(gson, response)
+            ResponseType.ServerError -> throw ServerException.fromResponse(gson, response)
+            else -> throw NotImplementedError(response.responseType.toString())
+        }
+    }
+
+    fun getVolumeStatus(repositoryName: String, volumeName: String) : VolumeStatus {
+        val localVariableBody: Any? = null
+        val localVariableQuery: Map<String,List<String>> = mapOf()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        val localVariableConfig = RequestConfig(
+                RequestMethod.GET,
+                "/v1/repositories/$repositoryName/volumes/$volumeName/status",
+                query = localVariableQuery,
+                headers = localVariableHeaders
+        )
+        val response = request<VolumeStatus>(
+                localVariableConfig,
+                localVariableBody
+        )
+
+        return when (response.responseType) {
+            ResponseType.Success -> (response as Success<*>).data as VolumeStatus
             ResponseType.ClientError -> throw ClientException.fromResponse(gson, response)
             ResponseType.ServerError -> throw ServerException.fromResponse(gson, response)
             else -> throw NotImplementedError(response.responseType.toString())

--- a/client/src/main/kotlin/io/titandata/models/CommitStatus.kt
+++ b/client/src/main/kotlin/io/titandata/models/CommitStatus.kt
@@ -7,5 +7,7 @@ package io.titandata.models
 data class CommitStatus(
     var logicalSize: Long,
     var actualSize: Long,
-    var uniqueSize: Long
+    var uniqueSize: Long,
+    var ready: Boolean,
+    var error: String?
 )

--- a/client/src/main/kotlin/io/titandata/models/RepositoryStatus.kt
+++ b/client/src/main/kotlin/io/titandata/models/RepositoryStatus.kt
@@ -6,6 +6,5 @@ package io.titandata.models
 
 data class RepositoryStatus(
     var lastCommit: String? = null,
-    var sourceCommit: String? = null,
-    var volumeStatus: List<RepositoryVolumeStatus>
+    var sourceCommit: String? = null
 )

--- a/client/src/main/kotlin/io/titandata/models/VolumeStatus.kt
+++ b/client/src/main/kotlin/io/titandata/models/VolumeStatus.kt
@@ -4,9 +4,11 @@
 
 package io.titandata.models
 
-data class RepositoryVolumeStatus(
+data class VolumeStatus(
     var name: String,
     var logicalSize: Long,
     var actualSize: Long,
-    var properties: Map<String, Any> = emptyMap()
+    var properties: Map<String, Any> = emptyMap(),
+    var ready: Boolean,
+    var error: String?
 )

--- a/server/src/endtoend-test/kotlin/io/titandata/EndToEndTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/EndToEndTest.kt
@@ -16,10 +16,9 @@ import io.titandata.models.ProgressEntry
 import io.titandata.serialization.RemoteUtil
 import org.slf4j.LoggerFactory
 
-abstract class EndToEndTest : StringSpec() {
+abstract class EndToEndTest(val titanContext: String = "docker-zfs") : StringSpec() {
 
-    val dockerUtil = DockerUtil()
-    val kubernetesUtil = DockerUtil("kubernetes-csi")
+    val dockerUtil = DockerUtil(titanContext)
     val remoteUtil = RemoteUtil()
     val url = "http://localhost:${dockerUtil.port}"
     val repoApi = RepositoriesApi(url)

--- a/server/src/endtoend-test/kotlin/io/titandata/docker/DockerVolumeTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/docker/DockerVolumeTest.kt
@@ -112,23 +112,6 @@ class DockerVolumeTest : EndToEndTest() {
             getTag(commit, "a") shouldBe "b"
         }
 
-        "get commit status succeeds" {
-            val status = commitApi.getCommitStatus("foo", "id")
-            status.logicalSize shouldNotBe 0
-            status.actualSize shouldNotBe 0
-            status.uniqueSize shouldBe 0
-        }
-
-        "get repository status succeeds" {
-            val status = repoApi.getRepositoryStatus("foo")
-            status.sourceCommit shouldBe "id"
-            status.lastCommit shouldBe "id"
-            status.volumeStatus.size shouldBe 1
-            status.volumeStatus[0].name shouldBe "vol"
-            status.volumeStatus[0].actualSize shouldNotBe 0
-            status.volumeStatus[0].logicalSize shouldNotBe 0
-        }
-
         "write new local value succeeds" {
             dockerUtil.writeFile("foo", "vol", "testfile", "Goodbye")
             val result = dockerUtil.readFile("foo", "vol", "testfile")

--- a/server/src/endtoend-test/kotlin/io/titandata/docker/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/docker/LocalWorkflowTest.kt
@@ -183,10 +183,15 @@ class LocalWorkflowTest : EndToEndTest() {
             val status = repoApi.getRepositoryStatus("foo")
             status.sourceCommit shouldBe "id"
             status.lastCommit shouldBe "id"
-            status.volumeStatus.size shouldBe 1
-            status.volumeStatus[0].name shouldBe "vol"
-            status.volumeStatus[0].actualSize shouldNotBe 0
-            status.volumeStatus[0].logicalSize shouldNotBe 0
+        }
+
+        "get volume status succeeds" {
+            val volumeStatus = volumeApi.getVolumeStatus("foo", "vol")
+            volumeStatus.name shouldBe "vol"
+            volumeStatus.actualSize shouldNotBe 0
+            volumeStatus.logicalSize shouldNotBe 0
+            volumeStatus.ready shouldBe true
+            volumeStatus.error shouldBe null
         }
 
         "commit shows up in list" {

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
@@ -1,23 +1,10 @@
 package io.titandata.kubernetes
 
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
 import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
-import io.kotlintest.specs.StringSpec
 import io.kubernetes.client.ApiException
-import io.kubernetes.client.apis.CoreV1Api
-import io.kubernetes.client.models.V1ContainerBuilder
-import io.kubernetes.client.models.V1ObjectMetaBuilder
-import io.kubernetes.client.models.V1PersistentVolumeClaimVolumeSourceBuilder
-import io.kubernetes.client.models.V1PodBuilder
-import io.kubernetes.client.models.V1PodSpecBuilder
-import io.kubernetes.client.models.V1VolumeBuilder
-import io.kubernetes.client.models.V1VolumeMountBuilder
-import io.titandata.context.kubernetes.KubernetesCsiContext
 import io.titandata.shell.CommandException
-import io.titandata.shell.CommandExecutor
 import java.util.UUID
 
 /**
@@ -25,109 +12,19 @@ import java.util.UUID
  * instantiated titan server. Rather, it's testing the internals of the KubernetesContext driver with a real
  * k8s environment (hence the reason for it being an end2end test).
  */
-class KubernetesContextTest : StringSpec() {
+class KubernetesContextTest : KubernetesTest() {
 
-    private val context: KubernetesCsiContext
-    private val coreApi: CoreV1Api
     private val vs = UUID.randomUUID().toString()
     private val vs2 = UUID.randomUUID().toString()
-    private val namespace = "default"
-    private val executor = CommandExecutor()
 
     private lateinit var volumeConfig: Map<String, Any>
     private lateinit var cloneConfig: Map<String, Any>
-
-    // TODO - clean up any partially created resources "vs-"
-
-    init {
-        val storageClass = System.getProperty("k8s.storageClass")
-        val snapshotClass = System.getProperty("k8s.snapshotClass")
-        context = KubernetesCsiContext(storageClass = storageClass, snapshotClass = snapshotClass)
-        coreApi = CoreV1Api()
-    }
-
-    private fun getVolumeStatus(name: String): String {
-        return coreApi.readNamespacedPersistentVolumeClaimStatus(name, namespace, null).status.phase
-    }
-
-    private fun waitForVolume(name: String) {
-        var status = getVolumeStatus(name)
-        // Volumes can remain in pending mode if the volume binding mode is WaitForFirstConsumer
-        while (status != "Pending" && status != "Bound") {
-            Thread.sleep(1000)
-            status = getVolumeStatus(name)
-        }
-    }
-
-    private fun getSnapshotStatus(name: String): JsonObject? {
-        val output = executor.exec("kubectl", "get", "volumesnapshot", name, "-o", "json")
-        val json = JsonParser.parseString(output)
-        return json.asJsonObject.getAsJsonObject("status")
-    }
-
-    private fun waitForSnapshot(name: String) {
-        var ready = getSnapshotStatus(name)?.get("readyToUse")?.asString
-        while (ready != "true") {
-            Thread.sleep(1000)
-            val status = getSnapshotStatus(name)
-            if (status != null) {
-                ready = status.get("readyToUse").asString
-                val error = status.getAsJsonObject("error")?.get("message")?.asString
-                error shouldBe null
-            }
-        }
-    }
-
-    private fun getPodStatus(name: String): Boolean {
-        var pod = coreApi.readNamespacedPod(name, context.defaultNamespace, null, null, null)
-        val statuses = pod?.status?.containerStatuses ?: return false
-        for (container in statuses) {
-            if (container.restartCount != 0) {
-                throw Exception("container ${container.name} restarted ${container.restartCount} times")
-            }
-            if (!container.isReady) {
-                return false
-            }
-        }
-        return true
-    }
-
-    private fun waitForPod(name: String) {
-        var ready = getPodStatus(name)
-        while (!ready) {
-            Thread.sleep(1000)
-            ready = getPodStatus(name)
-        }
-    }
-
-    private fun launchPod(name: String, claim: String) {
-        val request = V1PodBuilder()
-                .withMetadata(V1ObjectMetaBuilder().withName(name).build())
-                .withSpec(V1PodSpecBuilder()
-                        .withContainers(V1ContainerBuilder()
-                                .withName("test")
-                                .withImage("ubuntu:bionic")
-                                .withCommand("/bin/sh")
-                                .withArgs("-c", "while true; do sleep 5; done")
-                                .withVolumeMounts(V1VolumeMountBuilder()
-                                        .withName("data")
-                                        .withMountPath("/data")
-                                        .build())
-                                .build())
-                        .withVolumes(V1VolumeBuilder()
-                                .withName("data")
-                                .withPersistentVolumeClaim(V1PersistentVolumeClaimVolumeSourceBuilder().withClaimName(claim).build())
-                                .build())
-                        .build())
-                .build()
-        coreApi.createNamespacedPod(context.defaultNamespace, request, null, null, null)
-    }
 
     init {
         "create volume succeeds" {
             volumeConfig = context.createVolume(vs, "test")
             volumeConfig["pvc"] shouldBe "$vs-test"
-            waitForVolume("$vs-test")
+            waitForVolume(vs, "test", volumeConfig)
         }
 
         "create pod succeeds" {
@@ -141,7 +38,7 @@ class KubernetesContextTest : StringSpec() {
 
         "create commit succeeds" {
             context.commitVolume(vs, "id", "test", volumeConfig)
-            waitForSnapshot("$vs-test-id")
+            waitForCommit(vs, "id", listOf("test"))
         }
 
         "delete pod succeeds" {
@@ -150,7 +47,7 @@ class KubernetesContextTest : StringSpec() {
 
         "clone volume succeeds" {
             cloneConfig = context.cloneVolume(vs, "id", vs2, "test", volumeConfig)
-            waitForVolume("$vs2-test")
+            waitForVolume(vs2, "test", cloneConfig)
         }
 
         "create cloned pod succeeds" {

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
@@ -9,9 +9,7 @@ import io.kotlintest.specs.StringSpec
 import io.kubernetes.client.ApiException
 import io.kubernetes.client.apis.CoreV1Api
 import io.kubernetes.client.models.V1ContainerBuilder
-import io.kubernetes.client.models.V1ObjectMeta
 import io.kubernetes.client.models.V1ObjectMetaBuilder
-import io.kubernetes.client.models.V1PersistentVolumeClaimVolumeSource
 import io.kubernetes.client.models.V1PersistentVolumeClaimVolumeSourceBuilder
 import io.kubernetes.client.models.V1PodBuilder
 import io.kubernetes.client.models.V1PodSpecBuilder
@@ -29,8 +27,8 @@ import java.util.UUID
  */
 class KubernetesContextTest : StringSpec() {
 
-    private val context : KubernetesCsiContext
-    private val coreApi : CoreV1Api
+    private val context: KubernetesCsiContext
+    private val coreApi: CoreV1Api
     private val vs = UUID.randomUUID().toString()
     private val vs2 = UUID.randomUUID().toString()
     private val namespace = "default"
@@ -48,7 +46,7 @@ class KubernetesContextTest : StringSpec() {
         coreApi = CoreV1Api()
     }
 
-    private fun getVolumeStatus(name: String) : String {
+    private fun getVolumeStatus(name: String): String {
         return coreApi.readNamespacedPersistentVolumeClaimStatus(name, namespace, null).status.phase
     }
 
@@ -61,7 +59,7 @@ class KubernetesContextTest : StringSpec() {
         }
     }
 
-    private fun getSnapshotStatus(name: String) : JsonObject? {
+    private fun getSnapshotStatus(name: String): JsonObject? {
         val output = executor.exec("kubectl", "get", "volumesnapshot", name, "-o", "json")
         val json = JsonParser.parseString(output)
         return json.asJsonObject.getAsJsonObject("status")
@@ -80,7 +78,7 @@ class KubernetesContextTest : StringSpec() {
         }
     }
 
-    private fun getPodStatus(name: String) : Boolean {
+    private fun getPodStatus(name: String): Boolean {
         var pod = coreApi.readNamespacedPod(name, context.defaultNamespace, null, null, null)
         val statuses = pod?.status?.containerStatuses ?: return false
         for (container in statuses) {
@@ -108,7 +106,7 @@ class KubernetesContextTest : StringSpec() {
                 .withSpec(V1PodSpecBuilder()
                         .withContainers(V1ContainerBuilder()
                                 .withName("test")
-                                .withImage("ubuntu")
+                                .withImage("ubuntu:bionic")
                                 .withCommand("/bin/sh")
                                 .withArgs("-c", "while true; do sleep 5; done")
                                 .withVolumeMounts(V1VolumeMountBuilder()
@@ -147,7 +145,7 @@ class KubernetesContextTest : StringSpec() {
         }
 
         "delete pod succeeds" {
-            executor.exec("kubectl", "delete", "pod", "$vs-test")
+            executor.exec("kubectl", "delete", "pod", "--grace-period=0", "--force", "$vs-test")
         }
 
         "clone volume succeeds" {
@@ -166,7 +164,7 @@ class KubernetesContextTest : StringSpec() {
         }
 
         "delete cloned pod succeeds" {
-            executor.exec("kubectl", "delete", "pod", "$vs2-test")
+            executor.exec("kubectl", "delete", "pod", "--grace-period=0", "--force", "$vs2-test")
         }
 
         "delete cloned volumed succeeds" {

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesTest.kt
@@ -1,0 +1,130 @@
+package io.titandata.kubernetes
+
+import io.kubernetes.client.apis.CoreV1Api
+import io.kubernetes.client.models.V1ContainerBuilder
+import io.kubernetes.client.models.V1ObjectMetaBuilder
+import io.kubernetes.client.models.V1PersistentVolumeClaimVolumeSourceBuilder
+import io.kubernetes.client.models.V1PodBuilder
+import io.kubernetes.client.models.V1PodSpecBuilder
+import io.kubernetes.client.models.V1VolumeBuilder
+import io.kubernetes.client.models.V1VolumeMountBuilder
+import io.titandata.EndToEndTest
+import io.titandata.context.kubernetes.KubernetesCsiContext
+import io.titandata.shell.CommandExecutor
+
+/**
+ * This test suite is a little different from the other endtoend tests in that it's not connecting to a fully
+ * instantiated titan server. Rather, it's testing the internals of the KubernetesContext driver with a real
+ * k8s environment (hence the reason for it being an end2end test).
+ */
+abstract class KubernetesTest : EndToEndTest("kubernetes-csi") {
+
+    internal val context: KubernetesCsiContext
+    internal val coreApi: CoreV1Api
+    internal val namespace = "default"
+    internal val executor = CommandExecutor()
+
+    init {
+        val storageClass = System.getProperty("k8s.storageClass")
+        val snapshotClass = System.getProperty("k8s.snapshotClass")
+        context = KubernetesCsiContext(storageClass = storageClass, snapshotClass = snapshotClass)
+        coreApi = CoreV1Api()
+    }
+
+    internal fun waitForVolume(volumeSet: String, volumeName: String, config: Map<String, Any>) {
+        var status = context.getVolumeStatus(volumeSet, volumeName, config)
+        while (!status.ready) {
+            if (status.error != null) {
+                throw Exception(status.error)
+            }
+            status = context.getVolumeStatus(volumeSet, volumeName, config)
+            if (!status.ready) {
+                Thread.sleep(1000)
+            }
+        }
+    }
+
+    internal fun waitForVolumeApi(repository: String, volumeName: String) {
+        var status = volumeApi.getVolumeStatus(repository, volumeName)
+        while (!status.ready) {
+            if (status.error != null) {
+                throw Exception(status.error)
+            }
+            status = volumeApi.getVolumeStatus(repository, volumeName)
+            if (!status.ready) {
+                Thread.sleep(1000)
+            }
+        }
+    }
+
+    internal fun waitForCommit(volumeSet: String, commitId: String, volumeNames: List<String>) {
+        var status = context.getCommitStatus(volumeSet, commitId, volumeNames)
+        while (!status.ready) {
+            if (status.error != null) {
+                throw Exception(status.error)
+            }
+            status = context.getCommitStatus(volumeSet, commitId, volumeNames)
+            if (!status.ready) {
+                Thread.sleep(1000)
+            }
+        }
+    }
+
+    internal fun waitForCommitApi(repo: String, commitId: String) {
+        var status = commitApi.getCommitStatus(repo, commitId)
+        while (!status.ready) {
+            if (status.error != null) {
+                throw Exception(status.error)
+            }
+            status = commitApi.getCommitStatus(repo, commitId)
+            if (!status.ready) {
+                Thread.sleep(1000)
+            }
+        }
+    }
+
+    internal fun getPodStatus(name: String): Boolean {
+        val pod = coreApi.readNamespacedPod(name, context.defaultNamespace, null, null, null)
+        val statuses = pod?.status?.containerStatuses ?: return false
+        for (container in statuses) {
+            if (container.restartCount != 0) {
+                throw Exception("container ${container.name} restarted ${container.restartCount} times")
+            }
+            if (!container.isReady) {
+                return false
+            }
+        }
+        return true
+    }
+
+    internal fun waitForPod(name: String) {
+        var ready = getPodStatus(name)
+        while (!ready) {
+            Thread.sleep(1000)
+            ready = getPodStatus(name)
+        }
+    }
+
+    internal fun launchPod(name: String, claim: String) {
+        val request = V1PodBuilder()
+                .withMetadata(V1ObjectMetaBuilder().withName(name).build())
+                .withSpec(V1PodSpecBuilder()
+                        .withContainers(V1ContainerBuilder()
+                                .withName("test")
+                                .withImage("ubuntu:bionic")
+                                .withCommand("/bin/sh")
+                                .withArgs("-c", "while true; do sleep 5; done")
+                                .withVolumeMounts(V1VolumeMountBuilder()
+                                        .withName("data")
+                                        .withMountPath("/data")
+                                        .build())
+                                .build())
+                        .withVolumes(V1VolumeBuilder()
+                                .withName("data")
+                                .withPersistentVolumeClaim(V1PersistentVolumeClaimVolumeSourceBuilder().withClaimName(claim).build())
+                                .build())
+                        .build())
+                .build()
+        coreApi.createNamespacedPod(context.defaultNamespace, request, null, null, null)
+    }
+}

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
@@ -5,7 +5,6 @@
 package io.titandata.kubernetes
 
 import io.kotlintest.Spec
-import io.kotlintest.matchers.string.shouldStartWith
 import io.titandata.EndToEndTest
 
 class KubernetesWorkflowTest : EndToEndTest() {

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
@@ -22,8 +22,7 @@ class KubernetesWorkflowTest : EndToEndTest() {
 
     init {
         "kubectl works" {
-            val output = kubernetesUtil.execServer("kubectl", "get", "pods")
-            output.shouldStartWith("NAME")
+            kubernetesUtil.execServer("kubectl", "cluster-info")
         }
     }
 }

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
@@ -5,23 +5,104 @@
 package io.titandata.kubernetes
 
 import io.kotlintest.Spec
-import io.titandata.EndToEndTest
+import io.kotlintest.shouldBe
+import io.titandata.models.Commit
+import io.titandata.models.Repository
+import io.titandata.models.Volume
+import java.util.UUID
 
-class KubernetesWorkflowTest : EndToEndTest() {
+class KubernetesWorkflowTest : KubernetesTest() {
+
+    private val uuid = UUID.randomUUID().toString()
 
     override fun beforeSpec(spec: Spec) {
-        kubernetesUtil.stopServer()
-        kubernetesUtil.startServer()
-        kubernetesUtil.waitForServer()
+        dockerUtil.stopServer()
+        dockerUtil.startServer()
+        dockerUtil.waitForServer()
     }
 
     override fun afterSpec(spec: Spec) {
-        kubernetesUtil.stopServer(ignoreExceptions = false)
+        dockerUtil.stopServer(ignoreExceptions = false)
     }
 
     init {
         "kubectl works" {
-            kubernetesUtil.execServer("kubectl", "cluster-info")
+            dockerUtil.execServer("kubectl", "cluster-info")
+        }
+
+        "create repository" {
+            repoApi.createRepository(Repository("foo"))
+        }
+
+        "create volume" {
+            volumeApi.createVolume("foo", Volume("vol")).config
+        }
+
+        "launch pod" {
+            val volumeConfig = volumeApi.getVolume("foo", "vol").config
+            launchPod("$uuid-test", volumeConfig["pvc"] as String)
+            waitForPod("$uuid-test")
+        }
+
+        "write data" {
+            executor.exec("kubectl", "exec", "$uuid-test", "--", "sh", "-c", "echo one > /data/out; sync; sleep 1;")
+        }
+
+        "get volume status" {
+            waitForVolumeApi("foo", "vol")
+            val status = volumeApi.getVolumeStatus("foo", "vol")
+            status.ready shouldBe true
+            status.error shouldBe null
+        }
+
+        "create commit" {
+            commitApi.createCommit("foo", Commit("id"))
+        }
+
+        "get commit status" {
+            waitForCommitApi("foo", "id")
+            val status = commitApi.getCommitStatus("foo", "id")
+            status.ready shouldBe true
+            status.error shouldBe null
+        }
+
+        "update data" {
+            executor.exec("kubectl", "exec", "$uuid-test", "--", "sh", "-c", "echo two > /data/out; sync; sleep 1;")
+        }
+
+        "delete pod" {
+            executor.exec("kubectl", "delete", "pod", "--grace-period=0", "--force", "$uuid-test")
+        }
+
+        "checkout commit" {
+            commitApi.checkoutCommit("foo", "id")
+        }
+
+        "launch new pod" {
+            val volumeConfig = volumeApi.getVolume("foo", "vol").config
+            launchPod("$uuid-test2", volumeConfig["pvc"] as String)
+            waitForPod("$uuid-test2")
+        }
+
+        "file contents are correct" {
+            val output = executor.exec("kubectl", "exec", "$uuid-test2", "cat", "/data/out").trim()
+            output shouldBe "one"
+        }
+
+        "delete cloned pod succeeds" {
+            executor.exec("kubectl", "delete", "pod", "--grace-period=0", "--force", "$uuid-test2")
+        }
+
+        "delete commit" {
+            commitApi.deleteCommit("foo", "id")
+        }
+
+        "delete volume" {
+            volumeApi.deleteVolume("foo", "vol")
+        }
+
+        "delete repository" {
+            repoApi.deleteRepository("foo")
         }
     }
 }

--- a/server/src/integration-test/kotlin/io/titandata/CommitsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/CommitsApiTest.kt
@@ -158,10 +158,10 @@ class CommitsApiTest : StringSpec() {
             transaction {
                 services.metadata.createCommit("foo", vs, Commit("hash"))
             }
-            every { context.getCommitStatus(any(), any(), any()) } returns CommitStatus(logicalSize = 3, actualSize = 6, uniqueSize = 9)
+            every { context.getCommitStatus(any(), any(), any()) } returns CommitStatus(logicalSize = 3, actualSize = 6, uniqueSize = 9, ready = false, error = "error")
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/foo/commits/hash/status")) {
                 response.status() shouldBe HttpStatusCode.OK
-                response.content shouldBe "{\"logicalSize\":3,\"actualSize\":6,\"uniqueSize\":9}"
+                response.content shouldBe "{\"logicalSize\":3,\"actualSize\":6,\"uniqueSize\":9,\"ready\":false,\"error\":\"error\"}"
             }
         }
 

--- a/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
@@ -33,8 +33,6 @@ import io.mockk.mockk
 import io.titandata.context.docker.DockerZfsContext
 import io.titandata.models.Error
 import io.titandata.models.Repository
-import io.titandata.models.RepositoryVolumeStatus
-import io.titandata.models.Volume
 import java.util.concurrent.TimeUnit
 import org.jetbrains.exposed.sql.transactions.transaction
 
@@ -126,14 +124,12 @@ class RepositoriesApiTest : StringSpec() {
         "get repository status succeeds" {
             transaction {
                 services.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
-                val vs = services.metadata.createVolumeSet("foo", null, true)
-                services.metadata.createVolume(vs, Volume(name = "volume", properties = mapOf("path" to "/var/a")))
+                services.metadata.createVolumeSet("foo", null, true)
             }
-            every { context.getVolumeStatus(any(), any()) } returns RepositoryVolumeStatus(name = "volume", logicalSize = 5, actualSize = 10)
             with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/foo/status")) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
-                response.content shouldBe "{\"volumeStatus\":[{\"name\":\"volume\",\"logicalSize\":5,\"actualSize\":10,\"properties\":{\"path\":\"/var/a\"}}]}"
+                response.content shouldBe "{}"
             }
         }
 

--- a/server/src/main/kotlin/io/titandata/apis/VolumesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/VolumesApi.kt
@@ -72,4 +72,12 @@ fun Route.VolumesApi(services: ServiceLocator) {
             call.respond(HttpStatusCode.OK)
         }
     }
+
+    route("/v1/repositories/{repositoryName}/volumes/{volumeName}/status") {
+        get {
+            val repo = getRepoName(call)
+            val volumeName = getVolumeName(call)
+            call.respond(services.volumes.getVolumeStatus(repo, volumeName))
+        }
+    }
 }

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -5,13 +5,13 @@
 package io.titandata.context
 
 import io.titandata.models.CommitStatus
-import io.titandata.models.RepositoryVolumeStatus
+import io.titandata.models.VolumeStatus
 
 interface RuntimeContext {
     fun createVolumeSet(volumeSet: String)
     fun cloneVolumeSet(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String)
     fun deleteVolumeSet(volumeSet: String)
-    fun getVolumeStatus(volumeSet: String, volume: String): RepositoryVolumeStatus
+    fun getVolumeStatus(volumeSet: String, volume: String): VolumeStatus
     fun deleteVolumeSetCommit(volumeSet: String, commitId: String)
     fun commitVolumeSet(volumeSet: String, commitId: String)
 

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -11,7 +11,6 @@ interface RuntimeContext {
     fun createVolumeSet(volumeSet: String)
     fun cloneVolumeSet(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String)
     fun deleteVolumeSet(volumeSet: String)
-    fun getVolumeStatus(volumeSet: String, volume: String): VolumeStatus
     fun deleteVolumeSetCommit(volumeSet: String, commitId: String)
     fun commitVolumeSet(volumeSet: String, commitId: String)
 
@@ -21,6 +20,7 @@ interface RuntimeContext {
     fun cloneVolume(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String, volumeName: String, sourceConfig: Map<String, Any>): Map<String, Any>
     fun commitVolume(volumeSet: String, commitId: String, volumeName: String, config: Map<String, Any>)
     fun deleteVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
+    fun getVolumeStatus(volumeSet: String, volume: String, config: Map<String, Any>): VolumeStatus
     fun activateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
     fun deactivateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
     fun deleteVolumeCommit(volumeSet: String, commitId: String, volumeName: String)

--- a/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
@@ -88,7 +88,7 @@ class DockerZfsContext(
         }
     }
 
-    override fun getVolumeStatus(volumeSet: String, volume: String): VolumeStatus {
+    override fun getVolumeStatus(volumeSet: String, volume: String, config: Map<String, Any>): VolumeStatus {
         val output = executor.exec("zfs", "list", "-pHo",
                 "logicalreferenced,referenced", "$poolName/data/$volumeSet/$volume")
         val regex = "^([^\t]+)\t([^\t]+)$".toRegex()

--- a/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
@@ -6,7 +6,7 @@ package io.titandata.context.docker
 
 import io.titandata.context.RuntimeContext
 import io.titandata.models.CommitStatus
-import io.titandata.models.RepositoryVolumeStatus
+import io.titandata.models.VolumeStatus
 import io.titandata.shell.CommandException
 import io.titandata.shell.CommandExecutor
 import org.slf4j.LoggerFactory
@@ -88,17 +88,19 @@ class DockerZfsContext(
         }
     }
 
-    override fun getVolumeStatus(volumeSet: String, volume: String): RepositoryVolumeStatus {
+    override fun getVolumeStatus(volumeSet: String, volume: String): VolumeStatus {
         val output = executor.exec("zfs", "list", "-pHo",
                 "logicalreferenced,referenced", "$poolName/data/$volumeSet/$volume")
         val regex = "^([^\t]+)\t([^\t]+)$".toRegex()
         val result = regex.find(output.trim())
         val volumeLogical = result!!.groupValues.get(1).toLong()
         val volumeActual = result.groupValues.get(2).toLong()
-        return RepositoryVolumeStatus(
+        return VolumeStatus(
                 name = volume,
                 logicalSize = volumeLogical,
-                actualSize = volumeActual
+                actualSize = volumeActual,
+                ready = true,
+                error = null
         )
     }
 
@@ -128,7 +130,11 @@ class DockerZfsContext(
             uniqueSize += result.groupValues.get(3).toLong()
         }
 
-        return CommitStatus(logicalSize = logicalSize, actualSize = actualSize, uniqueSize = uniqueSize)
+        return CommitStatus(logicalSize = logicalSize,
+                actualSize = actualSize,
+                uniqueSize = uniqueSize,
+                ready = true,
+                error = null)
     }
 
     /**

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -10,7 +10,7 @@ import io.kubernetes.client.models.V1ResourceRequirementsBuilder
 import io.kubernetes.client.util.Config
 import io.titandata.context.RuntimeContext
 import io.titandata.models.CommitStatus
-import io.titandata.models.RepositoryVolumeStatus
+import io.titandata.models.VolumeStatus
 import io.titandata.shell.CommandException
 import io.titandata.shell.CommandExecutor
 import org.slf4j.LoggerFactory
@@ -188,7 +188,7 @@ class KubernetesCsiContext(private val storageClass: String? = null, private val
                 "size" to size)
     }
 
-    override fun getVolumeStatus(volumeSet: String, volume: String): RepositoryVolumeStatus {
+    override fun getVolumeStatus(volumeSet: String, volume: String): VolumeStatus {
         TODO("not implemented")
     }
 

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory
  */
 class KubernetesCsiContext(private val storageClass : String? = null, private val snapshotClass : String? = null) : RuntimeContext {
     private var coreApi: CoreV1Api
-    private val defaultNamespace = "default"
+    val defaultNamespace = "default"
     private val executor = CommandExecutor()
 
     companion object {

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -188,7 +188,7 @@ class KubernetesCsiContext(private val storageClass: String? = null, private val
                 "size" to size)
     }
 
-    override fun getVolumeStatus(volumeSet: String, volume: String): VolumeStatus {
+    override fun getVolumeStatus(volumeSet: String, volume: String, config: Map<String, Any>): VolumeStatus {
         TODO("not implemented")
     }
 

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -1,7 +1,5 @@
 package io.titandata.context.kubernetes
 
-import com.google.gson.JsonSyntaxException
-import io.kubernetes.client.ApiException
 import io.kubernetes.client.Configuration.setDefaultApiClient
 import io.kubernetes.client.apis.CoreV1Api
 import io.kubernetes.client.custom.Quantity
@@ -22,7 +20,7 @@ import org.slf4j.LoggerFactory
  * snapshot and cloning of data for us. Each volume is a PersistentVolumeClaim, while every commit is a
  * VolumeSnapshot.
  */
-class KubernetesCsiContext(private val storageClass : String? = null, private val snapshotClass : String? = null) : RuntimeContext {
+class KubernetesCsiContext(private val storageClass: String? = null, private val snapshotClass: String? = null) : RuntimeContext {
     private var coreApi: CoreV1Api
     val defaultNamespace = "default"
     private val executor = CommandExecutor()

--- a/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
@@ -2,6 +2,7 @@ package io.titandata.orchestrator
 
 import io.titandata.ServiceLocator
 import io.titandata.models.Volume
+import io.titandata.models.VolumeStatus
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class VolumeOrchestrator(val services: ServiceLocator) {
@@ -41,6 +42,22 @@ class VolumeOrchestrator(val services: ServiceLocator) {
             val vs = services.metadata.getActiveVolumeSet(repo)
             services.metadata.getVolume(vs, name)
         }
+    }
+
+    fun getVolumeStatus(repo: String, name: String): VolumeStatus {
+        val vol = getVolume(repo, name)
+        val vs = transaction {
+            services.metadata.getActiveVolumeSet(repo)
+        }
+        val rawStatus = services.context.getVolumeStatus(vs, name)
+        return VolumeStatus(
+                name = vol.name,
+                logicalSize = rawStatus.logicalSize,
+                actualSize = rawStatus.actualSize,
+                properties = vol.properties,
+                ready = rawStatus.ready,
+                error = rawStatus.error
+        )
     }
 
     fun activateVolume(repo: String, name: String) {

--- a/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
@@ -49,7 +49,7 @@ class VolumeOrchestrator(val services: ServiceLocator) {
         val vs = transaction {
             services.metadata.getActiveVolumeSet(repo)
         }
-        val rawStatus = services.context.getVolumeStatus(vs, name)
+        val rawStatus = services.context.getVolumeStatus(vs, name, vol.config)
         return VolumeStatus(
                 name = vol.name,
                 logicalSize = rawStatus.logicalSize,

--- a/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
+++ b/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
@@ -104,7 +104,7 @@ class DockerZfsContextTest : StringSpec() {
 
         "get volume status succeeds" {
             every { executor.exec(*anyVararg()) } returns "20\t30"
-            val status = provider.getVolumeStatus("vs", "vol")
+            val status = provider.getVolumeStatus("vs", "vol", emptyMap())
             status.name shouldBe "vol"
             status.logicalSize shouldBe 20
             status.actualSize shouldBe 30

--- a/server/src/test/kotlin/io/titandata/orchestrator/RepositoryOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/RepositoryOrchestratorTest.kt
@@ -28,7 +28,6 @@ import io.titandata.exception.NoSuchObjectException
 import io.titandata.exception.ObjectExistsException
 import io.titandata.models.Commit
 import io.titandata.models.Repository
-import io.titandata.models.RepositoryVolumeStatus
 import io.titandata.models.Volume
 import org.jetbrains.exposed.sql.transactions.transaction
 
@@ -167,19 +166,9 @@ class RepositoryOrchestratorTest : StringSpec() {
             every { context.commitVolumeSet(any(), any()) } just Runs
             every { context.commitVolume(any(), any(), any(), any()) } just Runs
             services.commits.createCommit("foo", Commit(id = "id"))
-            every { context.getVolumeStatus(any(), any()) } returns RepositoryVolumeStatus(
-                name = "vol", logicalSize = 20, actualSize = 10)
             val status = services.repositories.getRepositoryStatus("foo")
             status.lastCommit shouldBe "id"
             status.sourceCommit shouldBe "id"
-            status.volumeStatus.size shouldBe 2
-            val vols = status.volumeStatus.sortedBy { it.name }
-            vols[0].actualSize shouldBe 10
-            vols[0].actualSize shouldBe 10
-            vols[0].logicalSize shouldBe 20
-            vols[0].name shouldBe "vol1"
-            vols[1].logicalSize shouldBe 20
-            vols[1].name shouldBe "vol2"
         }
     }
 }

--- a/server/src/test/kotlin/io/titandata/orchestrator/VolumeOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/VolumeOrchestratorTest.kt
@@ -27,6 +27,7 @@ import io.titandata.context.docker.DockerZfsContext
 import io.titandata.exception.NoSuchObjectException
 import io.titandata.models.Repository
 import io.titandata.models.Volume
+import io.titandata.models.VolumeStatus
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class VolumeOrchestratorTest : StringSpec() {
@@ -240,6 +241,21 @@ class VolumeOrchestratorTest : StringSpec() {
             val volumes = services.volumes.listVolumes("foo")
             volumes.size shouldBe 1
             volumes[0].name shouldBe "vol"
+        }
+
+        "get volume status succeeds" {
+            createVolume()
+
+            every { services.context.getVolumeStatus(any(), any()) } returns VolumeStatus(name = "vol",
+                    actualSize = 10L, logicalSize = 20L, ready = true, error = null)
+
+            val status = services.volumes.getVolumeStatus("foo", "vol")
+
+            status.name shouldBe "vol"
+            status.actualSize shouldBe 10L
+            status.logicalSize shouldBe 20L
+            status.ready shouldBe true
+            status.error shouldBe null
         }
     }
 }

--- a/server/src/test/kotlin/io/titandata/orchestrator/VolumeOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/VolumeOrchestratorTest.kt
@@ -246,7 +246,7 @@ class VolumeOrchestratorTest : StringSpec() {
         "get volume status succeeds" {
             createVolume()
 
-            every { services.context.getVolumeStatus(any(), any()) } returns VolumeStatus(name = "vol",
+            every { services.context.getVolumeStatus(any(), any(), any()) } returns VolumeStatus(name = "vol",
                     actualSize = 10L, logicalSize = 20L, ready = true, error = null)
 
             val status = services.volumes.getVolumeStatus("foo", "vol")


### PR DESCRIPTION
## Proposed Changes

This adds implementations for k8s volume and commit status. As part of this work, I updated those APIs to report ready and error status out to clients, and separated out the volume status API from being embedded in repo status (should have been done when we created a first-class volume API).

## Testing

`gradle build test integrationTest endtoendTest`. Ran kubernetes e2e tests on both DigitalOcean and EC2 clusters.