### PR TITLE
don't fail if ZFS unload fails

### DIFF
--- a/server/src/scripts/teardown
+++ b/server/src/scripts/teardown
@@ -33,7 +33,7 @@ remove_network $IDENTITY
 echo "Unbinding mounts"
 unbind_mounts $MNT_DIR
 echo "Unloading ZFS"
-unload_zfs $INSTALL_DIR || log_error "failed to unload ZFS module"
+unload_zfs $INSTALL_DIR
 echo "Removing any lingering mountpoints"
 rm -rf $MNT_DIR || log_error "failed to remove $MNT_DIR"
 echo "Removing docker plugin socket"


### PR DESCRIPTION
## Proposed Changes

With the addition of multiple contexts, it's no longer safe to assume that the context that was responsible for installing ZFS should be the one to uninstall it. Properly handling this, such as doing it only when the last context is torn down, will require some rethought. For now, I'm just updating it to not be an error so that we can drive on even if ZFS is in use.
