### PR TITLE
fix tests for new HTTP status codes

### DIFF
--- a/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/OperationsApiTest.kt
@@ -255,7 +255,7 @@ class OperationsApiTest : StringSpec() {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody("{\"provider\":\"nop\",\"properties\":{}}")
             }
-            result.response.status() shouldBe HttpStatusCode.OK
+            result.response.status() shouldBe HttpStatusCode.Created
             val operation = gson.fromJson(result.response.content, Operation::class.java)
 
             operation.commitId shouldBe "commit"
@@ -271,7 +271,7 @@ class OperationsApiTest : StringSpec() {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody("{\"provider\":\"nop\",\"properties\":{}}")
             }
-            result.response.status() shouldBe HttpStatusCode.OK
+            result.response.status() shouldBe HttpStatusCode.Created
             val operation = gson.fromJson(result.response.content, Operation::class.java)
 
             operation.commitId shouldBe "commit"


### PR DESCRIPTION
## Issues Addressed

Fixes #101 

## Proposed Changes

While doing some OpenAPI documentation, I fixed the status codes for push/pull as they actually create operations (and hence should be 201). But I forgot to run the integration tests.

## Testing

Ran integration tests.