### PR TITLE
k8s operations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         classpath("com.github.ben-manes:gradle-versions-plugin:0.27.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
     }
 }
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     kotlin("jvm")
     jacoco
     application
-    id("com.github.johnrengelman.shadow") version("5.1.0")
+    id("com.github.johnrengelman.shadow") version("5.2.0")
 }
 
 val titanVersion: String by rootProject.extra
@@ -24,7 +24,7 @@ repositories {
     }
 }
 
-val ktorVersion = "1.2.5"
+val ktorVersion = "1.2.6"
 
 dependencies {
     compile(project(":client"))

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
@@ -32,6 +32,7 @@ class KubernetesContextTest : KubernetesTest() {
             waitForVolume(vs, "test", volumeConfig)
         }
 
+        /*
         "create pod succeeds" {
             launchPod("$vs-test", "$vs-test")
             waitForPod("$vs-test")
@@ -50,6 +51,8 @@ class KubernetesContextTest : KubernetesTest() {
             executor.exec("kubectl", "delete", "pod", "--grace-period=0", "--force", "$vs-test")
         }
 
+         */
+
         "syncVolumes succeeds" {
             val provider = NopRemoteServer()
             val operation = RemoteOperation(
@@ -64,6 +67,7 @@ class KubernetesContextTest : KubernetesTest() {
             context.syncVolumes(provider, operation, emptyList(), Volume("test", emptyMap(), volumeConfig))
         }
 
+        /*
         "clone volume succeeds" {
             cloneConfig = context.cloneVolume(vs, "id", vs2, "test", volumeConfig)
             waitForVolume(vs2, "test", cloneConfig)
@@ -102,6 +106,8 @@ class KubernetesContextTest : KubernetesTest() {
         "delete of non-existent commit succeeds" {
             context.deleteVolumeCommit(vs, "id", "test")
         }
+
+         */
 
         "delete volume succeeds" {
             context.deleteVolume(vs, "test", volumeConfig)

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
@@ -4,6 +4,11 @@ import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kubernetes.client.ApiException
+import io.titandata.models.Volume
+import io.titandata.remote.RemoteOperation
+import io.titandata.remote.RemoteOperationType
+import io.titandata.remote.RemoteProgress
+import io.titandata.remote.nop.server.NopRemoteServer
 import io.titandata.shell.CommandException
 import java.util.UUID
 
@@ -43,6 +48,20 @@ class KubernetesContextTest : KubernetesTest() {
 
         "delete pod succeeds" {
             executor.exec("kubectl", "delete", "pod", "--grace-period=0", "--force", "$vs-test")
+        }
+
+        "syncVolumes succeeds" {
+            val provider = NopRemoteServer()
+            val operation = RemoteOperation(
+                    updateProgress = { _: RemoteProgress, _: String?, _: Int? -> Unit },
+                    operationId = vs,
+                    commitId = "commit",
+                    commit = emptyMap(),
+                    remote = emptyMap(),
+                    parameters = emptyMap(),
+                    type = RemoteOperationType.PUSH
+            )
+            context.syncVolumes(provider, operation, emptyList(), Volume("test", emptyMap(), volumeConfig))
         }
 
         "clone volume succeeds" {

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesContextTest.kt
@@ -32,7 +32,6 @@ class KubernetesContextTest : KubernetesTest() {
             waitForVolume(vs, "test", volumeConfig)
         }
 
-        /*
         "create pod succeeds" {
             launchPod("$vs-test", "$vs-test")
             waitForPod("$vs-test")
@@ -51,8 +50,6 @@ class KubernetesContextTest : KubernetesTest() {
             executor.exec("kubectl", "delete", "pod", "--grace-period=0", "--force", "$vs-test")
         }
 
-         */
-
         "syncVolumes succeeds" {
             val provider = NopRemoteServer()
             val operation = RemoteOperation(
@@ -67,7 +64,6 @@ class KubernetesContextTest : KubernetesTest() {
             context.syncVolumes(provider, operation, emptyList(), Volume("test", emptyMap(), volumeConfig))
         }
 
-        /*
         "clone volume succeeds" {
             cloneConfig = context.cloneVolume(vs, "id", vs2, "test", volumeConfig)
             waitForVolume(vs2, "test", cloneConfig)
@@ -106,8 +102,6 @@ class KubernetesContextTest : KubernetesTest() {
         "delete of non-existent commit succeeds" {
             context.deleteVolumeCommit(vs, "id", "test")
         }
-
-         */
 
         "delete volume succeeds" {
             context.deleteVolume(vs, "test", volumeConfig)

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesTest.kt
@@ -24,7 +24,19 @@ abstract class KubernetesTest : EndToEndTest("kubernetes-csi") {
     internal val executor = CommandExecutor()
 
     init {
-        context = KubernetesCsiContext()
+        val config = if (System.getProperty("kubernetes.config") != null) {
+            val configValues = System.getProperty("kubernetes.config")
+            val configMap = mutableMapOf<String, String>()
+            for (nameval in configValues.split(",")) {
+                val name = nameval.substringBefore("=")
+                val value = nameval.substringAfter("=")
+                configMap[name] = value
+            }
+            configMap
+        } else {
+            emptyMap<String, String>()
+        }
+        context = KubernetesCsiContext(config)
         coreApi = CoreV1Api()
     }
 

--- a/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/kubernetes/KubernetesWorkflowTest.kt
@@ -141,7 +141,6 @@ class KubernetesWorkflowTest : KubernetesTest() {
             executor.exec("kubectl", "delete", "pod", "--grace-period=0", "--force", "$uuid-test")
         }
 
-        /*
         "checkout commit" {
             commitApi.checkoutCommit("foo", "id")
         }
@@ -160,7 +159,6 @@ class KubernetesWorkflowTest : KubernetesTest() {
         "delete cloned pod succeeds" {
             executor.exec("kubectl", "delete", "pod", "--grace-period=0", "--force", "$uuid-test2")
         }
-         */
 
         "add s3 remote succeeds" {
             val remote = getRemote()
@@ -174,6 +172,11 @@ class KubernetesWorkflowTest : KubernetesTest() {
 
         "delete commit" {
             commitApi.deleteCommit("foo", "id")
+        }
+
+        "pull original commit succeeds" {
+            val op = operationApi.pull("foo", "origin", "id", params)
+            waitForOperation(op.id)
         }
 
         "delete volume" {

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -377,7 +377,7 @@ class KubernetesCsiContext(private val properties: Map<String, String> = emptyMa
                 type = operation.type,
                 scratchVolume = scratchVolume.name,
                 volumes = volumes.map { it.name },
-                volumeDescriptions = volumes.map { it.properties["mountpoint"] as? String ?: it.name }
+                volumeDescriptions = volumes.map { it.properties["path"] as? String ?: it.name }
         )
         val configJson = gson.toJson(kubeOperation)
         log.info("creating secret ${metadata.name}")

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesRunner.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesRunner.kt
@@ -1,0 +1,120 @@
+package io.titandata.context.kubernetes
+
+import com.google.gson.GsonBuilder
+import io.titandata.models.ProgressEntry
+import io.titandata.remote.RemoteOperation
+import io.titandata.remote.RemoteOperationType
+import io.titandata.remote.RemoteProgress
+import io.titandata.remote.RemoteServer
+import java.io.FileReader
+import java.util.ServiceLoader
+
+/*
+ * This main entry point is invoked in the context of a new pod via KubernetesCsiContext in order to perform push
+ * and pull operations.
+ *
+ * The runner is passed the base path to the directory tree with the data and configuration. This should look like:
+ *
+ *      /var/titan/
+ *          _config.json        Operation configuration (serialized KubernetesParameters)
+ *          _scratch/           Scratch space
+ *          <volume>/           One or more volumes
+ *
+ * Progress reporting is sent to the console as a JSON data (KubernetesProgress). The KubernetesCsiContext driver will
+ * ignore any data
+ */
+
+/**
+ * This parameters object is passed (in JSON form) from the main KubernetesCsiContext to the KubernetesRunner executing
+ * in a separate pod. It's basically an alternate form of the RemoteOperation data class that doesn't have the
+ * unserializable callback within it.
+ */
+data class KubernetesOperation(
+    val remoteType: String,
+    val remote: Map<String, Any>,
+    val parameters: Map<String, Any>,
+    val operationId: String,
+    val commitId: String,
+    val commit: Map<String, Any>?,
+    val type: RemoteOperationType,
+    val scratchVolume: String,
+    val volumes: List<String>,
+    val volumeDescriptions: List<String>
+)
+
+/**
+ * This progress object is printed to stdout to then be consumed by the KubernetesCsiContext syncVolumes() method.
+ */
+data class KubernetesProgress(
+    val type: ProgressEntry.Type,
+    val message: String?,
+    val percent: Int?
+)
+
+class KubernetesRunner() {
+    private val loader = ServiceLoader.load(RemoteServer::class.java)
+    private val remoteProviders: MutableMap<String, RemoteServer>
+    private val gson = GsonBuilder().create()
+
+    init {
+        val providers = mutableMapOf<String, RemoteServer>()
+        loader.forEach {
+            if (it != null) {
+                providers[it.getProvider()] = it
+            }
+        }
+        remoteProviders = providers
+    }
+
+    val updateProgress = fun(type: RemoteProgress, message: String?, percent: Int?) {
+        val progressType = when (type) {
+            RemoteProgress.START -> ProgressEntry.Type.START
+            RemoteProgress.END -> ProgressEntry.Type.END
+            RemoteProgress.PROGRESS -> ProgressEntry.Type.PROGRESS
+            RemoteProgress.MESSAGE -> ProgressEntry.Type.MESSAGE
+        }
+        val progress = KubernetesProgress(type = progressType, message = message, percent = percent)
+        println(gson.toJson(progress))
+    }
+
+    fun runOperation(basePath: String, params: KubernetesOperation) {
+        val operation = RemoteOperation(
+                updateProgress = updateProgress,
+                type = params.type,
+                commit = params.commit,
+                commitId = params.commitId,
+                operationId = params.operationId,
+                remote = params.remote,
+                parameters = params.parameters
+        )
+
+        val remote = remoteProviders[params.remoteType] ?: error("unknown remote type '${params.remoteType}'")
+        val scratchPath = params.scratchVolume
+        val data = remote.syncDataStart(operation)
+        var success = false
+        try {
+            for ((idx, volume) in params.volumes.withIndex()) {
+                remote.syncDataVolume(operation, data, volume, params.volumeDescriptions[idx], "$basePath/$volume",
+                        "$basePath/$scratchPath")
+            }
+            success = true
+        } finally {
+            remote.syncDataEnd(operation, data, success)
+        }
+    }
+}
+
+fun main(args: Array<String>) {
+    val gson = GsonBuilder().create()
+
+    val basePath = System.getProperty("basePath") ?: error("missing basePath property")
+    val operation = gson.fromJson(FileReader("$basePath/_config.json"), KubernetesOperation::class.java)
+
+    try {
+        KubernetesRunner().runOperation(basePath, operation)
+        println(gson.toJson(KubernetesProgress(ProgressEntry.Type.COMPLETE, null, null)))
+    } catch (t: Throwable) {
+        println(gson.toJson(KubernetesProgress(ProgressEntry.Type.ERROR, t.message, null)))
+        throw t
+    }
+}

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesRunner.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesRunner.kt
@@ -16,8 +16,8 @@ import java.util.ServiceLoader
  * The runner is passed the base path to the directory tree with the data and configuration. This should look like:
  *
  *      /var/titan/
- *          _secret/config      Operation configuration (serialized KubernetesParameters)
- *          _scratch/           Scratch space
+ *          x-secret/config      Operation configuration (serialized KubernetesParameters)
+ *          x-scratch/           Scratch space
  *          <volume>/           One or more volumes
  *
  * Progress reporting is sent to the console as a JSON data (KubernetesProgress). The KubernetesCsiContext driver will
@@ -100,7 +100,7 @@ fun main(args: Array<String>) {
     val gson = GsonBuilder().create()
 
     val basePath = System.getProperty("basePath") ?: error("missing basePath property")
-    val operation = gson.fromJson(FileReader("$basePath/_secret/config"), KubernetesOperation::class.java)
+    val operation = gson.fromJson(FileReader("$basePath/x-secret/config"), KubernetesOperation::class.java)
 
     val runner = KubernetesRunner()
     try {

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesRunner.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesRunner.kt
@@ -16,7 +16,7 @@ import java.util.ServiceLoader
  * The runner is passed the base path to the directory tree with the data and configuration. This should look like:
  *
  *      /var/titan/
- *          _config.json        Operation configuration (serialized KubernetesParameters)
+ *          _secret/config      Operation configuration (serialized KubernetesParameters)
  *          _scratch/           Scratch space
  *          <volume>/           One or more volumes
  *
@@ -108,7 +108,7 @@ fun main(args: Array<String>) {
     val gson = GsonBuilder().create()
 
     val basePath = System.getProperty("basePath") ?: error("missing basePath property")
-    val operation = gson.fromJson(FileReader("$basePath/_config.json"), KubernetesOperation::class.java)
+    val operation = gson.fromJson(FileReader("$basePath/_secret/config"), KubernetesOperation::class.java)
 
     try {
         KubernetesRunner().runOperation(basePath, operation)

--- a/server/src/main/kotlin/io/titandata/orchestrator/NameUtil.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/NameUtil.kt
@@ -18,6 +18,10 @@ import java.util.UUID
  * For our names, we take the subset of those two groups (basically the kubernetes restrictions), but limit them to
  * 63 characters. 253 is just way more than we reasonably need, and by limiting it to 63 we can ensure that we can
  * concatenate multiple names and still remain under that 253 limit.
+ *
+ * There are time when we need special volume names that won't conflict with any user-defined volumes. However, they
+ * must remain otherwise valid volume names (lest we're unable to use them in kubernetes names, for example). So we
+ * reserve the "x-" namespace and don't allow
  */
 class NameUtil {
 
@@ -52,6 +56,9 @@ class NameUtil {
 
         fun validateVolumeName(volumeName: String) {
             validateCommon(volumeName, "volume")
+            if (volumeName.startsWith("x-")) {
+                throw IllegalArgumentException("invalid volume name, cannot start with 'x-'")
+            }
         }
 
         fun validateOperationId(operationId: String) {

--- a/server/src/scripts/kubernetesOperation
+++ b/server/src/scripts/kubernetesOperation
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#
+# Entry point for running a kubernetes operation. See KubernetesRunner for how this works. We expect the TITAN_PATH
+# environment variable to point to the base path for volumes and configuration, which is then passed to the runner.
+#
+
+exec java -DbasePath=$TITAN_PATH -cp /titan/titan-server.jar io.titandata.context.kubernetes.KubernetesRunnerKt
+

--- a/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
+++ b/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
@@ -260,7 +260,7 @@ class DockerZfsContextTest : StringSpec() {
             val op = createRemoteOperation()
             context.syncVolumes(nopProvider, op,
                     listOf(Volume("vol", mapOf("path" to "/path"), mapOf("mountpoint" to "/vol"))),
-                    Volume("_scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
+                    Volume("x-scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
             verify {
                 nopProvider.syncDataStart(op)
                 nopProvider.syncDataEnd(op, any(), true)
@@ -274,7 +274,7 @@ class DockerZfsContextTest : StringSpec() {
             shouldThrow<Exception> {
                 context.syncVolumes(nopProvider, op,
                         listOf(Volume("vol", mapOf("path" to "/path"), mapOf("mountpoint" to "/vol"))),
-                        Volume("_scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
+                        Volume("x-scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
             }
             verify {
                 nopProvider.syncDataEnd(op, any(), false)

--- a/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
+++ b/server/src/test/kotlin/io/titandata/operation/OperationExecutorTest.kt
@@ -123,7 +123,7 @@ class OperationExecutorTest : StringSpec() {
 
         "sync data for pull succeeds" {
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
-            every { context.createVolume(any(), "_scratch") } returns mapOf("mountpoint" to "/scratch")
+            every { context.createVolume(any(), "x-scratch") } returns mapOf("mountpoint" to "/scratch")
 
             val data = createOperation()
             val executor = getExecutor(data)
@@ -131,20 +131,20 @@ class OperationExecutorTest : StringSpec() {
             executor.syncData(services.remoteProvider("nop"), remoteOperation)
 
             verify {
-                context.activateVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
+                context.activateVolume(data.operation.id, "x-scratch", mapOf("mountpoint" to "/scratch"))
                 context.activateVolume(data.operation.id, "volume", mapOf("mountpoint" to "/mountpoint"))
-                context.deactivateVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
+                context.deactivateVolume(data.operation.id, "x-scratch", mapOf("mountpoint" to "/scratch"))
                 context.deactivateVolume(data.operation.id, "volume", mapOf("mountpoint" to "/mountpoint"))
-                context.createVolume(data.operation.id, "_scratch")
-                context.deleteVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
+                context.createVolume(data.operation.id, "x-scratch")
+                context.deleteVolume(data.operation.id, "x-scratch", mapOf("mountpoint" to "/scratch"))
                 context.syncVolumes(any(), any(), listOf(Volume("volume", emptyMap(), mapOf("mountpoint" to "/mountpoint"))),
-                        Volume("_scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
+                        Volume("x-scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
             }
         }
 
         "sync data for push succeeds" {
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
-            every { context.createVolume(any(), "_scratch") } returns mapOf("mountpoint" to "/scratch")
+            every { context.createVolume(any(), "x-scratch") } returns mapOf("mountpoint" to "/scratch")
 
             val data = createOperation(Operation.Type.PUSH)
             val executor = getExecutor(data)
@@ -152,20 +152,20 @@ class OperationExecutorTest : StringSpec() {
             executor.syncData(services.remoteProvider("nop"), remoteOperation)
 
             verify {
-                context.activateVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
+                context.activateVolume(data.operation.id, "x-scratch", mapOf("mountpoint" to "/scratch"))
                 context.activateVolume(data.operation.id, "volume", mapOf("mountpoint" to "/mountpoint"))
-                context.deactivateVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
+                context.deactivateVolume(data.operation.id, "x-scratch", mapOf("mountpoint" to "/scratch"))
                 context.deactivateVolume(data.operation.id, "volume", mapOf("mountpoint" to "/mountpoint"))
-                context.createVolume(data.operation.id, "_scratch")
-                context.deleteVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
+                context.createVolume(data.operation.id, "x-scratch")
+                context.deleteVolume(data.operation.id, "x-scratch", mapOf("mountpoint" to "/scratch"))
                 context.syncVolumes(any(), any(), listOf(Volume("volume", emptyMap(), mapOf("mountpoint" to "/mountpoint"))),
-                        Volume("_scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
+                        Volume("x-scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
             }
         }
 
         "pull operation succeeds" {
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
-            every { context.createVolume(any(), "_scratch") } returns mapOf("mountpoint" to "/scratch")
+            every { context.createVolume(any(), "x-scratch") } returns mapOf("mountpoint" to "/scratch")
 
             val data = createOperation(Operation.Type.PULL)
             val executor = getExecutor(data)
@@ -175,7 +175,7 @@ class OperationExecutorTest : StringSpec() {
 
             verify {
                 context.syncVolumes(any(), any(), listOf(Volume("volume", emptyMap(), mapOf("mountpoint" to "/mountpoint"))),
-                        Volume("_scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
+                        Volume("x-scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
                 context.commitVolumeSet(data.operation.id, "id")
                 context.commitVolume(data.operation.id, "id", "volume", mapOf("mountpoint" to "/mountpoint"))
             }
@@ -183,7 +183,7 @@ class OperationExecutorTest : StringSpec() {
 
         "push operation succeeds" {
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
-            every { context.createVolume(any(), "_scratch") } returns mapOf("mountpoint" to "/scratch")
+            every { context.createVolume(any(), "x-scratch") } returns mapOf("mountpoint" to "/scratch")
 
             transaction {
                 services.metadata.createCommit("foo", vs, Commit("id"))
@@ -197,13 +197,13 @@ class OperationExecutorTest : StringSpec() {
 
             verify {
                 context.syncVolumes(any(), any(), listOf(Volume("volume", emptyMap(), mapOf("mountpoint" to "/mountpoint"))),
-                        Volume("_scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
+                        Volume("x-scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
             }
         }
 
         "interrupted operation is aborted" {
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
-            every { context.createVolume(any(), "_scratch") } returns mapOf("mountpoint" to "/scratch")
+            every { context.createVolume(any(), "x-scratch") } returns mapOf("mountpoint" to "/scratch")
             every { context.syncVolumes(any(), any(), any(), any()) } throws InterruptedException()
 
             val data = createOperation(Operation.Type.PULL)
@@ -213,11 +213,11 @@ class OperationExecutorTest : StringSpec() {
             services.operations.getOperation(vs).state shouldBe Operation.State.ABORTED
 
             verify {
-                context.deactivateVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
+                context.deactivateVolume(data.operation.id, "x-scratch", mapOf("mountpoint" to "/scratch"))
                 context.deactivateVolume(data.operation.id, "volume", mapOf("mountpoint" to "/mountpoint"))
-                context.deleteVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
+                context.deleteVolume(data.operation.id, "x-scratch", mapOf("mountpoint" to "/scratch"))
                 context.syncVolumes(any(), any(), listOf(Volume("volume", emptyMap(), mapOf("mountpoint" to "/mountpoint"))),
-                        Volume("_scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
+                        Volume("x-scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
             }
 
             shouldThrow<NoSuchObjectException> {
@@ -227,7 +227,7 @@ class OperationExecutorTest : StringSpec() {
 
         "failed operation is marked failed" {
             every { context.createVolume(any(), any()) } returns mapOf("mountpoint" to "/mountpoint")
-            every { context.createVolume(any(), "_scratch") } returns mapOf("mountpoint" to "/scratch")
+            every { context.createVolume(any(), "x-scratch") } returns mapOf("mountpoint" to "/scratch")
             every { context.syncVolumes(any(), any(), any(), any()) } throws Exception()
 
             val data = createOperation(Operation.Type.PULL)
@@ -237,11 +237,11 @@ class OperationExecutorTest : StringSpec() {
             services.operations.getOperation(vs).state shouldBe Operation.State.FAILED
 
             verify {
-                context.deactivateVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
+                context.deactivateVolume(data.operation.id, "x-scratch", mapOf("mountpoint" to "/scratch"))
                 context.deactivateVolume(data.operation.id, "volume", mapOf("mountpoint" to "/mountpoint"))
-                context.deleteVolume(data.operation.id, "_scratch", mapOf("mountpoint" to "/scratch"))
+                context.deleteVolume(data.operation.id, "x-scratch", mapOf("mountpoint" to "/scratch"))
                 context.syncVolumes(any(), any(), listOf(Volume("volume", emptyMap(), mapOf("mountpoint" to "/mountpoint"))),
-                        Volume("_scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
+                        Volume("x-scratch", emptyMap(), mapOf("mountpoint" to "/scratch")))
             }
 
             shouldThrow<NoSuchObjectException> {


### PR DESCRIPTION
## Proposed Changes

This adds push & pull ability for k8s repositories. To do this, we add an alternate entry point to the jarfile (and docker container) that is then invoked via a k8s job, along with a secret describing the operation and all the required volumes. This then invokes the remote operation and streams progress to stdout, which is picked up by the main titan-server process.

Some changes that stretched their tendrils into other code include renaming "_scratch" to "x-scratch", and the ability to specify the titan image name in the configuration (necessary for testing since titandata/titan won't be available in the k8s cluster)

## Testing

`gradle build test integrationTest endtoendTest`, including new k8s tests. Ran with a modified titan CLI and successfully pushed to a S3 bucket and pulled down to a local repository.