### PR TITLE
add openapi definition

### DIFF
--- a/client/src/main/kotlin/io/titandata/models/docker/PluginDescription.kt
+++ b/client/src/main/kotlin/io/titandata/models/docker/PluginDescription.kt
@@ -2,7 +2,7 @@
  * Copyright The Titan Project Contributors.
  */
 
-package io.titandata.models
+package io.titandata.models.docker
 
 import com.google.gson.annotations.SerializedName
 

--- a/openapi/titan.yaml
+++ b/openapi/titan.yaml
@@ -1,0 +1,1034 @@
+openapi: 3.0.2
+info:
+  title: Titan API
+  description: API used by the Titan CLI
+  version: 0.3.0
+servers:
+  - url: http://localhost:5001
+paths:
+
+  #
+  # Context APIs.
+  #
+  /v1/context:
+    get:
+      summary: Get current context
+      operationId: getContext
+      tags:
+        - contexts
+      responses:
+        "200":
+          description: Current context
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/context"
+
+  #
+  # Repository APIs
+  #
+  /v1/repositories:
+    get:
+      summary: List repositories
+      operationId: listRepositories
+      tags:
+        - repositories
+      responses:
+        "200":
+          description: List of repositories
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/repository"
+        default:
+          $ref: "#/components/responses/error"
+    post:
+      summary: Create new repository
+      operationId: createRepository
+      tags:
+        - repositories
+      requestBody:
+        description: New repository to create
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/repository"
+      responses:
+        "201":
+          description: Newly created repository
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/repository"
+        "401":
+          $ref: "#/components/responses/badinput"
+        default:
+          $ref: "#/components/responses/error"
+  /v1/repositories/{repositoryName}:
+    get:
+      summary: Get info for a repository
+      operationId: getRepository
+      tags:
+        - repositories
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+      responses:
+        "200":
+          description: Repository info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/repository"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+    post:
+      summary: Update or rename a repository
+      operationId: updateRepository
+      tags:
+        - repositories
+      description: Update any properties of the repository. If the repository name
+                   is changed, this will rename the repository.
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+      requestBody:
+        description: New repository
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/repository"
+      responses:
+        "200":
+          description: Updated repository
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/repository"
+        "401":
+          $ref: "#/components/responses/badinput"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+    delete:
+      summary: Remove a repository
+      operationId: deleteRepository
+      tags:
+        - repositories
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+      responses:
+        "204":
+          description: Repository deleted
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+  /v1/repositories/{repositoryName}/status:
+    get:
+      summary: Get current status of a repository
+      operationId: getRepositoryStatus
+      tags:
+        - repositories
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+      responses:
+        "200":
+          description: Repository status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/repositoryStatus"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+
+  #
+  # Volume APIs.
+  #
+  /v1/repositories/{repositoryName}/volumes:
+    get:
+      summary: List volumes
+      operationId: listVolumes
+      tags:
+        - volumes
+      responses:
+        "200":
+          description: List of volumes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/volume"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+    post:
+      summary: Create new volume
+      operationId: createVolume
+      tags:
+        - volumes
+      requestBody:
+        description: New volume to create
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/volume"
+      responses:
+        "201":
+          description: Newly created volume
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/volume"
+        "401":
+          $ref: "#/components/responses/badinput"
+        "404":
+          $ref: "#/components/responses/nosuchobjct"
+        default:
+          $ref: "#/components/responses/error"
+  /v1/repositories/{repositoryName}/volumes/{volumeName}:
+    get:
+      summary: Get info for a volume
+      operationId: getVolume
+      tags:
+        - volumes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/volumeName"
+      responses:
+        "200":
+          description: Volume info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/volume"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+    delete:
+      summary: Remove a volume
+      operationId: deleteVolume
+      tags:
+        - volumes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/volumeName"
+      responses:
+        "204":
+          description: Volume deleted
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+  /v1/repositories/{repositoryName}/volumes/{volumeName}/activate:
+    post:
+      summary: Activate a volume for use by a repository (e.g. mount)
+      operationId: activateVolume
+      tags:
+        - volumes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/volumeName"
+      responses:
+        "204":
+          description: Activated repository
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+  /v1/repositories/{repositoryName}/volumes/{volumeName}/deactivate:
+    post:
+      summary: Deactivate a volume prior to its deletion (e.g. unmount)
+      operationId: deactivateVolume
+      tags:
+        - volumes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/volumeName"
+      responses:
+        "204":
+          description: Deactivated repository
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+  /v1/repositories/{repositoryName}/volumes/{volumeName}/status:
+    get:
+      summary: Get status of a volume
+      operationId: getVolumeStatus
+      tags:
+        - volumes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/volumeName"
+      responses:
+        "200":
+          description: Volume status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/volumeStatus"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+
+  #
+  # Commit APIs
+  #
+  /v1/repositories/{repositoryName}/commits:
+    get:
+      summary: Get commit history for a repository
+      operationId: listCommits
+      tags:
+        - commits
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+      responses:
+        "200":
+          description: List of commits
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/commit"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+    post:
+      summary: Create new commit
+      operationId: createCommit
+      tags:
+        - commits
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+      requestBody:
+        description: "New commit to create"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/commit"
+      responses:
+        "201":
+          description: Newly created commit
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/commit"
+        "401":
+          $ref: "#/components/responses/badinput"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+  /v1/repositories/{repositoryName}/commits/{commitId}:
+    get:
+      summary: Get information for a specific commit
+      operationId: getCommit
+      tags:
+        - commits
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/commitId"
+      responses:
+        "200":
+          description: Commit information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/commit"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+    delete:
+      summary: Discard a past commit
+      operationId: deleteCommit
+      tags:
+        - commits
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/commitId"
+      responses:
+        "204":
+          description: Commit discarded
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+    post:
+      summary: Update tags for a previous commit
+      operationId: updateCommit
+      tags:
+        - commits
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/commitId"
+      requestBody:
+        description: "Commit contents to update"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/commit"
+      responses:
+        "200":
+          description: Updated commit
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/commit"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+  /v1/repositories/{repositoryName}/commits/{commitId}/status:
+    post:
+      summary: Get commit status
+      operationId: getCommitStatus
+      tags:
+        - commits
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/commitId"
+      responses:
+        "200":
+          description: Commit status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/commitStatus"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+  /v1/repositories/{repositoryName}/commits/{commitId}/checkout:
+    post:
+      summary: Checkout the given commit
+      operationId: checkoutCommit
+      tags:
+        - commits
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/commitId"
+      responses:
+        "204":
+          description: Commit checked out
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+
+  #
+  # Remote APIs.
+  #
+  /v1/repositories/{repositoryName}/remotes:
+    get:
+      summary: Get list of remotes
+      operationId: listRemotes
+      tags:
+        - remotes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+      responses:
+        "200":
+          description: List of remotes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/remote"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+    post:
+      summary: Create new remote
+      operationId: createRemote
+      tags:
+        - remotes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+      requestBody:
+        description: "Remote to create"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/remote"
+      responses:
+        "201":
+          description: Newly created remote
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/remote"
+        "401":
+          $ref: "#/components/responses/badinput"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+
+  /v1/repositories/{repositoryName}/remotes/{remoteName}:
+    get:
+      summary: Get information about a particular remote
+      operationId: getRemote
+      tags:
+        - remotes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/remoteName"
+      responses:
+        "200":
+          description: Remote information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/remote"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+    post:
+      summary: Update remote information
+      operationId: updateRemote
+      tags:
+        - remotes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/remoteName"
+      requestBody:
+        description: "Remote information to update"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/remote"
+      responses:
+        "200":
+          description: Remote information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/remote"
+        "401":
+          $ref: "#/components/responses/badinput"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+    delete:
+      summary: Delete remote
+      operationId: deleteRemote
+      tags:
+        - remotes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/remoteName"
+      responses:
+        "204":
+          description: Remote deleted
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+
+  /v1/repositories/{repositoryName}/remotes/{remoteName}/commits:
+    get:
+      summary: List remote commits
+      operationId: listRemoteCommits
+      tags:
+        - remotes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/remoteName"
+        - $ref: "#/components/parameters/remoteParameters"
+      responses:
+        "200":
+          description: List of commits
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/commit"
+        "401":
+          $ref: "#/components/responses/badinput"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+  /v1/repositories/{repositoryName}/remotes/{remoteName}/commits/{commitId}:
+    get:
+      summary: Get a remote commit
+      operationId: getRemoteCommit
+      tags:
+        - remotes
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/remoteName"
+        - $ref: "#/components/parameters/commitId"
+        - $ref: "#/components/parameters/remoteParameters"
+      responses:
+        "200":
+          description: Remote commit
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/commit"
+        "401":
+          $ref: "#/components/responses/badinput"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+
+  #
+  # Operation APIs.
+  #
+  /v1/operations:
+    get:
+      summary: List operations
+      operationId: listOperations
+      tags:
+        - operations
+      parameters:
+        - $ref: "#/components/parameters/repositoryQuery"
+      responses:
+        "200":
+          description: List of operations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/operation"
+        default:
+          $ref: "#/components/responses/default"
+  /v1/operations/{operationId}:
+    get:
+      summary: Get operation
+      operationId: getOperation
+      tags:
+        - operations
+      paramters:
+        - $ref: "#/components/parameters/operationId"
+      responses:
+        "200":
+          description: Operation information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/operation"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+    delete:
+      summary: Abort operation
+      operationId: abortOperation
+      tags:
+        - operations
+      paramters:
+        - $ref: "#/components/parameters/operationId"
+      responses:
+        "204":
+          description: Operation aborted
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+  /v1/operations/{operationId}/progress:
+    get:
+      summary: Get operation progress
+      operationId: getOperationProgress
+      tags:
+        - operations
+      paramters:
+        - $ref: "#/components/parameters/operationId"
+      responses:
+        "200":
+          description: Operation progress information
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/progressEntry"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/error"
+  /v1/repositories/{repositoryName}/remotes/{remoteName}/commits/{commitId}/pull:
+    post:
+      summary: Start a pull operation
+      operationId: pull
+      tags:
+        - operations
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/remoteName"
+        - $ref: "#/components/parameters/commitId"
+        - $ref: "#/components/parameters/metadataOnlyQuery"
+      requestBody:
+        description: Provider specific parameters
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/remoteParameters"
+      responses:
+        "201":
+          description: New operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/operation"
+        "401":
+          $ref: "#/components/responses/badinput"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+  /v1/repositories/{repositoryName}/remotes/{remoteName}/commits/{commitId}/push:
+    post:
+      summary: Start a push operation
+      operationId: push
+      tags:
+        - operations
+      parameters:
+        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/remoteName"
+        - $ref: "#/components/parameters/commitId"
+        - $ref: "#/components/parameters/metadataOnlyQuery"
+      requestBody:
+        description: Provider specific parameters
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/remoteParameters"
+      responses:
+        "201":
+          description: New operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/operation"
+        "401":
+          $ref: "#/components/responses/badinput"
+        "404":
+          $ref: "#/components/responses/nosuchobject"
+        default:
+          $ref: "#/components/responses/default"
+
+components:
+  schemas:
+    commit:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Commit identifier
+        properties:
+          type: object
+          description: Additional commit metadata
+      required:
+        - id
+        - properties
+    commitStatus:
+      type: object
+      properties:
+        logicalSize:
+          type: integer
+          format: int64
+          description: Logical size of data referenced by commit
+        actualSize:
+          type: integer
+          format: int64
+          description: Actual size of data referenced by commit
+        uniqueSize:
+          type: integer
+          format: int64
+          description: Amount of data uniquely held by this commit
+        ready:
+          type: boolean
+          description: Whether this commit can be used as the source of an operation or whether it's still being created
+        error:
+          type: string
+          decription: If commit failed to be created, error string explaining why
+      required:
+        - logicalSize
+        - actualSize
+        - uniqueSize
+        - ready
+    context:
+      type: object
+      properties:
+        provider:
+          type: string
+          description: Provider type
+        properties:
+          type: object
+          description: Additional provider-specific configuration
+      required:
+        - provider
+        - properties
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Unique code for the error
+        message:
+          type: string
+          description: Human readable description of the error
+        details:
+          type: string
+          description: Additional details, such as server-side stack trace
+      required:
+        - message
+    operation:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the operation
+        type:
+          type: string
+          description: Operation type
+          enum:
+            - PUSH
+            - PULL
+        state:
+          type: string
+          description: Current operation state
+          enum:
+            - RUNNING
+            - ABORTED
+            - FAILED
+            - COMPLETE
+        remote:
+          type: string
+          description: Name of remote associated with the operation
+        commitId:
+          type: string
+          description: Commit identifier being pushed or pulled
+      required:
+        - id
+        - type
+        - state
+        - remote
+        - commitId
+    progressEntry:
+      type: object
+      properties:
+        id:
+          type: int
+          description: Sequenced entry identifier
+        type:
+          type: string
+          description: Entry type
+          enum:
+            - MESSAGE
+            - START
+            - PROGRESS
+            - END
+            - ERROR
+            - ABORT
+            - FAILED
+            - COMPLETE
+        message:
+          type: string
+          description: Optional message for progress step
+        percent:
+          type: int
+          description: Optional percent for step
+          minValue: 0
+          maxValue: 100
+      required:
+        - id
+        - type
+    remote:
+      type: object
+      properties:
+        provider:
+          type: string
+          description: Remote type
+        name:
+          type: string
+          description: Name of remote
+        properties:
+          type: object
+          description: Provider-specific remote properties
+      required:
+        - provider
+        - name
+        - propertiers
+    remoteParameters:
+      type: object
+      properties:
+        provider:
+          type: string
+          description: Remote type
+        properties:
+          type: object
+          description: Provider-specific remote properties
+      required:
+        - provider
+        - propertiers
+    repository:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Repository name
+        properties:
+          type: object
+          description: Client-specific propertiers
+      required:
+        - name
+        - propertiers
+    repositoryStatus:
+      type: object
+      properties:
+        lastCommit:
+          type: string
+          description: The latest commit ID for the repository
+        sourceCommit:
+          type: string
+          description: The source commit for the current state (last checkout or commit)
+    volume:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Volume name
+        properties:
+          type: object
+          description: Client-specific properties
+        config:
+          type: object
+          description: Server-generated configuration
+      required:
+        - name
+        - properties
+    volumeStatus:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Volume name
+        logicalSize:
+          type: integer
+          format: int64
+          description: Logical size consumed by the volume
+        actualSize:
+          type: integer
+          format: int64
+          description: Actual (compressed) size used by the volume
+        properties:
+          type: object
+          description: Client-specific properties
+        ready:
+          type: boolean
+          description: True if the volume is ready for use in a runtime environmemnt
+        error:
+          type: string
+          description: Optional error message if volume asynchronously failed to be created
+      required:
+        - name
+        - logicalSize
+        - actualSize
+        - properties
+        - ready
+
+  responses:
+    default:
+      description: An internal error occurred
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    badinput:
+      description: Malformed user input
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    nosuchobject:
+      description: No such object
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+
+  parameters:
+    repositoryName:
+      name: repositoryName
+      in: path
+      required: true
+      description: Name of the repository
+      schema:
+        type: string
+    remoteName:
+      name: remoteName
+      in: path
+      required: true
+      description: Name of the remote
+      schema:
+        type: string
+    commitId:
+      name: commitId
+      in: path
+      required: true
+      description: Commit identifier
+      schema:
+        type: string
+    operationId:
+      name: operationId
+      in: path
+      required: true
+      description: Operation identifier
+      schema:
+        type: string
+    volumeName:
+      name: volumeName
+      in: path
+      required: true
+      description: Name of the volume
+      schema:
+        type: string
+
+    remoteParameters:
+      name: titan-remote-request
+      in: header
+      schema:
+        $ref: "#/components/schemas/remoteParameters"
+
+    repositoryQuery:
+      name: repository
+      in: query
+      schema:
+        type: string
+    metadataOnlyQuery:
+      name: metadataOnly
+      in: query
+      schema:
+        type: boolean

--- a/openapi/titan.yaml
+++ b/openapi/titan.yaml
@@ -68,13 +68,13 @@ paths:
         default:
           $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
     get:
       summary: Get info for a repository
       operationId: getRepository
       tags:
         - repositories
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
       responses:
         "200":
           description: Repository info
@@ -91,10 +91,6 @@ paths:
       operationId: updateRepository
       tags:
         - repositories
-      description: Update any properties of the repository. If the repository name
-                   is changed, this will rename the repository.
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
       requestBody:
         description: New repository
         required: true
@@ -120,8 +116,6 @@ paths:
       operationId: deleteRepository
       tags:
         - repositories
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
       responses:
         "204":
           description: Repository deleted
@@ -130,13 +124,13 @@ paths:
         default:
           $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/status:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
     get:
       summary: Get current status of a repository
       operationId: getRepositoryStatus
       tags:
         - repositories
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
       responses:
         "200":
           description: Repository status
@@ -153,6 +147,8 @@ paths:
   # Volume APIs.
   #
   /v1/repositories/{repositoryName}/volumes:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
     get:
       summary: List volumes
       operationId: listVolumes
@@ -193,18 +189,18 @@ paths:
         "401":
           $ref: "#/components/responses/badinput"
         "404":
-          $ref: "#/components/responses/nosuchobjct"
+          $ref: "#/components/responses/nosuchobject"
         default:
           $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/volumes/{volumeName}:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/volumeName"
     get:
       summary: Get info for a volume
       operationId: getVolume
       tags:
         - volumes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/volumeName"
       responses:
         "200":
           description: Volume info
@@ -221,9 +217,6 @@ paths:
       operationId: deleteVolume
       tags:
         - volumes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/volumeName"
       responses:
         "204":
           description: Volume deleted
@@ -232,14 +225,14 @@ paths:
         default:
           $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/volumes/{volumeName}/activate:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/volumeName"
     post:
       summary: Activate a volume for use by a repository (e.g. mount)
       operationId: activateVolume
       tags:
         - volumes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/volumeName"
       responses:
         "204":
           description: Activated repository
@@ -248,14 +241,14 @@ paths:
         default:
           $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/volumes/{volumeName}/deactivate:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/volumeName"
     post:
       summary: Deactivate a volume prior to its deletion (e.g. unmount)
       operationId: deactivateVolume
       tags:
         - volumes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/volumeName"
       responses:
         "204":
           description: Deactivated repository
@@ -264,14 +257,14 @@ paths:
         default:
           $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/volumes/{volumeName}/status:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/volumeName"
     get:
       summary: Get status of a volume
       operationId: getVolumeStatus
       tags:
         - volumes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/volumeName"
       responses:
         "200":
           description: Volume status
@@ -288,13 +281,15 @@ paths:
   # Commit APIs
   #
   /v1/repositories/{repositoryName}/commits:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
     get:
       summary: Get commit history for a repository
       operationId: listCommits
       tags:
         - commits
       parameters:
-        - $ref: "#/components/parameters/repositoryName"
+        - $ref: "#/components/parameters/tagQuery"
       responses:
         "200":
           description: List of commits
@@ -307,14 +302,12 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
     post:
       summary: Create new commit
       operationId: createCommit
       tags:
         - commits
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
       requestBody:
         description: "New commit to create"
         required: true
@@ -334,16 +327,16 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/commits/{commitId}:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/commitId"
     get:
       summary: Get information for a specific commit
       operationId: getCommit
       tags:
         - commits
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/commitId"
       responses:
         "200":
           description: Commit information
@@ -354,30 +347,24 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
     delete:
       summary: Discard a past commit
       operationId: deleteCommit
       tags:
         - commits
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/commitId"
       responses:
         "204":
           description: Commit discarded
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
     post:
       summary: Update tags for a previous commit
       operationId: updateCommit
       tags:
         - commits
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/commitId"
       requestBody:
         description: "Commit contents to update"
         required: true
@@ -395,16 +382,16 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/commits/{commitId}/status:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/commitId"
     post:
       summary: Get commit status
       operationId: getCommitStatus
       tags:
         - commits
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/commitId"
       responses:
         "200":
           description: Commit status
@@ -415,35 +402,35 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/commits/{commitId}/checkout:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/commitId"
     post:
       summary: Checkout the given commit
       operationId: checkoutCommit
       tags:
         - commits
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/commitId"
       responses:
         "204":
           description: Commit checked out
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
 
   #
   # Remote APIs.
   #
   /v1/repositories/{repositoryName}/remotes:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
     get:
       summary: Get list of remotes
       operationId: listRemotes
       tags:
         - remotes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
       responses:
         "200":
           description: List of remotes
@@ -456,14 +443,12 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
     post:
       summary: Create new remote
       operationId: createRemote
       tags:
         - remotes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
       requestBody:
         description: "Remote to create"
         required: true
@@ -483,17 +468,17 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
 
   /v1/repositories/{repositoryName}/remotes/{remoteName}:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/remoteName"
     get:
       summary: Get information about a particular remote
       operationId: getRemote
       tags:
         - remotes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/remoteName"
       responses:
         "200":
           description: Remote information
@@ -504,15 +489,12 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
     post:
       summary: Update remote information
       operationId: updateRemote
       tags:
         - remotes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/remoteName"
       requestBody:
         description: "Remote information to update"
         required: true
@@ -532,33 +514,32 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
     delete:
       summary: Delete remote
       operationId: deleteRemote
       tags:
         - remotes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/remoteName"
       responses:
         "204":
           description: Remote deleted
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
 
   /v1/repositories/{repositoryName}/remotes/{remoteName}/commits:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/remoteName"
+      - $ref: "#/components/parameters/remoteParameters"
     get:
       summary: List remote commits
       operationId: listRemoteCommits
       tags:
         - remotes
       parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/remoteName"
-        - $ref: "#/components/parameters/remoteParameters"
+        - $ref: "#/components/parameters/tagQuery"
       responses:
         "200":
           description: List of commits
@@ -573,18 +554,18 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/remotes/{remoteName}/commits/{commitId}:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/remoteName"
+      - $ref: "#/components/parameters/commitId"
+      - $ref: "#/components/parameters/remoteParameters"
     get:
       summary: Get a remote commit
       operationId: getRemoteCommit
       tags:
         - remotes
-      parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/remoteName"
-        - $ref: "#/components/parameters/commitId"
-        - $ref: "#/components/parameters/remoteParameters"
       responses:
         "200":
           description: Remote commit
@@ -597,7 +578,7 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
 
   #
   # Operation APIs.
@@ -609,7 +590,11 @@ paths:
       tags:
         - operations
       parameters:
-        - $ref: "#/components/parameters/repositoryQuery"
+        - name: repository
+          description: Limit to the given repository
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: List of operations
@@ -620,15 +605,15 @@ paths:
                 items:
                   $ref: "#/components/schemas/operation"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
   /v1/operations/{operationId}:
+    parameters:
+      - $ref: "#/components/parameters/operationId"
     get:
       summary: Get operation
       operationId: getOperation
       tags:
         - operations
-      paramters:
-        - $ref: "#/components/parameters/operationId"
       responses:
         "200":
           description: Operation information
@@ -645,7 +630,7 @@ paths:
       operationId: abortOperation
       tags:
         - operations
-      paramters:
+      parameters:
         - $ref: "#/components/parameters/operationId"
       responses:
         "204":
@@ -655,13 +640,19 @@ paths:
         default:
           $ref: "#/components/responses/error"
   /v1/operations/{operationId}/progress:
+    parameters:
+      - $ref: "#/components/parameters/operationId"
     get:
       summary: Get operation progress
       operationId: getOperationProgress
       tags:
         - operations
-      paramters:
-        - $ref: "#/components/parameters/operationId"
+      parameters:
+        - name: lastId
+          in: query
+          schema:
+            type: integer
+            description: Only return entries with an id greater than this value
       responses:
         "200":
           description: Operation progress information
@@ -676,15 +667,16 @@ paths:
         default:
           $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/remotes/{remoteName}/commits/{commitId}/pull:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/remoteName"
+      - $ref: "#/components/parameters/commitId"
     post:
       summary: Start a pull operation
       operationId: pull
       tags:
         - operations
       parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/remoteName"
-        - $ref: "#/components/parameters/commitId"
         - $ref: "#/components/parameters/metadataOnlyQuery"
       requestBody:
         description: Provider specific parameters
@@ -705,17 +697,18 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
   /v1/repositories/{repositoryName}/remotes/{remoteName}/commits/{commitId}/push:
+    parameters:
+      - $ref: "#/components/parameters/repositoryName"
+      - $ref: "#/components/parameters/remoteName"
+      - $ref: "#/components/parameters/commitId"
     post:
       summary: Start a push operation
       operationId: push
       tags:
         - operations
       parameters:
-        - $ref: "#/components/parameters/repositoryName"
-        - $ref: "#/components/parameters/remoteName"
-        - $ref: "#/components/parameters/commitId"
         - $ref: "#/components/parameters/metadataOnlyQuery"
       requestBody:
         description: Provider specific parameters
@@ -736,7 +729,7 @@ paths:
         "404":
           $ref: "#/components/responses/nosuchobject"
         default:
-          $ref: "#/components/responses/default"
+          $ref: "#/components/responses/error"
 
 components:
   schemas:
@@ -772,7 +765,7 @@ components:
           description: Whether this commit can be used as the source of an operation or whether it's still being created
         error:
           type: string
-          decription: If commit failed to be created, error string explaining why
+          description: If commit failed to be created, error string explaining why
       required:
         - logicalSize
         - actualSize
@@ -840,7 +833,7 @@ components:
       type: object
       properties:
         id:
-          type: int
+          type: integer
           description: Sequenced entry identifier
         type:
           type: string
@@ -858,10 +851,10 @@ components:
           type: string
           description: Optional message for progress step
         percent:
-          type: int
+          type: integer
           description: Optional percent for step
-          minValue: 0
-          maxValue: 100
+          minimum: 0
+          maximum: 100
       required:
         - id
         - type
@@ -960,7 +953,7 @@ components:
         - ready
 
   responses:
-    default:
+    error:
       description: An internal error occurred
       content:
         application/json:
@@ -1017,18 +1010,24 @@ components:
         type: string
 
     remoteParameters:
-      name: titan-remote-request
+      name: titan-remote-parameters
+      description: Remote-specific parameters
+      required: true
       in: header
       schema:
         $ref: "#/components/schemas/remoteParameters"
 
-    repositoryQuery:
-      name: repository
+    tagQuery:
+      name: tag
+      description: Tags (name or name=value) to search for
       in: query
       schema:
-        type: string
+        type: array
+        items:
+          type: string
     metadataOnlyQuery:
       name: metadataOnly
+      description: Transfer only tag metadata
       in: query
       schema:
         type: boolean

--- a/server/src/endtoend-test/kotlin/io/titandata/docker/DockerVolumeApi.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/docker/DockerVolumeApi.kt
@@ -11,7 +11,6 @@ import io.titandata.client.infrastructure.RequestMethod
 import io.titandata.client.infrastructure.ResponseType
 import io.titandata.client.infrastructure.ServerException
 import io.titandata.client.infrastructure.Success
-import io.titandata.models.docker.PluginDescription
 import io.titandata.models.docker.DockerVolumeCapabilitiesResponse
 import io.titandata.models.docker.DockerVolumeCreateRequest
 import io.titandata.models.docker.DockerVolumeGetResponse
@@ -20,6 +19,7 @@ import io.titandata.models.docker.DockerVolumeMountRequest
 import io.titandata.models.docker.DockerVolumePathResponse
 import io.titandata.models.docker.DockerVolumeRequest
 import io.titandata.models.docker.DockerVolumeResponse
+import io.titandata.models.docker.PluginDescription
 
 class DockerVolumeApi(basePath: String = "http://localhost:5001") : ApiClient(basePath) {
 

--- a/server/src/endtoend-test/kotlin/io/titandata/docker/DockerVolumeApi.kt
+++ b/server/src/endtoend-test/kotlin/io/titandata/docker/DockerVolumeApi.kt
@@ -11,7 +11,7 @@ import io.titandata.client.infrastructure.RequestMethod
 import io.titandata.client.infrastructure.ResponseType
 import io.titandata.client.infrastructure.ServerException
 import io.titandata.client.infrastructure.Success
-import io.titandata.models.PluginDescription
+import io.titandata.models.docker.PluginDescription
 import io.titandata.models.docker.DockerVolumeCapabilitiesResponse
 import io.titandata.models.docker.DockerVolumeCreateRequest
 import io.titandata.models.docker.DockerVolumeGetResponse

--- a/server/src/main/kotlin/io/titandata/apis/DockerVolumesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/DockerVolumesApi.kt
@@ -11,7 +11,6 @@ import io.ktor.routing.Route
 import io.ktor.routing.post
 import io.ktor.routing.route
 import io.titandata.ServiceLocator
-import io.titandata.models.docker.PluginDescription
 import io.titandata.models.Volume
 import io.titandata.models.docker.DockerVolume
 import io.titandata.models.docker.DockerVolumeCapabilities
@@ -23,6 +22,7 @@ import io.titandata.models.docker.DockerVolumeMountRequest
 import io.titandata.models.docker.DockerVolumePathResponse
 import io.titandata.models.docker.DockerVolumeRequest
 import io.titandata.models.docker.DockerVolumeResponse
+import io.titandata.models.docker.PluginDescription
 
 fun Route.DockerVolumeApi(services: ServiceLocator) {
 

--- a/server/src/main/kotlin/io/titandata/apis/DockerVolumesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/DockerVolumesApi.kt
@@ -11,7 +11,7 @@ import io.ktor.routing.Route
 import io.ktor.routing.post
 import io.ktor.routing.route
 import io.titandata.ServiceLocator
-import io.titandata.models.PluginDescription
+import io.titandata.models.docker.PluginDescription
 import io.titandata.models.Volume
 import io.titandata.models.docker.DockerVolume
 import io.titandata.models.docker.DockerVolumeCapabilities

--- a/server/src/main/kotlin/io/titandata/apis/OperationsApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/OperationsApi.kt
@@ -57,7 +57,7 @@ fun Route.OperationsApi(services: ServiceLocator) {
             } else {
                 false
             }
-            call.respond(services.operations.startPull(repo, remote, commitId, params, metadataOnly))
+            call.respond(HttpStatusCode.Created, services.operations.startPull(repo, remote, commitId, params, metadataOnly))
         }
     }
 
@@ -72,7 +72,7 @@ fun Route.OperationsApi(services: ServiceLocator) {
             } else {
                 false
             }
-            call.respond(services.operations.startPush(repo, remote, commitId, params, metadataOnly))
+            call.respond(HttpStatusCode.Created, services.operations.startPush(repo, remote, commitId, params, metadataOnly))
         }
     }
 }

--- a/server/src/main/kotlin/io/titandata/apis/VolumesApi.kt
+++ b/server/src/main/kotlin/io/titandata/apis/VolumesApi.kt
@@ -60,7 +60,7 @@ fun Route.VolumesApi(services: ServiceLocator) {
             val repo = getRepoName(call)
             val volumeName = getVolumeName(call)
             services.volumes.activateVolume(repo, volumeName)
-            call.respond(HttpStatusCode.OK)
+            call.respond(HttpStatusCode.NoContent)
         }
     }
 
@@ -69,7 +69,7 @@ fun Route.VolumesApi(services: ServiceLocator) {
             val repo = getRepoName(call)
             val volumeName = getVolumeName(call)
             services.volumes.deactivateVolume(repo, volumeName)
-            call.respond(HttpStatusCode.OK)
+            call.respond(HttpStatusCode.NoContent)
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

We used to have an openapi definition for titan-server, but moved away from it because (a) we were doing weird things with inheritance and the docker volume api and (b) the kotlin client generation was pretty sub-par. Now that we've addressed (a), and are looking at moving to golang, it would be nicer if we could go back to a standard openapi definition with generated clients.

This adds an openapi definition file, and makes a few adjustments to HTTP codes / etc that I noticed while implementing it. It has been validated with the openapi validator, but there's no way to know it truly works until we start using it.

## Testing

Tested with swagger editor, viewed resulting docs, manually reviewed against server API implementation.
