### PR TITLE
update names to respect k8s limitations

### DIFF
--- a/server/src/integration-test/kotlin/io/titandata/CommitsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/CommitsApiTest.kt
@@ -9,6 +9,7 @@ import io.kotlintest.Spec
 import io.kotlintest.TestCase
 import io.kotlintest.TestCaseOrder
 import io.kotlintest.TestResult
+import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
@@ -188,7 +189,7 @@ class CommitsApiTest : StringSpec() {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 val error = Gson().fromJson(response.content, Error::class.java)
                 error.code shouldBe "IllegalArgumentException"
-                error.message shouldBe "invalid commit id, can only contain alphanumeric characters, '-', ':', '.', or '_'"
+                error.message shouldContain "invalid commit id"
             }
         }
 

--- a/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
@@ -9,6 +9,7 @@ import io.kotlintest.Spec
 import io.kotlintest.TestCase
 import io.kotlintest.TestCaseOrder
 import io.kotlintest.TestResult
+import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 import io.ktor.http.ContentType
@@ -117,7 +118,7 @@ class RepositoriesApiTest : StringSpec() {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 val error = Gson().fromJson(response.content, Error::class.java)
                 error.code shouldBe "IllegalArgumentException"
-                error.message shouldBe "invalid repository name, can only contain alphanumeric characters, '-', ':', '.', or '_'"
+                error.message shouldContain "invalid repository name"
             }
         }
 
@@ -148,7 +149,7 @@ class RepositoriesApiTest : StringSpec() {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 val error = Gson().fromJson(response.content, Error::class.java)
                 error.code shouldBe "IllegalArgumentException"
-                error.message shouldBe "invalid repository name, can only contain alphanumeric characters, '-', ':', '.', or '_'"
+                error.message shouldContain "invalid repository name"
             }
         }
 
@@ -172,7 +173,7 @@ class RepositoriesApiTest : StringSpec() {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 val error = Gson().fromJson(response.content, Error::class.java)
                 error.code shouldBe "IllegalArgumentException"
-                error.message shouldBe "invalid repository name, can only contain alphanumeric characters, '-', ':', '.', or '_'"
+                error.message shouldContain "invalid repository name"
             }
         }
 
@@ -220,7 +221,7 @@ class RepositoriesApiTest : StringSpec() {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 val error = Gson().fromJson(response.content, Error::class.java)
                 error.code shouldBe "IllegalArgumentException"
-                error.message shouldBe "invalid repository name, can only contain alphanumeric characters, '-', ':', '.', or '_'"
+                error.message shouldContain "invalid repository name"
             }
         }
     }

--- a/server/src/main/kotlin/io/titandata/orchestrator/NameUtil.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/NameUtil.kt
@@ -2,52 +2,56 @@ package io.titandata.orchestrator
 
 import java.util.UUID
 
+/**
+ * Our object names are designed to be used within supported contexts, such as kubernetes and ZFS. This allows us to
+ * name objects with matching names and not have to create a layer of indirection at the metadata layer. Note that
+ * there are some names that don't have storage representation (such as remotes), but
+ *
+ * ZFS components can contain alphanumeric characters plus '_', '-', ':', and '.'. Components must be 255 characters
+ * or less.
+ *
+ * Kubernetes names can contain alphanumeric characters plus '-' and '.'. Names can be up to 253 characters long. Note
+ * that some kubernetes resources have additional restrictions, like what characters can be at the beginning and end.
+ * The assumption is that in those cases we can augment the string (e.g. add leading text) without having to
+ * introduce those restrictions into our core naming rules.
+ *
+ * For our names, we take the subset of those two groups (basically the kubernetes restrictions), but limit them to
+ * 63 characters. 253 is just way more than we reasonably need, and by limiting it to 63 we can ensure that we can
+ * concatenate multiple names and still remain under that 253 limit.
+ */
 class NameUtil {
 
     companion object {
-        private val nameRegex = "^[a-zA-Z0-9_\\-:.]+$".toRegex()
+        private val nameRegex = "^[a-zA-Z0-9\\-.]+$".toRegex()
+        private val nameLimit = 63
+
+        internal fun validateCommon(name: String, type: String) {
+            if (!nameRegex.matches(name)) {
+                throw IllegalArgumentException("invalid $type name, can only contain " +
+                        "alphanumeric characters, '-', or '.'")
+            }
+            if (name.length > nameLimit) {
+                throw IllegalArgumentException("invalid $type name, must be $nameLimit characters or less")
+            }
+            if (name.length == 0) {
+                throw IllegalArgumentException("invalid $type name, cannot be empty")
+            }
+        }
 
         fun validateRepoName(repoName: String) {
-            if (!nameRegex.matches(repoName)) {
-                throw IllegalArgumentException("invalid repository name, can only contain " +
-                        "alphanumeric characters, '-', ':', '.', or '_'")
-            }
-            if (repoName.length > 64) {
-                throw IllegalArgumentException("invalid repository name, must be 64 characters or less")
-            }
+            validateCommon(repoName, "repository")
         }
 
         fun validateCommitId(commitId: String) {
-            if (!nameRegex.matches(commitId)) {
-                throw IllegalArgumentException("invalid commit id, can only contain " +
-                        "alphanumeric characters, '-', ':', '.', or '_'")
-            }
-            if (commitId.length > 64) {
-                throw IllegalArgumentException("invalid commit id, must be 64 characters or less")
-            }
+            validateCommon(commitId, "commit id")
         }
 
-        fun validateRemoteName(repoName: String) {
-            if (!nameRegex.matches(repoName)) {
-                throw IllegalArgumentException("invalid remote name, can only contain " +
-                        "alphanumeric characters, '-', ':', '.', or '_'")
-            }
-            if (repoName.length > 64) {
-                throw IllegalArgumentException("invalid remote name, must be 64 characters or less")
-            }
+        fun validateRemoteName(remoteName: String) {
+            validateCommon(remoteName, "remote")
         }
 
         fun validateVolumeName(volumeName: String) {
-            if (!nameRegex.matches(volumeName)) {
-                throw IllegalArgumentException("invalid volume name, can only contain " +
-                        "alphanumeric characters, '-', ':', '.', or '_'")
-            }
-            if (volumeName.length > 64) {
-                throw IllegalArgumentException("invalid volume name, must be 64 characters or less")
-            }
-            if (volumeName.startsWith("_")) {
-                throw IllegalArgumentException("invalid volume name, cannot start with '_'")
-            }
+            validateCommon(volumeName, "volume")
         }
 
         fun validateOperationId(operationId: String) {

--- a/server/src/test/kotlin/io/titandata/orchestrator/NameUtilTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/NameUtilTest.kt
@@ -1,0 +1,52 @@
+package io.titandata.orchestrator
+
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.StringSpec
+import java.util.UUID
+
+class NameUtilTest : StringSpec() {
+
+    init {
+        "names cannot be zero length" {
+            shouldThrow<IllegalArgumentException> {
+                NameUtil.validateCommon("", "")
+            }
+        }
+
+        "names can be 63 characters long" {
+            NameUtil.validateCommon("a".repeat(63), "")
+        }
+
+        "names cannot be 64 characters long" {
+            shouldThrow<IllegalArgumentException> {
+                NameUtil.validateCommon("a".repeat(64), "")
+            }
+        }
+
+        "names can contain valid characters" {
+            NameUtil.validateCommon("aB09.-c", "")
+        }
+
+        "names cannot contain underscores" {
+            shouldThrow<IllegalArgumentException> {
+                NameUtil.validateCommon("a_b", "")
+            }
+        }
+
+        "names cannot contain colons" {
+            shouldThrow<IllegalArgumentException> {
+                NameUtil.validateCommon("a:b", "")
+            }
+        }
+
+        "operation IDs fail if non-UUID" {
+            shouldThrow<IllegalArgumentException> {
+                NameUtil.validateOperationId("a")
+            }
+        }
+
+        "operation IDs success if UUID" {
+            NameUtil.validateOperationId(UUID.randomUUID().toString())
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Now that I know how we're using names in kubernetes, this tightens our naming rules to better align with that environment. This way, users can't create a repository named "foo_bar" that cannot be used to name a k8s resource (creating a "foo_bar" pod would fail).

## Testing

`gradle build test integrationTest endtoendTest`