### PR TITLE
list volumes of non-existent repo should return 404

### DIFF
--- a/server/src/integration-test/kotlin/io/titandata/VolumesApiTest.kt
+++ b/server/src/integration-test/kotlin/io/titandata/VolumesApiTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata
+
+import io.kotlintest.Spec
+import io.kotlintest.TestCase
+import io.kotlintest.TestCaseOrder
+import io.kotlintest.TestResult
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.TestApplicationEngine
+import io.ktor.server.testing.contentType
+import io.ktor.server.testing.createTestEnvironment
+import io.ktor.server.testing.handleRequest
+import io.ktor.util.KtorExperimentalAPI
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.OverrideMockKs
+import io.mockk.mockk
+import io.titandata.context.docker.DockerZfsContext
+import io.titandata.models.Repository
+import java.util.concurrent.TimeUnit
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@UseExperimental(KtorExperimentalAPI::class)
+class VolumesApiTest : StringSpec() {
+
+    lateinit var vs: String
+
+    @MockK
+    var context = DockerZfsContext(mapOf("pool" to "test"))
+
+    @InjectMockKs
+    @OverrideMockKs
+    var services = ServiceLocator(mockk())
+
+    var engine = TestApplicationEngine(createTestEnvironment())
+
+    override fun beforeSpec(spec: Spec) {
+        with(engine) {
+            start()
+            services.metadata.init()
+            application.mainProvider(services)
+        }
+    }
+
+    override fun afterSpec(spec: Spec) {
+        engine.stop(0L, 0L, TimeUnit.MILLISECONDS)
+    }
+
+    override fun beforeTest(testCase: TestCase) {
+        services.metadata.clear()
+        vs = transaction {
+            services.metadata.createRepository(Repository(name = "foo", properties = emptyMap()))
+            services.metadata.createVolumeSet("foo", null, true)
+        }
+        return MockKAnnotations.init(this)
+    }
+
+    override fun afterTest(testCase: TestCase, result: TestResult) {
+        clearAllMocks()
+    }
+
+    override fun testCaseOrder() = TestCaseOrder.Random
+
+    init {
+        "list volumes succeeds" {
+            with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/foo/volumes")) {
+                response.status() shouldBe HttpStatusCode.OK
+                response.contentType().toString() shouldBe "application/json; charset=UTF-8"
+                response.content shouldBe "[]"
+            }
+        }
+
+        "list volumes for non-existent repo fails" {
+            with(engine.handleRequest(HttpMethod.Get, "/v1/repositories/bar/volumes")) {
+                response.status() shouldBe HttpStatusCode.NotFound
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
+++ b/server/src/main/kotlin/io/titandata/orchestrator/VolumeOrchestrator.kt
@@ -82,6 +82,7 @@ class VolumeOrchestrator(val services: ServiceLocator) {
     }
 
     fun listVolumes(repo: String): List<Volume> {
+        services.repositories.getRepository(repo)
         return transaction {
             val vs = services.metadata.getActiveVolumeSet(repo)
             services.metadata.listVolumes(vs)


### PR DESCRIPTION
## Proposed Changes

Currently, if you attempt to list volumes of a non-existent repo, you get a null pointer exception. Other volume methods will do a `getRepository()`call  to make sure the repository exists and we get a nice exception (and therefore 404 error) if it doesn't.

## Testing

Added new integration tests that failed on the old code and now works on the new. re-ran all tests. I did not attempt to build out a complete volumes API integration test suite as a result of this change.