### PR TITLE
remove plugin socket on teardown

### DIFF
--- a/server/src/scripts/teardown
+++ b/server/src/scripts/teardown
@@ -36,3 +36,5 @@ echo "Unloading ZFS"
 unload_zfs $INSTALL_DIR || log_error "failed to unload ZFS module"
 echo "Removing any lingering mountpoints"
 rm -rf $MNT_DIR || log_error "failed to remove $MNT_DIR"
+echo "Removing docker plugin socket"
+rm -f /run/docker/plugins/$IDENTITY.sock


### PR DESCRIPTION
## Proposed Changes

We were leaving a stale socket on teardown, we should remove it when the local context is uninstalled.

## Testing

Ran teardown, ensured socket was removed.