### PR TITLE
support multiple local titan contexts

### DIFF
--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -67,7 +67,7 @@ class DockerUtil(
         val args = arrayOf("docker", "run",
                 "-d", "--restart", "always", "--name", "$identity-server",
                 "-v", "$home/.kube:/root/.kube", "-v", "$identity-data:/var/lib/$identity",
-                "-e", "TITAN_CONTEXT=kubernetes-csi", "-e", "TITAN_DATA=$identity",
+                "-e", "TITAN_CONTEXT=kubernetes-csi", "-e", "TITAN_IDENTITY=$identity",
                 "-e", "TITAN_CONFIG=$config",
                 "-p", "$port:5001", image, "/bin/bash", "/titan/$entryPoint")
         return executor.exec(*args).trim()

--- a/server/src/integration-test/kotlin/io/titandata/DockerVolumesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/DockerVolumesApiTest.kt
@@ -85,7 +85,7 @@ class DockerVolumesApiTest : StringSpec() {
         "create volume succeeds" {
             every { context.createVolume(any(), any()) } returns emptyMap()
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Create") {
-                setBody("{\"Name\":\"test/foo/vol\",\"Opts\":{\"a\":\"b\"}}")
+                setBody("{\"Name\":\"foo/vol\",\"Opts\":{\"a\":\"b\"}}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -99,7 +99,7 @@ class DockerVolumesApiTest : StringSpec() {
 
         "create volume for unknown repo fails" {
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Create") {
-                setBody("{\"Name\":\"test/bar/vol\",\"Opts\":{\"a\":\"b\"}}")
+                setBody("{\"Name\":\"bar/vol\",\"Opts\":{\"a\":\"b\"}}")
             }) {
                 response.status() shouldBe HttpStatusCode.NotFound
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -136,7 +136,7 @@ class DockerVolumesApiTest : StringSpec() {
                 services.metadata.createVolume(vs, Volume("vol"))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Remove") {
-                setBody("{\"Name\":\"test/foo/vol\"}")
+                setBody("{\"Name\":\"foo/vol\"}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -150,7 +150,7 @@ class DockerVolumesApiTest : StringSpec() {
             }
             every { context.activateVolume(any(), any(), any()) } just Runs
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Mount") {
-                setBody("{\"Name\":\"test/foo/vol\"}")
+                setBody("{\"Name\":\"foo/vol\"}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -168,7 +168,7 @@ class DockerVolumesApiTest : StringSpec() {
             }
             every { context.deactivateVolume(any(), any(), any()) } just Runs
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Unmount") {
-                setBody("{\"Name\":\"test/foo/vol\"}")
+                setBody("{\"Name\":\"foo/vol\"}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -185,7 +185,7 @@ class DockerVolumesApiTest : StringSpec() {
                 services.metadata.createVolume(vs, Volume(name = "vol", config = mapOf("mountpoint" to "/mountpoint")))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Path") {
-                setBody("{\"Name\":\"test/foo/vol\"}")
+                setBody("{\"Name\":\"foo/vol\"}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -194,18 +194,17 @@ class DockerVolumesApiTest : StringSpec() {
         }
 
         "get volume succeeds" {
-            every { context.getVolumePrefix() } returns "test"
             transaction {
                 services.metadata.createVolume(vs, Volume(name = "vol", properties = mapOf("a" to "b"), config = mapOf("mountpoint" to "/mountpoint")))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Get") {
-                setBody("{\"Name\":\"test/foo/vol\"}")
+                setBody("{\"Name\":\"foo/vol\"}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
                 response.content shouldBe "{\"Err\":\"\"," +
                         "\"Volume\":{" +
-                        "\"Name\":\"test/foo/vol\"," +
+                        "\"Name\":\"foo/vol\"," +
                         "\"Mountpoint\":\"/mountpoint\"," +
                         "\"Status\":{}," +
                         "\"properties\":{\"a\":\"b\"}" +
@@ -214,7 +213,6 @@ class DockerVolumesApiTest : StringSpec() {
         }
 
         "list volumes succeeds" {
-            every { context.getVolumePrefix() } returns "test"
             transaction {
                 services.metadata.createVolume(vs, Volume(name = "one", properties = mapOf("a" to "b"), config = mapOf("mountpoint" to "/mountpoint")))
                 services.metadata.createVolume(vs, Volume(name = "two", properties = mapOf("c" to "d"), config = mapOf("mountpoint" to "/mountpoint")))
@@ -225,12 +223,12 @@ class DockerVolumesApiTest : StringSpec() {
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
                 response.content shouldBe "{\"Err\":\"\"," +
                         "\"Volumes\":[{" +
-                        "\"Name\":\"test/foo/one\"," +
+                        "\"Name\":\"foo/one\"," +
                         "\"Mountpoint\":\"/mountpoint\"," +
                         "\"Status\":{}," +
                         "\"properties\":{\"a\":\"b\"}" +
                         "},{" +
-                        "\"Name\":\"test/foo/two\"," +
+                        "\"Name\":\"foo/two\"," +
                         "\"Mountpoint\":\"/mountpoint\"," +
                         "\"Status\":{}," +
                         "\"properties\":{\"c\":\"d\"}" +

--- a/server/src/integration-test/kotlin/io/titandata/DockerVolumesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/DockerVolumesApiTest.kt
@@ -85,7 +85,7 @@ class DockerVolumesApiTest : StringSpec() {
         "create volume succeeds" {
             every { context.createVolume(any(), any()) } returns emptyMap()
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Create") {
-                setBody("{\"Name\":\"foo/vol\",\"Opts\":{\"a\":\"b\"}}")
+                setBody("{\"Name\":\"test/foo/vol\",\"Opts\":{\"a\":\"b\"}}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -99,7 +99,7 @@ class DockerVolumesApiTest : StringSpec() {
 
         "create volume for unknown repo fails" {
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Create") {
-                setBody("{\"Name\":\"bar/vol\",\"Opts\":{\"a\":\"b\"}}")
+                setBody("{\"Name\":\"test/bar/vol\",\"Opts\":{\"a\":\"b\"}}")
             }) {
                 response.status() shouldBe HttpStatusCode.NotFound
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -136,7 +136,7 @@ class DockerVolumesApiTest : StringSpec() {
                 services.metadata.createVolume(vs, Volume("vol"))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Remove") {
-                setBody("{\"Name\":\"foo/vol\"}")
+                setBody("{\"Name\":\"test/foo/vol\"}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -150,7 +150,7 @@ class DockerVolumesApiTest : StringSpec() {
             }
             every { context.activateVolume(any(), any(), any()) } just Runs
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Mount") {
-                setBody("{\"Name\":\"foo/vol\"}")
+                setBody("{\"Name\":\"test/foo/vol\"}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -168,7 +168,7 @@ class DockerVolumesApiTest : StringSpec() {
             }
             every { context.deactivateVolume(any(), any(), any()) } just Runs
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Unmount") {
-                setBody("{\"Name\":\"foo/vol\"}")
+                setBody("{\"Name\":\"test/foo/vol\"}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -185,7 +185,7 @@ class DockerVolumesApiTest : StringSpec() {
                 services.metadata.createVolume(vs, Volume(name = "vol", config = mapOf("mountpoint" to "/mountpoint")))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Path") {
-                setBody("{\"Name\":\"foo/vol\"}")
+                setBody("{\"Name\":\"test/foo/vol\"}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
@@ -194,17 +194,18 @@ class DockerVolumesApiTest : StringSpec() {
         }
 
         "get volume succeeds" {
+            every { context.getVolumePrefix() } returns "test"
             transaction {
                 services.metadata.createVolume(vs, Volume(name = "vol", properties = mapOf("a" to "b"), config = mapOf("mountpoint" to "/mountpoint")))
             }
             with(engine.handleRequest(HttpMethod.Post, "/VolumeDriver.Get") {
-                setBody("{\"Name\":\"foo/vol\"}")
+                setBody("{\"Name\":\"test/foo/vol\"}")
             }) {
                 response.status() shouldBe HttpStatusCode.OK
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
                 response.content shouldBe "{\"Err\":\"\"," +
                         "\"Volume\":{" +
-                        "\"Name\":\"foo/vol\"," +
+                        "\"Name\":\"test/foo/vol\"," +
                         "\"Mountpoint\":\"/mountpoint\"," +
                         "\"Status\":{}," +
                         "\"properties\":{\"a\":\"b\"}" +
@@ -213,6 +214,7 @@ class DockerVolumesApiTest : StringSpec() {
         }
 
         "list volumes succeeds" {
+            every { context.getVolumePrefix() } returns "test"
             transaction {
                 services.metadata.createVolume(vs, Volume(name = "one", properties = mapOf("a" to "b"), config = mapOf("mountpoint" to "/mountpoint")))
                 services.metadata.createVolume(vs, Volume(name = "two", properties = mapOf("c" to "d"), config = mapOf("mountpoint" to "/mountpoint")))
@@ -223,12 +225,12 @@ class DockerVolumesApiTest : StringSpec() {
                 response.contentType().toString() shouldBe "application/json; charset=UTF-8"
                 response.content shouldBe "{\"Err\":\"\"," +
                         "\"Volumes\":[{" +
-                        "\"Name\":\"foo/one\"," +
+                        "\"Name\":\"test/foo/one\"," +
                         "\"Mountpoint\":\"/mountpoint\"," +
                         "\"Status\":{}," +
                         "\"properties\":{\"a\":\"b\"}" +
                         "},{" +
-                        "\"Name\":\"foo/two\"," +
+                        "\"Name\":\"test/foo/two\"," +
                         "\"Mountpoint\":\"/mountpoint\"," +
                         "\"Status\":{}," +
                         "\"properties\":{\"c\":\"d\"}" +

--- a/server/src/integration-test/kotlin/io/titandata/DockerVolumesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/DockerVolumesApiTest.kt
@@ -42,7 +42,7 @@ class DockerVolumesApiTest : StringSpec() {
     lateinit var vs: String
 
     @MockK
-    var context = DockerZfsContext("test")
+    var context = DockerZfsContext(mapOf("pool" to "test"))
 
     @InjectMockKs
     @OverrideMockKs

--- a/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
@@ -52,7 +52,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 class OperationsApiTest : StringSpec() {
 
     @SpyK
-    var context = DockerZfsContext("test")
+    var context = DockerZfsContext(mapOf("pool" to "test"))
 
     lateinit var vs1: String
     lateinit var vs2: String

--- a/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/RepositoriesApiTest.kt
@@ -41,7 +41,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 class RepositoriesApiTest : StringSpec() {
 
     @MockK
-    var context = DockerZfsContext("test")
+    var context = DockerZfsContext(mapOf("pool" to "test"))
 
     @InjectMockKs
     @OverrideMockKs

--- a/server/src/main/kotlin/io/titandata/apis/DockerVolumesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/DockerVolumesApi.kt
@@ -27,25 +27,21 @@ import io.titandata.models.docker.DockerVolumeResponse
 fun Route.DockerVolumeApi(services: ServiceLocator) {
 
     /**
-     * Volumes names are expressed as "context/repo/vol". This is a helper method to separate the
+     * Volumes names are expressed as "repo/vol". This is a helper method to separate the
      * repository name and the volume name, throwing an exception if it's not well formed.
-     * We ignore the context portion here, it's assumed that the client has requested the volume relevant to
-     * their driver. The context is just used to create a unique name so two different contexts can share the
-     * same repository.
      */
     fun getVolumeName(name: String?): Pair<String, String> {
         name ?: throw IllegalArgumentException("volume name must be specified")
         val components = name.split("/")
-        if (components.size != 3) {
+        if (components.size != 2) {
             throw IllegalArgumentException("volume must name be of the form 'repository/volume'")
         }
-        return Pair(components[1], components[2])
+        return Pair(components[0], components[1])
     }
 
     fun convertVolume(repo: String, volume: Volume): DockerVolume {
-        val prefix = services.context.getVolumePrefix()
         return DockerVolume(
-                name = "$prefix/$repo/${volume.name}",
+                name = "$repo/${volume.name}",
                 properties = volume.properties,
                 mountpoint = volume.config["mountpoint"] as String,
                 status = mapOf<String, Any>()

--- a/server/src/main/kotlin/io/titandata/apis/DockerVolumesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/DockerVolumesApi.kt
@@ -27,21 +27,25 @@ import io.titandata.models.docker.DockerVolumeResponse
 fun Route.DockerVolumeApi(services: ServiceLocator) {
 
     /**
-     * Volumes names are expressed as "repo/vol". This is a helper method to separate the
+     * Volumes names are expressed as "context/repo/vol". This is a helper method to separate the
      * repository name and the volume name, throwing an exception if it's not well formed.
+     * We ignore the context portion here, it's assumed that the client has requested the volume relevant to
+     * their driver. The context is just used to create a unique name so two different contexts can share the
+     * same repository.
      */
     fun getVolumeName(name: String?): Pair<String, String> {
         name ?: throw IllegalArgumentException("volume name must be specified")
         val components = name.split("/")
-        if (components.size != 2) {
+        if (components.size != 3) {
             throw IllegalArgumentException("volume must name be of the form 'repository/volume'")
         }
-        return Pair(components[0], components[1])
+        return Pair(components[1], components[2])
     }
 
     fun convertVolume(repo: String, volume: Volume): DockerVolume {
+        val prefix = services.context.getVolumePrefix()
         return DockerVolume(
-                name = "$repo/${volume.name}",
+                name = "$prefix/$repo/${volume.name}",
                 properties = volume.properties,
                 mountpoint = volume.config["mountpoint"] as String,
                 status = mapOf<String, Any>()
@@ -75,7 +79,7 @@ fun Route.DockerVolumeApi(services: ServiceLocator) {
             val request = call.receive(DockerVolumeRequest::class)
             val (repo, volname) = getVolumeName(request.name)
             val result = convertVolume(repo, services.volumes.getVolume(repo, volname))
-            call.respond(DockerVolumeGetResponse(volume = result.copy(name = "$repo/$volname")))
+            call.respond(DockerVolumeGetResponse(volume = result))
         }
     }
 

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -19,6 +19,7 @@ interface RuntimeContext {
     fun deleteVolumeSet(volumeSet: String)
     fun deleteVolumeSetCommit(volumeSet: String, commitId: String)
     fun commitVolumeSet(volumeSet: String, commitId: String)
+    fun getVolumePrefix(): String
 
     fun getCommitStatus(volumeSet: String, commitId: String, volumeNames: List<String>): CommitStatus
 

--- a/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/RuntimeContext.kt
@@ -19,7 +19,6 @@ interface RuntimeContext {
     fun deleteVolumeSet(volumeSet: String)
     fun deleteVolumeSetCommit(volumeSet: String, commitId: String)
     fun commitVolumeSet(volumeSet: String, commitId: String)
-    fun getVolumePrefix(): String
 
     fun getCommitStatus(volumeSet: String, commitId: String, volumeNames: List<String>): CommitStatus
 

--- a/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
@@ -43,14 +43,6 @@ class DockerZfsContext(private val properties: Map<String, String> = emptyMap())
     }
 
     /**
-     * The volume prefix is used only for docker when returning volumes through the docker volume API. It is
-     * equivalent to the pool name.
-     */
-    override fun getVolumePrefix(): String {
-        return poolName
-    }
-
-    /**
      * Create a new volume set. This is simply an empty placeholder volumeset.
      */
     override fun createVolumeSet(volumeSet: String) {

--- a/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
@@ -43,6 +43,14 @@ class DockerZfsContext(private val properties: Map<String, String> = emptyMap())
     }
 
     /**
+     * The volume prefix is used only for docker when returning volumes through the docker volume API. It is
+     * equivalent to the pool name.
+     */
+    override fun getVolumePrefix(): String {
+        return poolName
+    }
+
+    /**
      * Create a new volume set. This is simply an empty placeholder volumeset.
      */
     override fun createVolumeSet(volumeSet: String) {

--- a/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/docker/DockerZfsContext.kt
@@ -24,9 +24,9 @@ import org.slf4j.LoggerFactory
  *      pool/data/volumeSet@commit      Recursive snapshot of a particular commit
  *      pool/data/volumeSet/volume      Volume within a volume set
  */
-class DockerZfsContext(
-    val poolName: String = "titan"
-) : RuntimeContext {
+class DockerZfsContext(private val properties: Map<String, String> = emptyMap()) : RuntimeContext {
+
+    val poolName = properties.get("pool") ?: "titan"
 
     companion object {
         val log = LoggerFactory.getLogger(DockerZfsContext::class.java)
@@ -39,7 +39,7 @@ class DockerZfsContext(
     }
 
     override fun getProperties(): Map<String, String> {
-        return mapOf("pool" to poolName)
+        return properties
     }
 
     /**
@@ -217,7 +217,7 @@ class DockerZfsContext(
         try {
             executor.exec("umount", config["mountpoint"] as String)
         } catch (e: CommandException) {
-            if ("not mounted" in e.output) {
+            if ("not mounted" in e.output || "no mount point specified" in e.output) {
                 return // Ignore
             } else if ("target is busy" in e.output) {
                 try {

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -51,6 +51,8 @@ import org.slf4j.LoggerFactory
  *      configFile      Path, relative to ~/.kube, for the kubernetes configuration file. If not specified, then the
  *                      the default ("config") is used.
  *
+ *      context         The context to use for all operations.
+ *
  *      namespace       Cluster namespace, defaults to "default".
  *
  *      storageClass    Default volume storage class to use when creating volumes. If unspecified, then the
@@ -126,6 +128,10 @@ class KubernetesCsiContext(private val properties: Map<String, String> = emptyMa
 
     override fun commitVolumeSet(volumeSet: String, commitId: String) {
         // Nothing to do
+    }
+
+    override fun getVolumePrefix(): String {
+        error("volume prefix not supported for kubernetes context")
     }
 
     override fun deleteVolumeSetCommit(volumeSet: String, commitId: String) {

--- a/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
+++ b/server/src/main/kotlin/io/titandata/context/kubernetes/KubernetesCsiContext.kt
@@ -130,10 +130,6 @@ class KubernetesCsiContext(private val properties: Map<String, String> = emptyMa
         // Nothing to do
     }
 
-    override fun getVolumePrefix(): String {
-        error("volume prefix not supported for kubernetes context")
-    }
-
     override fun deleteVolumeSetCommit(volumeSet: String, commitId: String) {
         // Nothing to do
     }

--- a/server/src/scripts-test/test-titan.sh
+++ b/server/src/scripts-test/test-titan.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bats
+#
+# Copyright The Titan Project Contributors.
+#
 
 titan_script=/test/src/scripts/titan.sh
 util_script=/test/src/scripts/util.sh

--- a/server/src/scripts-test/test-util.sh
+++ b/server/src/scripts-test/test-util.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bats
+#
+# Copyright The Titan Project Contributors.
+#
 
 util_script=/test/src/scripts/util.sh
 

--- a/server/src/scripts-test/test-zfs.sh
+++ b/server/src/scripts-test/test-zfs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bats
+#
+# Copyright The Titan Project Contributors.
+#
 
 zfs_script=/test/src/scripts/zfs.sh
 util_script=/test/src/scripts/util.sh

--- a/server/src/scripts/get-userland
+++ b/server/src/scripts/get-userland
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Copyright The Titan Project Contributors.
+#
 
 #
 # Utility script used during the docker build process to download and extract ZFS userland, using the same shell

--- a/server/src/scripts/kubernetesOperation
+++ b/server/src/scripts/kubernetesOperation
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Copyright The Titan Project Contributors.
+#
 
 #
 # Entry point for running a kubernetes operation. See KubernetesRunner for how this works. We expect the TITAN_PATH

--- a/server/src/scripts/launch
+++ b/server/src/scripts/launch
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Copyright The Titan Project Contributors.
+#
 
 #
 # Main entry point for launching the titan server. The responsibility of this script is to ensure

--- a/server/src/scripts/run
+++ b/server/src/scripts/run
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Copyright The Titan Project Contributors.
+#
 
 #
 # Main entry point for the titan server. This server can be run in different contexts, such as managing local

--- a/server/src/scripts/run
+++ b/server/src/scripts/run
@@ -80,7 +80,7 @@ if [[ $TITAN_CONTEXT = "docker-zfs" ]]; then
   start_database $DB_DIR
 
   # Run socat to pipe from unix socket to server port
-  socat -v -d -lf /var/log/socat.log UNIX-LISTEN:/run/docker/plugins/titan.sock,reuseaddr,fork TCP:localhost:5001 2>/var/log/socat.trace &
+  socat -v -d -lf /var/log/socat.log UNIX-LISTEN:/run/docker/plugins/$IDENTITY.sock,reuseaddr,fork TCP:localhost:5001 2>/var/log/socat.trace &
 
   exec java -Dtitan.context=$TITAN_CONTEXT -Dtitan.pool=$TITAN_POOL -jar /titan/titan-server.jar
 elif [[ $TITAN_CONTEXT = "kubernetes-csi" ]]; then

--- a/server/src/scripts/run
+++ b/server/src/scripts/run
@@ -5,13 +5,14 @@
 # docker containers or kubernetes pods. The behavior is controlled via the TITAN_CONTEXT environemnt variable.
 # We currently support two contexts:
 #
-#   docker-zfs      Controls local containers on your laptops, backing storage via ZFS. The TITAN_POOL
-#                   environment variable must be set, and the container must be run via the 'launch' script
-#                   to ensure that ZFS is properly configured.
+#   docker-zfs      Controls local containers on your laptops, backing storage via ZFS. The TITAN_IDENTITY
+#                   environment variable must be set, which must also match the name of the corresponding storage
+#                   pool, and the container must be run via the 'launch' script to ensure that ZFS is properly
+#                   configured.
 #
 #   kubernetes-csi  Controls remote containers running in a kubernetes cluster, backing storage via a CSI
-#                   driver. The TITAN_DATA variable must be set to determine where to place the persistent
-#                   database in /var/lib/$TITAN_DATA, which should be backed by a persistent volume. Unlike
+#                   driver. The TITAN_IDENTITY variable must be set to determine where to place the persistent
+#                   database in /var/lib/$TITAN_IDENTITY, which should be backed by a persistent volume. Unlike
 #                   the docker-zfs context, the server doesn't need to be run via 'launch', and can operate
 #                   in any docker environment even if kernel ZFS support isn't present. Additional context
 #                   can be passed through the TITAN_CONFIG variable, which is a list of name=value pairs,
@@ -30,11 +31,11 @@ function log_error {
 #
 function mount_database() {
   local db_dir=$1
-  mount | grep ^$TITAN_POOL/db > /dev/null
+  mount | grep ^$TITAN_IDENTITY/db > /dev/null
   if [[ $? != 0 ]]; then
-    echo "Mounting $TITAN_POOL/db at $db_dir"
+    echo "Mounting $TITAN_IDENTITY/db at $db_dir"
     mkdir -p $db_dir
-    mount -t zfs $TITAN_POOL/db $db_dir || log_error "failed to mount database directory"
+    mount -t zfs $TITAN_IDENTITY/db $db_dir || log_error "failed to mount database directory"
   fi
 }
 
@@ -68,25 +69,21 @@ function start_database() {
 # Check that our context is configured correctly
 #
 [[ -z $TITAN_CONTEXT ]] && log_error "TITAN_CONTEXT must be set"
+[[ -z $TITAN_IDENTITY ]] && log_error "TITAN_IDENTITY must be set"
 
 #
 # Check or configure any context-specific configuration.
 #
+DB_DIR=/var/lib/$TITAN_IDENTITY/mnt/_db
 if [[ $TITAN_CONTEXT = "docker-zfs" ]]; then
-  [[ -z $TITAN_POOL ]] && log_error "TITAN_POOL must be set"
-  DB_DIR=/var/lib/$TITAN_POOL/mnt/_db
-
   mount_database $DB_DIR
   start_database $DB_DIR
 
   # Run socat to pipe from unix socket to server port
-  socat -v -d -lf /var/log/socat.log UNIX-LISTEN:/run/docker/plugins/$IDENTITY.sock,reuseaddr,fork TCP:localhost:5001 2>/var/log/socat.trace &
+  socat -v -d -lf /var/log/socat.log UNIX-LISTEN:/run/docker/plugins/$TITAN_IDENTITY.sock,reuseaddr,fork TCP:localhost:5001 2>/var/log/socat.trace &
 
-  exec java -Dtitan.context=$TITAN_CONTEXT -Dtitan.pool=$TITAN_POOL -jar /titan/titan-server.jar
+  exec java -Dtitan.context=$TITAN_CONTEXT -Dtitan.contextConfig=pool=$TITAN_IDENTITY -jar /titan/titan-server.jar
 elif [[ $TITAN_CONTEXT = "kubernetes-csi" ]]; then
-  [[ -z $TITAN_DATA ]] && log_error "TITAN_DATA must be set"
-  DB_DIR=/var/lib/$TITAN_DATA/mnt/_db
-
   start_database $DB_DIR
 
   exec java -Dtitan.context=$TITAN_CONTEXT -Dtitan.contextConfig=$TITAN_CONFIG -jar /titan/titan-server.jar

--- a/server/src/scripts/teardown
+++ b/server/src/scripts/teardown
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Copyright The Titan Project Contributors.
+#
 
 #
 # This script will teardown any underlying ZFS infrastructure that we may have installed on the

--- a/server/src/scripts/titan.sh
+++ b/server/src/scripts/titan.sh
@@ -129,7 +129,7 @@ function launch_server() {
       -v /run/docker/plugins:/run/docker/plugins \
       -v $mount:$mount:rshared \
       -e TITAN_CONTEXT=docker-zfs \
-      -e TITAN_POOL=$pool \
+      -e TITAN_IDENTITY=$identity \
       -p $port:5001 \
       --network $identity \
       $image \

--- a/server/src/scripts/titan.sh
+++ b/server/src/scripts/titan.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Copyright The Titan Project Contributors.
+#
 
 #
 # Get the desired size of the pool. Since the pool will be built on a sparse file, this is really

--- a/server/src/scripts/titan.sh
+++ b/server/src/scripts/titan.sh
@@ -36,6 +36,9 @@ function create_import_pool() {
       log_start "Creating storage pool"
       local size=$(get_pool_size $pool_dir)
       truncate -s $size $data || log_error "Failed to create $size data file for storage pool"
+      # Clean up any stale mounts
+      unmount_filesystems $pool
+      rm -rf $mnt_dir
       if ! create_pool $pool $data $mnt_dir $cachefile; then
         rm -f $data
         log_error "Failed to create storage pool"

--- a/server/src/scripts/util.sh
+++ b/server/src/scripts/util.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright The Titan Project Contributors.
 #
 
 #

--- a/server/src/scripts/zfs.sh
+++ b/server/src/scripts/zfs.sh
@@ -366,7 +366,7 @@ function unload_zfs() {
 #
 function unmount_filesystems() {
   local pool=$1
-  local dirs=$(mount -t zfs | grep ^$pool | awk '{print $3}')
+  local dirs=$(mount -t zfs | grep ^$pool | awk '{print $3}' | sort -r)
   for dir in $dirs; do
      nsenter -m -u -t 1 -n -i umount $dir
   done

--- a/server/src/scripts/zfs.sh
+++ b/server/src/scripts/zfs.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Copyright The Titan Project Contributors.
+#
 
 #
 # Minimum ZFS version. Starting in version 0.8.0, the community is going to attempt to maintain

--- a/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
+++ b/server/src/test/kotlin/io/titandata/context/docker/DockerZfsContextTest.kt
@@ -38,7 +38,7 @@ class DockerZfsContextTest : StringSpec() {
 
     @InjectMockKs
     @OverrideMockKs
-    private var context = DockerZfsContext("test")
+    private var context = DockerZfsContext(mapOf("pool" to "test"))
 
     override fun beforeTest(testCase: TestCase) {
         return MockKAnnotations.init(this)


### PR DESCRIPTION
## Proposed Changes

This changes how we handle the instantiation of titan contexts, especially local docker contexts. Some of it just cleanup, unifying the variables. The most significant change is that we now listen on a docker plugin socket that is specific to the identity, rather than just "titan". This allows multiple local contexts to be run independently (not necessarily advisable, but important from an isolation perspective).

## Testing

`gradle build test integrationTest endtoendTest`