### PR TITLE
refactor operations to isolate context-specific data sync

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -57,9 +57,9 @@ dependencies {
     compile("com.squareup.okhttp3:okhttp:3.14.2")
     compile("com.google.code.gson:gson:2.8.6")
     compile("io.titandata:remote-sdk:0.2.0")
-    compile("io.titandata:nop-remote-client:0.1.0")
+    compile("io.titandata:nop-remote-client:0.2.0")
     compile("io.titandata:ssh-remote-client:0.1.0")
-    compile("io.titandata:s3-remote-client:0.1.0")
-    compile("io.titandata:s3web-remote-client:0.1.0")
-    compile("io.titandata:delphix-remote-client:0.1.0")
+    compile("io.titandata:s3-remote-client:0.2.0")
+    compile("io.titandata:s3web-remote-client:0.2.0")
+    compile("io.titandata:delphix-remote-client:0.2.0")
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     compile(kotlin("stdlib"))
     compile("com.squareup.okhttp3:okhttp:3.14.2")
     compile("com.google.code.gson:gson:2.8.6")
-    compile("io.titandata:remote-sdk:0.1.0")
+    compile("io.titandata:remote-sdk:0.2.0")
     compile("io.titandata:nop-remote-client:0.1.0")
     compile("io.titandata:ssh-remote-client:0.1.0")
     compile("io.titandata:s3-remote-client:0.1.0")

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     compile("com.google.code.gson:gson:2.8.6")
     compile("io.titandata:remote-sdk:0.2.0")
     compile("io.titandata:nop-remote-client:0.2.0")
-    compile("io.titandata:ssh-remote-client:0.1.0")
+    compile("io.titandata:ssh-remote-client:0.2.0")
     compile("io.titandata:s3-remote-client:0.2.0")
     compile("io.titandata:s3web-remote-client:0.2.0")
     compile("io.titandata:delphix-remote-client:0.2.0")

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     // Remotes
     compile("io.titandata:remote-sdk:0.2.0")
     compile("io.titandata:nop-remote-server:0.2.0")
-    compile("io.titandata:ssh-remote-server:0.1.0")
+    compile("io.titandata:ssh-remote-server:0.2.0")
     compile("io.titandata:s3-remote-server:0.2.0")
     compile("io.titandata:s3web-remote-server:0.2.0")
     compile("io.titandata:delphix-remote-server:0.2.0")

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     compile("io.kubernetes:client-java:6.0.1")
 
     // Remotes
-    compile("io.titandata:remote-sdk:0.1.0")
+    compile("io.titandata:remote-sdk:0.2.0")
     compile("io.titandata:nop-remote-server:0.1.0")
     compile("io.titandata:ssh-remote-server:0.1.0")
     compile("io.titandata:s3-remote-server:0.1.0")

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -41,11 +41,11 @@ dependencies {
 
     // Remotes
     compile("io.titandata:remote-sdk:0.2.0")
-    compile("io.titandata:nop-remote-server:0.1.0")
+    compile("io.titandata:nop-remote-server:0.2.0")
     compile("io.titandata:ssh-remote-server:0.1.0")
-    compile("io.titandata:s3-remote-server:0.1.0")
-    compile("io.titandata:s3web-remote-server:0.1.0")
-    compile("io.titandata:delphix-remote-server:0.1.0")
+    compile("io.titandata:s3-remote-server:0.2.0")
+    compile("io.titandata:s3web-remote-server:0.2.0")
+    compile("io.titandata:delphix-remote-server:0.2.0")
 
     testCompile("com.h2database:h2:1.4.200")
     testCompile("io.ktor:ktor-server-test-host:$ktorVersion")

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -5,7 +5,10 @@
 package io.titandata.context
 
 import io.titandata.models.CommitStatus
+import io.titandata.models.Volume
 import io.titandata.models.VolumeStatus
+import io.titandata.remote.RemoteOperation
+import io.titandata.remote.RemoteServer
 
 interface RuntimeContext {
     fun getProvider(): String
@@ -27,4 +30,6 @@ interface RuntimeContext {
     fun activateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
     fun deactivateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>)
     fun deleteVolumeCommit(volumeSet: String, commitId: String, volumeName: String)
+
+    fun syncVolumes(provider: RemoteServer, operation: RemoteOperation, volumes: List<Volume>, scratchVolume: Volume)
 }

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -14,7 +14,10 @@ import io.kubernetes.client.util.Config
 import io.kubernetes.client.util.KubeConfig
 import io.titandata.context.RuntimeContext
 import io.titandata.models.CommitStatus
+import io.titandata.models.Volume
 import io.titandata.models.VolumeStatus
+import io.titandata.remote.RemoteOperation
+import io.titandata.remote.RemoteServer
 import io.titandata.shell.CommandException
 import io.titandata.shell.CommandExecutor
 import java.io.FileReader
@@ -304,5 +307,9 @@ class KubernetesCsiContext(private val properties: Map<String, String> = emptyMa
 
     override fun deactivateVolume(volumeSet: String, volumeName: String, config: Map<String, Any>) {
         // Nothing to do
+    }
+
+    override fun syncVolumes(provider: RemoteServer, operation: RemoteOperation, volumes: List<Volume>, scratchVolume: Volume) {
+        TODO("not implemented")
     }
 }

--- a/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
+++ b/server/src/main/kotlin/io/titandata/operation/OperationExecutor.kt
@@ -131,7 +131,7 @@ class OperationExecutor(
             if (metadataOnly) {
                 services.commits.updateCommit(repo, commit)
             } else {
-                services.commits.createCommit(repo, commit)
+                services.commits.createCommit(repo, commit, operation.operationId)
             }
         }
     }

--- a/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
@@ -94,8 +94,7 @@ class OperationExecutorTest : StringSpec() {
                 commit = null,
                 remote = emptyMap(),
                 parameters = emptyMap(),
-                type = type,
-                data = null
+                type = type
         )
     }
 
@@ -149,7 +148,7 @@ class OperationExecutorTest : StringSpec() {
                 context.deactivateVolume(data.operation.id, "volume", mapOf("mountpoint" to "/mountpoint"))
                 context.createVolume(data.operation.id, "_scratch")
                 context.deleteVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
-                nopProvider.syncVolume(remoteOperation, "volume", "volume", "/mountpoint", "/scratch")
+                nopProvider.syncDataVolume(remoteOperation, any(), "volume", "volume", "/mountpoint", "/scratch")
             }
         }
 
@@ -172,7 +171,7 @@ class OperationExecutorTest : StringSpec() {
                 context.deactivateVolume(data.operation.id, "volume", mapOf("mountpoint" to "/mountpoint"))
                 context.createVolume(data.operation.id, "_scratch")
                 context.deleteVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
-                nopProvider.syncVolume(remoteOperation, "volume", "volume", "/mountpoint", "/scratch")
+                nopProvider.syncDataVolume(remoteOperation, any(), "volume", "volume", "/mountpoint", "/scratch")
             }
         }
 
@@ -190,7 +189,7 @@ class OperationExecutorTest : StringSpec() {
             services.operations.getOperation(vs).state shouldBe Operation.State.COMPLETE
 
             verify {
-                nopProvider.syncVolume(any(), "volume", "volume", "/mountpoint", "/scratch")
+                nopProvider.syncDataVolume(any(), any(), "volume", "volume", "/mountpoint", "/scratch")
                 context.commitVolumeSet(data.operation.id, "id")
                 context.commitVolume(data.operation.id, "id", "volume", mapOf("mountpoint" to "/mountpoint"))
             }
@@ -214,7 +213,7 @@ class OperationExecutorTest : StringSpec() {
             services.operations.getOperation(vs).state shouldBe Operation.State.COMPLETE
 
             verify {
-                nopProvider.syncVolume(any(), "volume", "volume", "/mountpoint", "/scratch")
+                nopProvider.syncDataVolume(any(), any(), "volume", "volume", "/mountpoint", "/scratch")
             }
         }
 
@@ -224,7 +223,7 @@ class OperationExecutorTest : StringSpec() {
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
             every { context.createVolume(any(), "_scratch") } returns mapOf("mountpoint" to "/scratch")
             every { context.deleteVolume(any(), any(), any()) } just Runs
-            every { nopProvider.syncVolume(any(), any(), any(), any(), any()) } throws InterruptedException()
+            every { nopProvider.syncDataVolume(any(), any(), any(), any(), any(), any()) } throws InterruptedException()
 
             val data = createOperation(Operation.Type.PULL)
             val executor = getExecutor(data)
@@ -236,7 +235,7 @@ class OperationExecutorTest : StringSpec() {
                 context.deactivateVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
                 context.deactivateVolume(data.operation.id, "volume", mapOf("mountpoint" to "/mountpoint"))
                 context.deleteVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
-                nopProvider.syncVolume(any(), "volume", "volume", "/mountpoint", "/scratch")
+                nopProvider.syncDataVolume(any(), any(), "volume", "volume", "/mountpoint", "/scratch")
             }
 
             shouldThrow<NoSuchObjectException> {
@@ -250,7 +249,7 @@ class OperationExecutorTest : StringSpec() {
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
             every { context.createVolume(any(), "_scratch") } returns mapOf("mountpoint" to "/scratch")
             every { context.deleteVolume(any(), any(), any()) } just Runs
-            every { nopProvider.syncVolume(any(), any(), any(), any(), any()) } throws Exception()
+            every { nopProvider.syncDataVolume(any(), any(), any(), any(), any(), any()) } throws Exception()
 
             val data = createOperation(Operation.Type.PULL)
             val executor = getExecutor(data)
@@ -262,7 +261,7 @@ class OperationExecutorTest : StringSpec() {
                 context.deactivateVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
                 context.deactivateVolume(data.operation.id, "volume", mapOf("mountpoint" to "/mountpoint"))
                 context.deleteVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
-                nopProvider.syncVolume(any(), "volume", "volume", "/mountpoint", "/scratch")
+                nopProvider.syncDataVolume(any(), any(), "volume", "volume", "/mountpoint", "/scratch")
             }
 
             shouldThrow<NoSuchObjectException> {
@@ -276,7 +275,7 @@ class OperationExecutorTest : StringSpec() {
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
             every { context.createVolume(any(), "_scratch") } returns mapOf("mountpoint" to "/scratch")
             every { context.deleteVolume(any(), any(), any()) } just Runs
-            every { nopProvider.syncVolume(any(), any(), any(), any(), any()) } throws Exception()
+            every { nopProvider.syncDataVolume(any(), any(), any(), any(), any(), any()) } throws Exception()
 
             val data = createOperation(Operation.Type.PULL)
             val executor = getExecutor(data)
@@ -285,7 +284,7 @@ class OperationExecutorTest : StringSpec() {
             services.operations.getOperation(vs).state shouldBe Operation.State.FAILED
 
             verify {
-                nopProvider.endOperation(any(), false)
+                nopProvider.syncDataEnd(any(), any(), false)
             }
         }
     }

--- a/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
@@ -89,7 +89,7 @@ class OperationExecutorTest : StringSpec() {
     fun createRemoteOperation(type: RemoteOperationType = RemoteOperationType.PULL): RemoteOperation {
         return RemoteOperation(
                 updateProgress = { _: RemoteProgress, _: String?, _: Int? -> Unit },
-                operationId = "operation",
+                operationId = vs,
                 commitId = "commit",
                 commit = null,
                 remote = emptyMap(),

--- a/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
+++ b/server/src/test/kotlin/io/titandata/orchestrator/OperationOrchestratorTest.kt
@@ -423,7 +423,7 @@ class OperationOrchestratorTest : StringSpec() {
             every { context.commitVolumeSet(any(), any()) } just Runs
             every { context.commitVolume(any(), any(), any(), any()) } just Runs
             every { context.createVolumeSet(any()) } just Runs
-            every { nopProvider.syncVolume(any(), any(), any(), any(), any()) } just Runs
+            every { nopProvider.syncDataVolume(any(), any(), any(), any(), any(), any()) } just Runs
 
             var op = services.operations.startPull("foo", "remote", "commit", params)
             op.commitId shouldBe "commit"
@@ -446,7 +446,7 @@ class OperationOrchestratorTest : StringSpec() {
             }
             every { context.createVolumeSet(any()) } just Runs
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
-            every { nopProvider.startOperation(any()) } throws Exception("error")
+            every { nopProvider.syncDataStart(any()) } throws Exception("error")
 
             var op = services.operations.startPull("foo", "remote", "commit", params)
             services.operations.waitForComplete(op.id)
@@ -468,7 +468,7 @@ class OperationOrchestratorTest : StringSpec() {
             }
             every { context.createVolumeSet(any()) } just Runs
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
-            every { nopProvider.startOperation(any()) } throws InterruptedException()
+            every { nopProvider.syncDataStart(any()) } throws InterruptedException()
 
             var op = services.operations.startPull("foo", "remote", "commit", params)
             services.operations.waitForComplete(op.id)
@@ -548,7 +548,7 @@ class OperationOrchestratorTest : StringSpec() {
             }
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
             every { context.cloneVolume(any(), any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
-            every { nopProvider.startOperation(any()) } throws Exception("error")
+            every { nopProvider.syncDataStart(any()) } throws Exception("error")
 
             var op = services.operations.startPush("foo", "remote", "id", params)
             services.operations.waitForComplete(op.id)
@@ -571,7 +571,7 @@ class OperationOrchestratorTest : StringSpec() {
             }
             every { context.cloneVolumeSet(any(), any(), any()) } just Runs
             every { context.cloneVolume(any(), any(), any(), any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
-            every { nopProvider.startOperation(any()) } throws InterruptedException()
+            every { nopProvider.syncDataStart(any()) } throws InterruptedException()
 
             var op = services.operations.startPush("foo", "remote", "id", params)
             services.operations.waitForComplete(op.id)


### PR DESCRIPTION
## Proposed Changes

This change refactors the operation executor to separate out the data sync portion and push that into the context provider.  All the volumes are activated by the time that method is called, so the DockerZfs provider simply calls the sync volume method with the local path. In k8s, we'll launch a separate pod with PVCs for each of those volumes.

## Testing

`gradle build test inegrationTest endtoendTest`, including Kubernetes tests.
