### PR TITLE
getCommitStatus should be GET

### DIFF
--- a/openapi/titan.yml
+++ b/openapi/titan.yml
@@ -387,7 +387,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/repositoryName"
       - $ref: "#/components/parameters/commitId"
-    post:
+    get:
       summary: Get commit status
       operationId: getCommitStatus
       tags:


### PR DESCRIPTION
## Proposed Changes

This mirrors a corresponding fix in the `titan-go-client` `titan.yml`, where we were incorrectly declaring `getCommitStatus()` as POST, not GET.

