### PR TITLE
refactor operations API

### DIFF
--- a/client/src/main/kotlin/io/titandata/client/apis/OperationsApi.kt
+++ b/client/src/main/kotlin/io/titandata/client/apis/OperationsApi.kt
@@ -17,13 +17,13 @@ import io.titandata.models.ProgressEntry
 
 class OperationsApi(basePath: String = "http://localhost:5001") : ApiClient(basePath) {
 
-    fun deleteOperation(repositoryName: String, operationId: String) {
+    fun deleteOperation(operationId: String) {
         val localVariableBody: Any? = null
         val localVariableQuery: Map<String,List<String>> = mapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.DELETE,
-                "/v1/repositories/$repositoryName/operations/$operationId",
+                "/v1/operations/$operationId",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -40,13 +40,13 @@ class OperationsApi(basePath: String = "http://localhost:5001") : ApiClient(base
         }
     }
 
-    fun getOperation(repositoryName: String, operationId: String) : Operation {
+    fun getOperation(operationId: String) : Operation {
         val localVariableBody: Any? = null
         val localVariableQuery: Map<String,List<String>> = mapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.GET,
-                "/v1/repositories/$repositoryName/operations/$operationId",
+                "/v1/operations/$operationId",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -64,13 +64,15 @@ class OperationsApi(basePath: String = "http://localhost:5001") : ApiClient(base
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun getProgress(repositoryName: String, operationId: String) : Array<ProgressEntry> {
+    fun getProgress(operationId: String, lastId: Int) : Array<ProgressEntry> {
         val localVariableBody: Any? = null
-        val localVariableQuery: Map<String,List<String>> = mapOf()
+        val localVariableQuery: Map<String,List<String>> = mapOf(
+                "lastId" to listOf(lastId.toString())
+        )
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.GET,
-                "/v1/repositories/$repositoryName/operations/$operationId/progress",
+                "/v1/operations/$operationId/progress",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )
@@ -90,11 +92,11 @@ class OperationsApi(basePath: String = "http://localhost:5001") : ApiClient(base
     @Suppress("UNCHECKED_CAST")
     fun listOperations(repositoryName: String) : Array<Operation> {
         val localVariableBody: Any? = null
-        val localVariableQuery: Map<String,List<String>> = mapOf()
+        val localVariableQuery: Map<String,List<String>> = mapOf("repository" to listOf(repositoryName))
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         val localVariableConfig = RequestConfig(
                 RequestMethod.GET,
-                "/v1/repositories/$repositoryName/operations",
+                "/v1/operations",
                 query = localVariableQuery,
                 headers = localVariableHeaders
         )

--- a/server/src/endtoend-test/kotlin/io/titandata/EndToEndTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/EndToEndTest.kt
@@ -42,8 +42,9 @@ abstract class EndToEndTest(val titanContext: String = "docker-zfs") : StringSpe
     fun waitForOperation(id: String): List<ProgressEntry> {
         var completed = false
         val result = mutableListOf<ProgressEntry>()
+        var lastEntry = 0
         while (!completed) {
-            val progress = operationApi.getProgress("foo", id)
+            val progress = operationApi.getProgress(id, lastEntry)
             result.addAll(progress)
             for (p in progress) {
                 when (p.type) {
@@ -51,6 +52,9 @@ abstract class EndToEndTest(val titanContext: String = "docker-zfs") : StringSpe
                     ProgressEntry.Type.ABORT -> throw Exception("operation aborted: ${p.message}")
                     ProgressEntry.Type.FAILED -> throw Exception("operation failed: ${p.message}")
                     else -> log.info(p.message)
+                }
+                if (p.id > lastEntry) {
+                    lastEntry = p.id
                 }
             }
             if (!completed) {

--- a/server/src/endtoend-test/kotlin/io/titandata/docker/LocalWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/docker/LocalWorkflowTest.kt
@@ -304,7 +304,7 @@ class LocalWorkflowTest : EndToEndTest() {
         }
 
         "get push operation succeeds" {
-            val result = operationApi.getOperation("foo", currentOp.id)
+            val result = operationApi.getOperation(currentOp.id)
             result.id shouldBe currentOp.id
             result.commitId shouldBe currentOp.commitId
             result.remote shouldBe currentOp.remote
@@ -319,20 +319,13 @@ class LocalWorkflowTest : EndToEndTest() {
 
         "get push operation progress succeeds" {
             delay(Duration.ofMillis(1000))
-            val result = operationApi.getOperation("foo", currentOp.id)
+            val result = operationApi.getOperation(currentOp.id)
             result.state shouldBe Operation.State.COMPLETE
-            val progress = operationApi.getProgress("foo", currentOp.id)
+            val progress = operationApi.getProgress(currentOp.id, 0)
             progress.size shouldBe 2
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[0].message shouldBe "Pushing id to 'b'"
             progress[1].type shouldBe ProgressEntry.Type.COMPLETE
-        }
-
-        "push operation no longer exists" {
-            val exception = shouldThrow<ClientException> {
-                operationApi.getOperation("foo", currentOp.id)
-            }
-            exception.code shouldBe "NoSuchObjectException"
         }
 
         "push operation no longer in list of operations" {
@@ -348,7 +341,7 @@ class LocalWorkflowTest : EndToEndTest() {
         }
 
         "get pull operation succeeds" {
-            val result = operationApi.getOperation("foo", currentOp.id)
+            val result = operationApi.getOperation(currentOp.id)
             result.id shouldBe currentOp.id
             result.commitId shouldBe currentOp.commitId
             result.remote shouldBe currentOp.remote
@@ -363,20 +356,13 @@ class LocalWorkflowTest : EndToEndTest() {
 
         "get pull progress succeeds" {
             delay(Duration.ofMillis(1000))
-            val result = operationApi.getOperation("foo", currentOp.id)
+            val result = operationApi.getOperation(currentOp.id)
             result.state shouldBe Operation.State.COMPLETE
-            val progress = operationApi.getProgress("foo", currentOp.id)
+            val progress = operationApi.getProgress(currentOp.id, 0)
             progress.size shouldBe 2
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[0].message shouldBe "Pulling id2 from 'b'"
             progress[1].type shouldBe ProgressEntry.Type.COMPLETE
-        }
-
-        "pull operation no longer exists" {
-            val exception = shouldThrow<ClientException> {
-                operationApi.getOperation("foo", currentOp.id)
-            }
-            exception.code shouldBe "NoSuchObjectException"
         }
 
         "pulled commit exists" {
@@ -408,11 +394,11 @@ class LocalWorkflowTest : EndToEndTest() {
             currentOp = operationApi.push("foo", "b", "id", RemoteParameters(params.provider, props))
             currentOp.state shouldBe Operation.State.RUNNING
             delay(Duration.ofMillis(1000))
-            operationApi.deleteOperation("foo", currentOp.id)
+            operationApi.deleteOperation(currentOp.id)
             delay(Duration.ofMillis(1000))
-            val result = operationApi.getOperation("foo", currentOp.id)
+            val result = operationApi.getOperation(currentOp.id)
             result.state shouldBe Operation.State.ABORTED
-            val progress = operationApi.getProgress("foo", currentOp.id)
+            val progress = operationApi.getProgress(currentOp.id, 0)
             progress.size shouldBe 2
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[0].message shouldBe "Pushing id to 'b'"

--- a/server/src/main/kotlin/io/titandata/apis/OperationsApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/OperationsApi.kt
@@ -18,33 +18,31 @@ import io.titandata.models.RemoteParameters
 
 fun Route.OperationsApi(services: ServiceLocator) {
 
-    route("/v1/repositories/{repositoryName}/operations") {
+    route("/v1/operations") {
         get {
-            val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
+            val repo = call.request.queryParameters["repositoryName"]
             call.respond(services.operations.listOperations(repo))
         }
     }
 
-    route("/v1/repositories/{repositoryName}/operations/{operationId}") {
+    route("/v1/operations/{operationId}") {
         delete {
-            val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val operation = call.parameters["operationId"] ?: throw IllegalArgumentException("missing operation id parameter")
-            services.operations.abortOperation(repo, operation)
+            services.operations.abortOperation(operation)
             call.respond(HttpStatusCode.NoContent)
         }
 
         get {
-            val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val operation = call.parameters["operationId"] ?: throw IllegalArgumentException("missing operation id parameter")
-            call.respond(services.operations.getOperation(repo, operation))
+            call.respond(services.operations.getOperation(operation))
         }
     }
 
-    route("/v1/repositories/{repositoryName}/operations/{operationId}/progress") {
+    route("/v1/operations/{operationId}/progress") {
         get {
-            val repo = call.parameters["repositoryName"] ?: throw IllegalArgumentException("missing repository name parameter")
             val operation = call.parameters["operationId"] ?: throw IllegalArgumentException("missing operation id parameter")
-            call.respond(services.operations.getProgress(repo, operation))
+            val lastId = call.request.queryParameters.get("lastId")?.toInt() ?: 0
+            call.respond(services.operations.getProgress(operation, lastId))
         }
     }
 

--- a/server/src/main/kotlin/io/titandata/apis/OperationsApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/OperationsApi.kt
@@ -20,7 +20,7 @@ fun Route.OperationsApi(services: ServiceLocator) {
 
     route("/v1/operations") {
         get {
-            val repo = call.request.queryParameters["repositoryName"]
+            val repo = call.request.queryParameters["repository"]
             call.respond(services.operations.listOperations(repo))
         }
     }

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -6,8 +6,6 @@ package io.titandata.context
 
 import io.titandata.models.CommitStatus
 import io.titandata.models.VolumeStatus
-import io.titandata.operation.OperationExecutor
-import io.titandata.remote.RemoteOperation
 
 interface RuntimeContext {
     fun createVolumeSet(volumeSet: String)

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -6,6 +6,8 @@ package io.titandata.context
 
 import io.titandata.models.CommitStatus
 import io.titandata.models.VolumeStatus
+import io.titandata.operation.OperationExecutor
+import io.titandata.remote.RemoteOperation
 
 interface RuntimeContext {
     fun createVolumeSet(volumeSet: String)

--- a/server/src/main/kotlin/io/titandata/metadata/OperationData.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/OperationData.kt
@@ -13,5 +13,6 @@ import io.titandata.models.RemoteParameters
 data class OperationData(
     val operation: Operation,
     val params: RemoteParameters,
+    val repo: String,
     var metadataOnly: Boolean = false
 )

--- a/server/src/main/kotlin/io/titandata/metadata/table/Operations.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/table/Operations.kt
@@ -1,8 +1,6 @@
 package io.titandata.metadata.table
 
-import io.titandata.metadata.table.Remotes.references
 import io.titandata.models.Operation
-import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Table
 
 /*

--- a/server/src/main/kotlin/io/titandata/metadata/table/Operations.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/table/Operations.kt
@@ -10,7 +10,7 @@ import org.jetbrains.exposed.sql.Table
  * is ongoing.
  */
 object Operations : Table("operations") {
-    val volumeSet = uuid("volume_set").references(VolumeSets.id, onDelete = ReferenceOption.CASCADE).primaryKey()
+    val id = uuid("id").primaryKey()
     val repo = varchar("repo", 64)
     val metadataOnly = bool("metadata_only")
     val remoteParameters = varchar("remote_parameters", 8192)

--- a/server/src/main/kotlin/io/titandata/metadata/table/ProgressEntries.kt
+++ b/server/src/main/kotlin/io/titandata/metadata/table/ProgressEntries.kt
@@ -10,7 +10,7 @@ import org.jetbrains.exposed.sql.ReferenceOption
  * such that consumers can fetch any progress entries that have been added since the last time they checked.
  */
 object ProgressEntries : IntIdTable("progress_entries") {
-    val operation = uuid("volume_set").references(Operations.volumeSet, onDelete = ReferenceOption.CASCADE).primaryKey()
+    val operation = uuid("operation_id").references(Operations.id, onDelete = ReferenceOption.CASCADE).primaryKey()
     val percent = integer("percent").nullable()
     val message = varchar("message", 4096).nullable()
     val type = enumerationByName("type", 16, ProgressEntry.Type::class)

--- a/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
+++ b/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
@@ -41,13 +41,15 @@ class OperationExecutor(
     private var commit: Commit? = null
 
     val updateProgress = fun(type: RemoteProgress, message: String?, percent: Int?) {
-        val progressType = when (type) {
-            RemoteProgress.START -> ProgressEntry.Type.START
-            RemoteProgress.END -> ProgressEntry.Type.END
-            RemoteProgress.PROGRESS -> ProgressEntry.Type.PROGRESS
-            RemoteProgress.MESSAGE -> ProgressEntry.Type.MESSAGE
+        transaction {
+            val progressType = when (type) {
+                RemoteProgress.START -> ProgressEntry.Type.START
+                RemoteProgress.END -> ProgressEntry.Type.END
+                RemoteProgress.PROGRESS -> ProgressEntry.Type.PROGRESS
+                RemoteProgress.MESSAGE -> ProgressEntry.Type.MESSAGE
+            }
+            services.metadata.addProgressEntry(operation.id, ProgressEntry(progressType, message, percent))
         }
-        services.metadata.addProgressEntry(operation.id, ProgressEntry(progressType, message, percent))
     }
 
     override fun run() {

--- a/server/src/main/kotlin/io/titandata/orchestrator/OperationOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/OperationOrchestrator.kt
@@ -20,15 +20,9 @@ import org.slf4j.LoggerFactory
 /**
  * The operation manager is responsible for starting, stopping, and monitoring all active
  * operations. There are two basic types of operations: push and pull. In either case, we
- * create a volume set that is marked as an in-progress operation. For pushes, it's simply
+ * create a volume set that has an associated in-progress operation. For pushes, it's simply
  * a clone of the source commit. For pulls, we try to find the closest possible commit based
  * on the commit source as recorded in the remote repository.
- *
- * Progress messages are queued up for the CLI to pull down and display to the user, but if the
- * server restarts then we will lose any progress and the CLI will have to start with progress
- * from the resumed operation. We have a very simple model of a single client, so we adopt a
- * model of simply discarding progress entries once they've been read, and marking the entire
- * operation complete once the last progress message has been read.
  */
 class OperationOrchestrator(val services: ServiceLocator) {
 

--- a/server/src/main/kotlin/io/titandata/orchestrator/OperationOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/OperationOrchestrator.kt
@@ -38,7 +38,7 @@ class OperationOrchestrator(val services: ServiceLocator) {
 
     private val runningOperations: MutableMap<String, OperationExecutor> = mutableMapOf()
 
-    val operationComplete = fun(operationId: String) {
+    private val operationComplete = fun(operationId: String) {
         runningOperations.remove(operationId)
         services.reaper.signal()
     }
@@ -210,7 +210,7 @@ class OperationOrchestrator(val services: ServiceLocator) {
         runningOperations.clear()
     }
 
-    fun getProgress(operationId: String, lastEntryId: Int): List<ProgressEntry> {
+    fun getProgress(operationId: String, lastEntryId: Int = 0): List<ProgressEntry> {
         return transaction {
             services.metadata.listProgressEntries(operationId, lastEntryId)
         }
@@ -237,6 +237,10 @@ class OperationOrchestrator(val services: ServiceLocator) {
     fun abortOperation(id: String) {
         getOperation(id)
         runningOperations[id]?.abort()
+    }
+
+    fun waitForComplete(id: String) {
+        runningOperations[id]?.join()
     }
 
     /**

--- a/server/src/main/kotlin/io/titandata/orchestrator/Reaper.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/Reaper.kt
@@ -97,7 +97,7 @@ class Reaper(val services: ServiceLocator) : Runnable {
         val volumeSets = transaction {
             services.metadata.listInactiveVolumeSets().filter {
                 services.metadata.isVolumeSetEmpty(it) &&
-                        !services.metadata.operationExists(it)
+                        !services.metadata.operationRunning(it)
             }
         }
 

--- a/server/src/test/kotlin/io/titandata/metadata/ProgressEntryMetadataTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/ProgressEntryMetadataTest.kt
@@ -27,6 +27,7 @@ class ProgressEntryMetadataTest : StringSpec() {
             md.createOperation("foo", vs, OperationData(
                     metadataOnly = false,
                     params = RemoteParameters("nop"),
+                    repo = "foo",
                     operation = Operation(
                             id = vs,
                             type = Operation.Type.PULL,
@@ -83,11 +84,28 @@ class ProgressEntryMetadataTest : StringSpec() {
             }
         }
 
-        "operation with progress entries can be deleted" {
-            transaction {
-                md.addProgressEntry(vs, ProgressEntry(type = ProgressEntry.Type.MESSAGE, message = "one"))
-                md.deleteOperation(vs)
+        "add failed progress entry updates operation state" {
+            val op = transaction {
+                md.addProgressEntry(vs, ProgressEntry(type = ProgressEntry.Type.FAILED, message = "message"))
+                md.getOperation(vs)
             }
+            op.operation.state shouldBe Operation.State.FAILED
+        }
+
+        "add aborted progress entry updates operation state" {
+            val op = transaction {
+                md.addProgressEntry(vs, ProgressEntry(type = ProgressEntry.Type.ABORT, message = "message"))
+                md.getOperation(vs)
+            }
+            op.operation.state shouldBe Operation.State.ABORTED
+        }
+
+        "add completed progress entry updates operation state" {
+            val op = transaction {
+                md.addProgressEntry(vs, ProgressEntry(type = ProgressEntry.Type.COMPLETE, message = "message"))
+                md.getOperation(vs)
+            }
+            op.operation.state shouldBe Operation.State.COMPLETE
         }
     }
 }

--- a/server/src/test/kotlin/io/titandata/metadata/VolumeMetadataTest.kt
+++ b/server/src/test/kotlin/io/titandata/metadata/VolumeMetadataTest.kt
@@ -126,6 +126,18 @@ class VolumeMetadataTest : StringSpec() {
             }
         }
 
+        "list deleting volumes succeeds" {
+            val vs = createVolumeSet()
+            val volumes = transaction {
+                md.createVolume(vs, Volume("vol"))
+                md.markVolumeDeleting(vs, "vol")
+                md.listDeletingVolumes()
+            }
+            volumes.size shouldBe 1
+            volumes[0].first shouldBe vs
+            volumes[0].second.name shouldBe "vol"
+        }
+
         "delete volume succeeds" {
             val vs = createVolumeSet()
             transaction {

--- a/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
@@ -24,7 +24,6 @@ import io.titandata.exception.NoSuchObjectException
 import io.titandata.metadata.OperationData
 import io.titandata.models.Commit
 import io.titandata.models.Operation
-import io.titandata.models.ProgressEntry
 import io.titandata.models.Remote
 import io.titandata.models.RemoteParameters
 import io.titandata.models.Repository
@@ -101,7 +100,7 @@ class OperationExecutorTest : StringSpec() {
     }
 
     fun getExecutor(data: OperationData): OperationExecutor {
-        return OperationExecutor(services, data.operation, "foo", Remote("nop", "origin"), RemoteParameters("nop"),
+        return services.operations.createExecutor(data.operation, "foo", Remote("nop", "origin"), RemoteParameters("nop"),
                 data.metadataOnly)
     }
 
@@ -188,7 +187,7 @@ class OperationExecutorTest : StringSpec() {
             val executor = getExecutor(data)
             executor.run()
 
-            data.operation.state shouldBe Operation.State.COMPLETE
+            services.operations.getOperation(vs).state shouldBe Operation.State.COMPLETE
 
             verify {
                 nopProvider.syncVolume(any(), "volume", "volume", "/mountpoint", "/scratch")
@@ -212,7 +211,7 @@ class OperationExecutorTest : StringSpec() {
             val executor = getExecutor(data)
             executor.run()
 
-            data.operation.state shouldBe Operation.State.COMPLETE
+            services.operations.getOperation(vs).state shouldBe Operation.State.COMPLETE
 
             verify {
                 nopProvider.syncVolume(any(), "volume", "volume", "/mountpoint", "/scratch")
@@ -231,7 +230,7 @@ class OperationExecutorTest : StringSpec() {
             val executor = getExecutor(data)
             executor.run()
 
-            data.operation.state shouldBe Operation.State.ABORTED
+            services.operations.getOperation(vs).state shouldBe Operation.State.ABORTED
 
             verify {
                 context.deactivateVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
@@ -257,7 +256,7 @@ class OperationExecutorTest : StringSpec() {
             val executor = getExecutor(data)
             executor.run()
 
-            data.operation.state shouldBe Operation.State.FAILED
+            services.operations.getOperation(vs).state shouldBe Operation.State.FAILED
 
             verify {
                 context.deactivateVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
@@ -283,7 +282,7 @@ class OperationExecutorTest : StringSpec() {
             val executor = getExecutor(data)
             executor.run()
 
-            data.operation.state shouldBe Operation.State.FAILED
+            services.operations.getOperation(vs).state shouldBe Operation.State.FAILED
 
             verify {
                 nopProvider.endOperation(any(), false)

--- a/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
@@ -80,7 +80,7 @@ class OperationExecutorTest : StringSpec() {
                 state = Operation.State.RUNNING,
                 remote = "remote",
                 commitId = "id"
-        ), params = RemoteParameters("nop"), metadataOnly = false)
+        ), params = RemoteParameters("nop"), metadataOnly = false, repo = "foo")
         transaction {
             services.metadata.createOperation("foo", vs, data)
         }
@@ -106,64 +106,6 @@ class OperationExecutorTest : StringSpec() {
     }
 
     init {
-        "add progress appends entry" {
-            val data = createOperation()
-            val executor = getExecutor(data)
-            executor.addProgress(ProgressEntry(type = ProgressEntry.Type.MESSAGE, message = "message"))
-            val entries = transaction {
-                services.metadata.listProgressEntries(vs)
-            }
-            entries.size shouldBe 1
-            entries[0].message shouldBe "message"
-        }
-
-        "add failed progress entry updates operation state" {
-            val data = createOperation()
-            val executor = getExecutor(data)
-            executor.addProgress(ProgressEntry(type = ProgressEntry.Type.FAILED, message = "message"))
-            executor.operation.state shouldBe Operation.State.FAILED
-            val op = transaction {
-                services.metadata.getOperation(vs)
-            }
-            op.operation.state shouldBe Operation.State.FAILED
-        }
-
-        "add aborted progress entry updates operation state" {
-            val data = createOperation()
-            val executor = getExecutor(data)
-            executor.addProgress(ProgressEntry(type = ProgressEntry.Type.ABORT, message = "message"))
-            executor.operation.state shouldBe Operation.State.ABORTED
-            val op = transaction {
-                services.metadata.getOperation(vs)
-            }
-            op.operation.state shouldBe Operation.State.ABORTED
-        }
-
-        "add completed progress entry updates operation state" {
-            val data = createOperation()
-            val executor = getExecutor(data)
-            executor.addProgress(ProgressEntry(type = ProgressEntry.Type.COMPLETE, message = "message"))
-            executor.operation.state shouldBe Operation.State.COMPLETE
-            val op = transaction {
-                services.metadata.getOperation(vs)
-            }
-            op.operation.state shouldBe Operation.State.COMPLETE
-        }
-
-        "get progress tracks last updated progress" {
-            val data = createOperation()
-            val executor = getExecutor(data)
-            executor.addProgress(ProgressEntry(type = ProgressEntry.Type.MESSAGE, message = "one"))
-            var progress = executor.getProgress()
-            progress.size shouldBe 1
-            progress[0].message shouldBe "one"
-            progress = executor.getProgress()
-            progress.size shouldBe 0
-            executor.addProgress(ProgressEntry(type = ProgressEntry.Type.MESSAGE, message = "two"))
-            progress = executor.getProgress()
-            progress.size shouldBe 1
-            progress[0].message shouldBe "two"
-        }
 
         "abort interrupts thread" {
             val thread = mockk<Thread>()

--- a/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
@@ -108,12 +108,6 @@ class OperationOrchestratorTest : StringSpec() {
             }
         }
 
-        "get operation fails for invalid repository name" {
-            shouldThrow<IllegalArgumentException> {
-                services.operations.getOperation(UUID.randomUUID().toString())
-            }
-        }
-
         "get operation fails for non-existent repository" {
             shouldThrow<NoSuchObjectException> {
                 services.operations.getOperation(UUID.randomUUID().toString())
@@ -444,10 +438,6 @@ class OperationOrchestratorTest : StringSpec() {
             progress.size shouldBe 2
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[1].type shouldBe ProgressEntry.Type.COMPLETE
-
-            shouldThrow<NoSuchObjectException> {
-                services.operations.getOperation(op.id)
-            }
         }
 
         "error during pull is reported correctly" {
@@ -549,10 +539,6 @@ class OperationOrchestratorTest : StringSpec() {
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[0].message shouldBe "Pushing id to 'remote'"
             progress[1].type shouldBe ProgressEntry.Type.COMPLETE
-
-            shouldThrow<NoSuchObjectException> {
-                services.operations.getOperation(op.id)
-            }
         }
 
         "error during push is reported correctly" {

--- a/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
@@ -88,51 +88,41 @@ class OperationOrchestratorTest : StringSpec() {
                 state = Operation.State.RUNNING,
                 remote = "remote",
                 commitId = "id"
-        ), params = params, metadataOnly = false)
+        ), params = params, metadataOnly = false, repo = "foo")
     }
 
     init {
         "get operation succeeds" {
             transaction {
                 services.metadata.createOperation("foo", vs, buildOperation())
-                val op = services.operations.getOperation("foo", vs)
+                val op = services.operations.getOperation(vs)
                 op.id shouldBe vs
                 op.remote shouldBe "remote"
                 op.commitId shouldBe "id"
             }
         }
 
-        "get operation fails if incorrect repo specified" {
-            transaction {
-                services.metadata.createOperation("foo", vs, buildOperation())
-                services.metadata.createRepository(Repository(name = "bar"))
-            }
-            shouldThrow<NoSuchObjectException> {
-                services.operations.getOperation("bar", vs)
-            }
-        }
-
         "get operation fails for invalid operation id" {
             shouldThrow<IllegalArgumentException> {
-                services.operations.getOperation("foo", "bad/id")
+                services.operations.getOperation("bad/id")
             }
         }
 
         "get operation fails for invalid repository name" {
             shouldThrow<IllegalArgumentException> {
-                services.operations.getOperation("bad/repo", UUID.randomUUID().toString())
+                services.operations.getOperation(UUID.randomUUID().toString())
             }
         }
 
         "get operation fails for non-existent repository" {
             shouldThrow<NoSuchObjectException> {
-                services.operations.getOperation("bar", UUID.randomUUID().toString())
+                services.operations.getOperation(UUID.randomUUID().toString())
             }
         }
 
         "get operation fails for non-existent operation" {
             shouldThrow<NoSuchObjectException> {
-                services.operations.getOperation("repo", UUID.randomUUID().toString())
+                services.operations.getOperation(UUID.randomUUID().toString())
             }
         }
 
@@ -294,27 +284,15 @@ class OperationOrchestratorTest : StringSpec() {
             }
         }
 
-        "abort operation fails for bad repository name" {
-            shouldThrow<IllegalArgumentException> {
-                services.operations.abortOperation("bad/repo", vs)
-            }
-        }
-
         "abort operation fails for bad operation name" {
             shouldThrow<IllegalArgumentException> {
-                services.operations.abortOperation("foo", "badid")
-            }
-        }
-
-        "abort operation fails for unknown repository" {
-            shouldThrow<NoSuchObjectException> {
-                services.operations.abortOperation("bar", vs)
+                services.operations.abortOperation("badid")
             }
         }
 
         "abort operation fails for unknown operation" {
             shouldThrow<NoSuchObjectException> {
-                services.operations.abortOperation("bar", UUID.randomUUID().toString())
+                services.operations.abortOperation(UUID.randomUUID().toString())
             }
         }
 
@@ -457,18 +435,18 @@ class OperationOrchestratorTest : StringSpec() {
             op.commitId shouldBe "commit"
             op.type shouldBe Operation.Type.PULL
             op.remote shouldBe "remote"
-            services.operations.getExecutor("foo", op.id).join()
+            services.operations.waitForComplete(op.id)
 
-            op = services.operations.getOperation("foo", op.id)
+            op = services.operations.getOperation(op.id)
             op.state shouldBe Operation.State.COMPLETE
 
-            val progress = services.operations.getProgress("foo", op.id)
+            val progress = services.operations.getProgress(op.id)
             progress.size shouldBe 2
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[1].type shouldBe ProgressEntry.Type.COMPLETE
 
             shouldThrow<NoSuchObjectException> {
-                services.operations.getOperation("foo", op.id)
+                services.operations.getOperation(op.id)
             }
         }
 
@@ -481,12 +459,12 @@ class OperationOrchestratorTest : StringSpec() {
             every { nopProvider.startOperation(any()) } throws Exception("error")
 
             var op = services.operations.startPull("foo", "remote", "commit", params)
-            services.operations.getExecutor("foo", op.id).join()
+            services.operations.waitForComplete(op.id)
 
-            op = services.operations.getOperation("foo", op.id)
+            op = services.operations.getOperation(op.id)
             op.state shouldBe Operation.State.FAILED
 
-            val progress = services.operations.getProgress("foo", op.id)
+            val progress = services.operations.getProgress(op.id)
             progress.size shouldBe 2
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[0].message shouldBe "Pulling commit from 'remote'"
@@ -503,12 +481,12 @@ class OperationOrchestratorTest : StringSpec() {
             every { nopProvider.startOperation(any()) } throws InterruptedException()
 
             var op = services.operations.startPull("foo", "remote", "commit", params)
-            services.operations.getExecutor("foo", op.id).join()
+            services.operations.waitForComplete(op.id)
 
-            op = services.operations.getOperation("foo", op.id)
+            op = services.operations.getOperation(op.id)
             op.state shouldBe Operation.State.ABORTED
 
-            val progress = services.operations.getProgress("foo", op.id)
+            val progress = services.operations.getProgress(op.id)
             progress.size shouldBe 2
             progress[1].type shouldBe ProgressEntry.Type.ABORT
         }
@@ -537,8 +515,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { context.createVolumeSet(any()) } just Runs
 
             var op = services.operations.startPull("foo", "remote", "commit", params)
-            services.operations.getExecutor("foo", op.id).join()
-            op = services.operations.getOperation("foo", op.id)
+            services.operations.waitForComplete(op.id)
+            op = services.operations.getOperation(op.id)
             op.state shouldBe Operation.State.COMPLETE
         }
 
@@ -561,19 +539,19 @@ class OperationOrchestratorTest : StringSpec() {
             op.commitId shouldBe "id"
             op.type shouldBe Operation.Type.PUSH
             op.remote shouldBe "remote"
-            services.operations.getExecutor("foo", op.id).join()
+            services.operations.waitForComplete(op.id)
 
-            op = services.operations.getOperation("foo", op.id)
+            op = services.operations.getOperation(op.id)
             op.state shouldBe Operation.State.COMPLETE
 
-            val progress = services.operations.getProgress("foo", op.id)
+            val progress = services.operations.getProgress(op.id)
             progress.size shouldBe 2
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[0].message shouldBe "Pushing id to 'remote'"
             progress[1].type shouldBe ProgressEntry.Type.COMPLETE
 
             shouldThrow<NoSuchObjectException> {
-                services.operations.getOperation("foo", op.id)
+                services.operations.getOperation(op.id)
             }
         }
 
@@ -587,12 +565,12 @@ class OperationOrchestratorTest : StringSpec() {
             every { nopProvider.startOperation(any()) } throws Exception("error")
 
             var op = services.operations.startPush("foo", "remote", "id", params)
-            services.operations.getExecutor("foo", op.id).join()
+            services.operations.waitForComplete(op.id)
 
-            op = services.operations.getOperation("foo", op.id)
+            op = services.operations.getOperation(op.id)
             op.state shouldBe Operation.State.FAILED
 
-            val progress = services.operations.getProgress("foo", op.id)
+            val progress = services.operations.getProgress(op.id)
             progress.size shouldBe 2
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[0].message shouldBe "Pushing id to 'remote'"
@@ -610,12 +588,11 @@ class OperationOrchestratorTest : StringSpec() {
             every { nopProvider.startOperation(any()) } throws InterruptedException()
 
             var op = services.operations.startPush("foo", "remote", "id", params)
-            services.operations.getExecutor("foo", op.id).join()
-
-            op = services.operations.getOperation("foo", op.id)
+            services.operations.waitForComplete(op.id)
+            op = services.operations.getOperation(op.id)
             op.state shouldBe Operation.State.ABORTED
 
-            val progress = services.operations.getProgress("foo", op.id)
+            val progress = services.operations.getProgress(op.id)
             progress.size shouldBe 2
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[0].message shouldBe "Pushing id to 'remote'"
@@ -650,8 +627,8 @@ class OperationOrchestratorTest : StringSpec() {
             every { context.cloneVolume(any(), any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
 
             var op = services.operations.startPush("foo", "remote", "id", params)
-            services.operations.getExecutor("foo", op.id).join()
-            op = services.operations.getOperation("foo", op.id)
+            services.operations.waitForComplete(op.id)
+            op = services.operations.getOperation(op.id)
             op.state shouldBe Operation.State.COMPLETE
         }
 
@@ -672,12 +649,12 @@ class OperationOrchestratorTest : StringSpec() {
             every { context.cloneVolume(any(), any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
 
             services.operations.loadState()
-            services.operations.getExecutor("foo", vs).join()
+            services.operations.waitForComplete(vs)
 
-            var op = services.operations.getOperation("foo", vs)
+            var op = services.operations.getOperation(vs)
             op.state shouldBe Operation.State.COMPLETE
 
-            val progress = services.operations.getProgress("foo", op.id)
+            val progress = services.operations.getProgress(op.id)
             progress.size shouldBe 2
             progress[0].type shouldBe ProgressEntry.Type.MESSAGE
             progress[0].message shouldBe "Retrying operation after restart"

--- a/server/src/test/kotlin/io/titandata/orchestrator/ReaperTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/ReaperTest.kt
@@ -154,7 +154,7 @@ class ReaperTest : StringSpec() {
             }
         }
 
-        "mark empty volume sets ignores volume sets with operations" {
+        "mark empty volume sets ignores volume sets with running operations" {
             transaction {
                 services.metadata.createRepository(Repository("foo"))
                 val vs = services.metadata.createVolumeSet("foo")
@@ -162,7 +162,7 @@ class ReaperTest : StringSpec() {
                         operation = Operation(
                                 id = vs,
                                 type = Operation.Type.PUSH,
-                                state = Operation.State.COMPLETE,
+                                state = Operation.State.RUNNING,
                                 remote = "origin",
                                 commitId = "commit"
                         ),

--- a/server/src/test/kotlin/io/titandata/orchestrator/ReaperTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/ReaperTest.kt
@@ -167,7 +167,8 @@ class ReaperTest : StringSpec() {
                                 commitId = "commit"
                         ),
                         params = RemoteParameters("nop"),
-                        metadataOnly = false
+                        metadataOnly = false,
+                        repo = "foo"
                 ))
             }
             services.reaper.markEmptyVolumeSets()


### PR DESCRIPTION
## Proposed Changes

Previously, operations existed only as long the last progress entry hadn't been read. The internal implementation had an in-memory map of operations that represented their current state. Both of these created challenges as we went to implement operations as an async pod for k8s. This PR changes the server such that operations always exist, whether they're in progress or not, and updates the APIs so that there is a global operations namespace instead of a per-repo one (which was always faked up). Running operations are now only meaningful for abort() (and waiting, but that's test-only). This will make it much easier to implement in k8s, as there won't have to be any tight interlock with the in-memory state. As part of this change, the responsibility for remembering the last progress entry fetched has been pushed onto the client, so that we don't need to remember global operation state within the server (a much saner behavior).

## Testing

`gradle build test integrationTest endtoendTest`