### PR TITLE
k8s context configuration

### DIFF
--- a/client/src/main/kotlin/io/titandata/client/apis/ContextApi.kt
+++ b/client/src/main/kotlin/io/titandata/client/apis/ContextApi.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.client.apis
+
+import io.titandata.client.infrastructure.ApiClient
+import io.titandata.client.infrastructure.ClientException
+import io.titandata.client.infrastructure.RequestConfig
+import io.titandata.client.infrastructure.RequestMethod
+import io.titandata.client.infrastructure.ResponseType
+import io.titandata.client.infrastructure.ServerException
+import io.titandata.client.infrastructure.Success
+import io.titandata.models.Commit
+import io.titandata.models.CommitStatus
+import io.titandata.models.Context
+
+class ContextApi(basePath: String = "http://localhost:5001") : ApiClient(basePath) {
+
+    fun getContext() : Context {
+        val localVariableBody: Any? = null
+        val localVariableQuery: Map<String,List<String>> = mapOf()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        val localVariableConfig = RequestConfig(
+                RequestMethod.GET,
+                "/v1/context",
+                query = localVariableQuery,
+                headers = localVariableHeaders
+        )
+        val response = request<Context>(
+            localVariableConfig,
+            localVariableBody
+        )
+
+        return when (response.responseType) {
+            ResponseType.Success -> (response as Success<*>).data as Context
+            ResponseType.ClientError -> throw ClientException.fromResponse(gson, response)
+            ResponseType.ServerError -> throw ServerException.fromResponse(gson, response)
+            else -> throw NotImplementedError(response.responseType.toString())
+        }
+    }
+}

--- a/client/src/main/kotlin/io/titandata/models/Context.kt
+++ b/client/src/main/kotlin/io/titandata/models/Context.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.models
+
+data class Context(
+    var provider: String,
+    var properties: Map<String, String>
+)

--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -61,22 +61,24 @@ class DockerUtil(
         return executor.exec(*args.toTypedArray()).trim()
     }
 
-    fun runTitanKubernetes(entryPoint: String): String {
+    fun runTitanKubernetes(entryPoint: String, parameters: Array<out String>): String {
         val home = System.getProperty("user.home")
+        val config = parameters.joinToString(",")
         val args = arrayOf("docker", "run",
                 "-d", "--restart", "always", "--name", "$identity-server",
                 "-v", "$home/.kube:/root/.kube", "-v", "$identity-data:/var/lib/$identity",
                 "-e", "TITAN_CONTEXT=kubernetes-csi", "-e", "TITAN_DATA=$identity",
+                "-e", "TITAN_CONFIG=$config",
                 "-p", "$port:5001", image, "/bin/bash", "/titan/$entryPoint")
         return executor.exec(*args).trim()
     }
 
-    fun startServer() {
+    fun startServer(vararg parameters: String) {
         executor.exec("docker", "volume", "create", "$identity-data")
         if (context == "docker-zfs") {
             runTitanDocker("launch", true)
         } else {
-            runTitanKubernetes("run")
+            runTitanKubernetes("run", parameters)
         }
     }
 

--- a/server/src/endtoend-test/kotlin/io/titandata/EndToEndTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/EndToEndTest.kt
@@ -7,6 +7,7 @@ package io.titandata
 import io.kotlintest.TestCaseOrder
 import io.kotlintest.specs.StringSpec
 import io.titandata.client.apis.CommitsApi
+import io.titandata.client.apis.ContextApi
 import io.titandata.client.apis.OperationsApi
 import io.titandata.client.apis.RemotesApi
 import io.titandata.client.apis.RepositoriesApi
@@ -26,6 +27,7 @@ abstract class EndToEndTest(val titanContext: String = "docker-zfs") : StringSpe
     val commitApi = CommitsApi(url)
     val remoteApi = RemotesApi(url)
     val operationApi = OperationsApi(url)
+    val contextApi = ContextApi(url)
 
     override fun testCaseOrder() = TestCaseOrder.Sequential
 

--- a/server/src/endtoend-test/kotlin/io/titandata/docker/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/docker/LocalWorkflowTest.kt
@@ -41,6 +41,13 @@ class LocalWorkflowTest : EndToEndTest() {
     }
 
     init {
+        "get context returns correct configuration" {
+            val context = contextApi.getContext()
+            context.provider shouldBe "docker-zfs"
+            context.properties.size shouldBe 1
+            context.properties["pool"] shouldBe "test"
+        }
+
         "repository list is empty" {
             val repositories = repoApi.listRepositories()
             repositories.size shouldBe 0

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesConfigTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesConfigTest.kt
@@ -1,0 +1,41 @@
+/*
+* Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.kubernetes
+
+import io.kotlintest.Spec
+import io.kotlintest.shouldBe
+
+class KubernetesConfigTest : KubernetesTest() {
+
+    override fun beforeSpec(spec: Spec) {
+        dockerUtil.stopServer()
+    }
+
+    override fun afterSpec(spec: Spec) {
+        dockerUtil.stopServer(ignoreExceptions = false)
+    }
+
+    val configFile = "config"
+    val kubeContext = executor.exec("kubectl", "config", "current-context").trim()
+    val storageClass = "noSuchClass"
+    val snapshotClass = "noSuchClass"
+
+    init {
+        "start server with configuration succeeds" {
+            dockerUtil.startServer("configFile=$configFile", "context=$kubeContext",
+                    "storageClass=$storageClass", "snapshotClass=$snapshotClass")
+            dockerUtil.waitForServer()
+        }
+
+        "get context returns custom configuration" {
+            val context = contextApi.getContext()
+            context.properties.size shouldBe 4
+            context.properties["configFile"] shouldBe configFile
+            context.properties["context"] shouldBe kubeContext
+            context.properties["storageClass"] shouldBe storageClass
+            context.properties["snapshotClass"] shouldBe snapshotClass
+        }
+    }
+}

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
@@ -67,7 +67,7 @@ class KubernetesContextTest : KubernetesTest() {
         "delete cloned volumed succeeds" {
             context.deleteVolume(vs2, "test", cloneConfig)
             val exception = shouldThrow<ApiException> {
-                coreApi.readNamespacedPersistentVolumeClaimStatus("$vs2-test", namespace, null)
+                coreApi.readNamespacedPersistentVolumeClaimStatus("$vs2-test", context.namespace, null)
             }
             exception.code shouldBe 404
         }
@@ -87,7 +87,7 @@ class KubernetesContextTest : KubernetesTest() {
         "delete volume succeeds" {
             context.deleteVolume(vs, "test", volumeConfig)
             val exception = shouldThrow<ApiException> {
-                coreApi.readNamespacedPersistentVolumeClaimStatus("$vs-test", namespace, null)
+                coreApi.readNamespacedPersistentVolumeClaimStatus("$vs-test", context.namespace, null)
             }
             exception.code shouldBe 404
         }

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesTest.kt
@@ -21,13 +21,10 @@ abstract class KubernetesTest : EndToEndTest("kubernetes-csi") {
 
     internal val context: KubernetesCsiContext
     internal val coreApi: CoreV1Api
-    internal val namespace = "default"
     internal val executor = CommandExecutor()
 
     init {
-        val storageClass = System.getProperty("k8s.storageClass")
-        val snapshotClass = System.getProperty("k8s.snapshotClass")
-        context = KubernetesCsiContext(storageClass = storageClass, snapshotClass = snapshotClass)
+        context = KubernetesCsiContext()
         coreApi = CoreV1Api()
     }
 
@@ -84,7 +81,7 @@ abstract class KubernetesTest : EndToEndTest("kubernetes-csi") {
     }
 
     internal fun getPodStatus(name: String): Boolean {
-        val pod = coreApi.readNamespacedPod(name, context.defaultNamespace, null, null, null)
+        val pod = coreApi.readNamespacedPod(name, context.namespace, null, null, null)
         val statuses = pod?.status?.containerStatuses ?: return false
         for (container in statuses) {
             if (container.restartCount != 0) {
@@ -125,6 +122,6 @@ abstract class KubernetesTest : EndToEndTest("kubernetes-csi") {
                                 .build())
                         .build())
                 .build()
-        coreApi.createNamespacedPod(context.defaultNamespace, request, null, null, null)
+        coreApi.createNamespacedPod(context.namespace, request, null, null, null)
     }
 }

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
@@ -26,6 +26,12 @@ class KubernetesWorkflowTest : KubernetesTest() {
     }
 
     init {
+        "get context returns correct configuration" {
+            val context = contextApi.getContext()
+            context.provider shouldBe "kubernetes-csi"
+            context.properties.size shouldBe 0
+        }
+
         "kubectl works" {
             dockerUtil.execServer("kubectl", "cluster-info")
         }

--- a/server/src/main/kotlin/io/titandata/Application.kt
+++ b/server/src/main/kotlin/io/titandata/Application.kt
@@ -6,7 +6,6 @@ package io.titandata
 
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonSyntaxException
-import com.google.gson.reflect.TypeToken
 import io.ktor.application.Application
 import io.ktor.application.call
 import io.ktor.application.install
@@ -30,6 +29,7 @@ import io.ktor.server.cio.CIO
 import io.ktor.server.engine.embeddedServer
 import io.ktor.util.KtorExperimentalAPI
 import io.titandata.apis.CommitsApi
+import io.titandata.apis.ContextApi
 import io.titandata.apis.DockerVolumeApi
 import io.titandata.apis.OperationsApi
 import io.titandata.apis.RemotesApi
@@ -125,6 +125,7 @@ fun Application.mainProvider(services: ServiceLocator) {
     install(Compression, ApplicationCompressionConfiguration())
     install(Routing) {
         CommitsApi(services)
+        ContextApi(services)
         DockerVolumeApi(services)
         OperationsApi(services)
         RemotesApi(services)

--- a/server/src/main/kotlin/io/titandata/apis/ContextApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/ContextApi.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.apis
+
+import io.ktor.application.call
+import io.ktor.response.respond
+import io.ktor.routing.Route
+import io.ktor.routing.get
+import io.ktor.routing.route
+import io.titandata.ServiceLocator
+import io.titandata.models.Context
+
+/**
+ * This is a single global context API to be able to get the current context configuration for the given server.
+ */
+fun Route.ContextApi(services: ServiceLocator) {
+    route("/v1/context") {
+        get {
+            call.respond(Context(
+                    provider = services.context.getProvider(),
+                    properties = services.context.getProperties()))
+        }
+    }
+}

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -8,6 +8,9 @@ import io.titandata.models.CommitStatus
 import io.titandata.models.VolumeStatus
 
 interface RuntimeContext {
+    fun getProvider() : String
+    fun getProperties() : Map<String, String>
+
     fun createVolumeSet(volumeSet: String)
     fun cloneVolumeSet(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String)
     fun deleteVolumeSet(volumeSet: String)

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -8,8 +8,8 @@ import io.titandata.models.CommitStatus
 import io.titandata.models.VolumeStatus
 
 interface RuntimeContext {
-    fun getProvider() : String
-    fun getProperties() : Map<String, String>
+    fun getProvider(): String
+    fun getProperties(): Map<String, String>
 
     fun createVolumeSet(volumeSet: String)
     fun cloneVolumeSet(sourceVolumeSet: String, sourceCommit: String, newVolumeSet: String)

--- a/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
@@ -31,6 +31,14 @@ class DockerZfsContext(
 
     internal val executor = CommandExecutor()
 
+    override fun getProvider(): String {
+        return "docker-zfs"
+    }
+
+    override fun getProperties(): Map<String, String> {
+        return mapOf("pool" to poolName)
+    }
+
     /**
      * Create a new volume set. This is simply an empty placeholder volumeset.
      */

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -17,8 +17,8 @@ import io.titandata.models.CommitStatus
 import io.titandata.models.VolumeStatus
 import io.titandata.shell.CommandException
 import io.titandata.shell.CommandExecutor
-import org.slf4j.LoggerFactory
 import java.io.FileReader
+import org.slf4j.LoggerFactory
 
 /**
  * Kubernetes runtime context. In a k8s environment, we leverage CSI (Container Storage Interface) drivers to do
@@ -38,10 +38,10 @@ import java.io.FileReader
  *      snapshotClass   Default snapshot class to use when createing snapshots. If unspecified, then the cluster
  *                      default is used.
  */
-class KubernetesCsiContext(private val properties : Map<String, String> = emptyMap()) : RuntimeContext {
+class KubernetesCsiContext(private val properties: Map<String, String> = emptyMap()) : RuntimeContext {
     private val coreApi: CoreV1Api
     private val storageApi: StorageV1Api
-    val namespace : String
+    val namespace: String
     private val executor = CommandExecutor()
 
     companion object {

--- a/server/src/scripts/run
+++ b/server/src/scripts/run
@@ -13,7 +13,9 @@
 #                   driver. The TITAN_DATA variable must be set to determine where to place the persistent
 #                   database in /var/lib/$TITAN_DATA, which should be backed by a persistent volume. Unlike
 #                   the docker-zfs context, the server doesn't need to be run via 'launch', and can operate
-#                   in any docker environment even if kernel ZFS support isn't present.
+#                   in any docker environment even if kernel ZFS support isn't present. Additional context
+#                   can be passed through the TITAN_CONFIG variable, which is a list of name=value pairs,
+#                   separated by commas.
 #
 
 function log_error {
@@ -87,7 +89,7 @@ elif [[ $TITAN_CONTEXT = "kubernetes-csi" ]]; then
 
   start_database $DB_DIR
 
-  exec java -Dtitan.context=$TITAN_CONTEXT -jar /titan/titan-server.jar
+  exec java -Dtitan.context=$TITAN_CONTEXT -Dtitan.contextConfig=$TITAN_CONFIG -jar /titan/titan-server.jar
 else
   log_error "Unknown context $TITAN_CONTEXT"
 fi


### PR DESCRIPTION
## Proposed Changes

This adds the ability to specify a number of k8s parameters dynamically through the server environment. This is necessary to support things like having one titan context talking to an ec2 cluster and another talking to a digital ocean cluster. It also adds a context endpoint, which the CLI will use to ensure that it's connecting to the right cluster and using the right parameters (such as namespace) for its API calls. This is all groundwork for supporting first class configuration of contexts via the CLI.

## Testing

`gradle build test integrationTest endtoendTest` including Kubernetes e2e tests.