### PR TITLE
support unprivileged users over SSH

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     compile("com.google.code.gson:gson:2.8.6")
     compile("io.titandata:remote-sdk:0.2.0")
     compile("io.titandata:nop-remote-client:0.2.0")
-    compile("io.titandata:ssh-remote-client:0.2.0")
+    compile("io.titandata:ssh-remote-client:0.2.1")
     compile("io.titandata:s3-remote-client:0.2.0")
     compile("io.titandata:s3web-remote-client:0.2.0")
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     // Remotes
     compile("io.titandata:remote-sdk:0.2.0")
     compile("io.titandata:nop-remote-server:0.2.0")
-    compile("io.titandata:ssh-remote-server:0.2.0")
+    compile("io.titandata:ssh-remote-server:0.2.1")
     compile("io.titandata:s3-remote-server:0.2.0")
     compile("io.titandata:s3web-remote-server:0.2.0")
 

--- a/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/DockerUtil.kt
@@ -29,8 +29,8 @@ class DockerUtil(
     private val executor = CommandExecutor()
     private val retries = 60
     private val timeout = 1000L
-    private val sshUser = "root"
-    private val sshPassword = "root"
+    private val sshUser = "test"
+    private val sshPassword = "test"
     private val url = "http://localhost:$port"
     private val volumeApi = VolumesApi(url)
 
@@ -191,8 +191,9 @@ class DockerUtil(
         return executor.exec("docker", "exec", "$identity-ssh", "cat", path)
     }
 
-    fun mkdirSsh(path: String): String {
-        return executor.exec("docker", "exec", "$identity-ssh", "mkdir", "-p", path)
+    fun mkdirSsh(path: String) {
+        executor.exec("docker", "exec", "$identity-ssh", "mkdir", "-p", path)
+        executor.exec("docker", "exec", "$identity-ssh", "chown", sshUser, path)
     }
 
     fun startSsh() {
@@ -240,6 +241,6 @@ class DockerUtil(
 
     fun getSshUri(): String {
         // We explicitly add the port even though it's superfluous, as it helps validate serialization
-        return "ssh://root:root@${getSshHost()}:22"
+        return "ssh://$sshUser:$sshPassword@${getSshHost()}:22"
     }
 }

--- a/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/remote/ssh/SshWorkflowTest.kt
@@ -78,8 +78,8 @@ class SshWorkflowTest : EndToEndTest() {
 
             val remote = RemoteUtil().parseUri("${dockerUtil.getSshUri()}/bar", "origin", mapOf())
             remote.properties["address"] shouldBe dockerUtil.getSshHost()
-            remote.properties["password"] shouldBe "root"
-            remote.properties["username"] shouldBe "root"
+            remote.properties["password"] shouldBe "test"
+            remote.properties["username"] shouldBe "test"
             remote.properties["port"] shouldBe 22
             remote.name shouldBe "origin"
 
@@ -201,11 +201,11 @@ class SshWorkflowTest : EndToEndTest() {
         }
 
         "add remote without password succeeds" {
-            val remote = Remote("ssh", "origin", mapOf("address" to dockerUtil.getSshHost(), "username" to "root",
+            val remote = Remote("ssh", "origin", mapOf("address" to dockerUtil.getSshHost(), "username" to "test",
                     "path" to "/bar"))
             remote.properties["address"] shouldBe dockerUtil.getSshHost()
             remote.properties["password"] shouldBe null
-            remote.properties["username"] shouldBe "root"
+            remote.properties["username"] shouldBe "test"
             remote.properties["port"] shouldBe null
             remote.name shouldBe "origin"
 
@@ -213,7 +213,7 @@ class SshWorkflowTest : EndToEndTest() {
         }
 
         "list commits with password succeeds" {
-            val commits = remoteApi.listRemoteCommits("foo", "origin", RemoteParameters("ssh", mapOf("password" to "root")))
+            val commits = remoteApi.listRemoteCommits("foo", "origin", RemoteParameters("ssh", mapOf("password" to "test")))
             commits.size shouldBe 1
             commits[0].id shouldBe "id"
         }
@@ -234,7 +234,7 @@ class SshWorkflowTest : EndToEndTest() {
 
         "copy SSH key to server succeeds" {
             val key = getResource("/id_rsa.pub")
-            dockerUtil.writeFileSsh("/root/.ssh/authorized_keys", key)
+            dockerUtil.writeFileSsh("/home/test/.ssh/authorized_keys", key)
         }
 
         "list commits with key succeeds" {


### PR DESCRIPTION
## Proposed Changes

This updates the SSH remote to 0.2.1, and adds a test for using the new unprivileged user in the SSH test server. These tests fail with the 0.2.0 remote but succeed with 0.2.1.

## Testing

SSH endtoend tests.