### PR TITLE
fix properties typo in openapi spec

### DIFF
--- a/openapi/titan.yml
+++ b/openapi/titan.yml
@@ -873,7 +873,7 @@ components:
       required:
         - provider
         - name
-        - propertiers
+        - properties
     remoteParameters:
       type: object
       properties:
@@ -885,7 +885,7 @@ components:
           description: Provider-specific remote properties
       required:
         - provider
-        - propertiers
+        - properties
     repository:
       type: object
       properties:
@@ -894,10 +894,10 @@ components:
           description: Repository name
         properties:
           type: object
-          description: Client-specific propertiers
+          description: Client-specific properties
       required:
         - name
-        - propertiers
+        - properties
     repositoryStatus:
       type: object
       properties:


### PR DESCRIPTION
## Proposed Changes

There was a typo of "propertiers" that was breaking titan-client-go.

## Testing

Regenerated client and made sure `omitempty` was not present.