### PR TITLE
big update to zfs 2.1.5 and ubuntu:focal

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
 }
 
 jacoco {
-    toolVersion = "0.8.6"
+    toolVersion = "0.8.7"
 }
 
 application {

--- a/server/docker/server.Dockerfile
+++ b/server/docker/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 ################################################
 # Ubuntu repository configuration
@@ -38,7 +38,7 @@ RUN apt-get -y install vim rsync sshpass jq
 RUN apt-get -y install openjdk-11-jre-headless
 RUN apt-get -y install zfsutils-linux
 RUN apt-get -y install lsof
-RUN apt-get -y install docker-ce
+RUN apt-get -y install docker.io
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata
 RUN apt-get -y install postgresql-12 postgresql-client-12
 

--- a/server/gradle/docker.gradle.kts
+++ b/server/gradle/docker.gradle.kts
@@ -3,10 +3,22 @@ val imageName = when(project.hasProperty("serverImageName")) {
     false -> "titandata/titan"
 }
 
+val titanVersion = when(project.hasProperty("titanVersion")) {
+    true -> project.property("titanVersion")
+    false -> "latest"
+}
+
 var buildDockerServer = tasks.register<Exec>("buildDockerServer") {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Build docker server image"
-    commandLine("docker", "build", "--no-cache", "-t", "$imageName:latest", "-f", "${project.projectDir}/docker/server.Dockerfile", "${project.projectDir}")
+    commandLine("docker", "build", "--no-cache", "-t", "$imageName:$titanVersion", "-f", "${project.projectDir}/docker/server.Dockerfile", "${project.projectDir}")
+    mustRunAfter(tasks.named("shadowJar"))
+}
+
+var publishDockerServer = tasks.register<Exec>("publishDockerServer") {
+    group = LifecycleBasePlugin.BUILD_GROUP
+    description = "Build and publish docker server image"
+    commandLine("docker", "buildx", "build", "--platform", "linux/amd64,linux/arm64", "--push", "--no-cache", "-t", "$imageName:$titanVersion", "-f", "${project.projectDir}/docker/server.Dockerfile", "${project.projectDir}")
     mustRunAfter(tasks.named("shadowJar"))
 }
 
@@ -14,7 +26,7 @@ var buildDockerServer = tasks.register<Exec>("buildDockerServer") {
 var rebuildDockerServer = tasks.register<Exec>("rebuildDockerServer") {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Build docker server image"
-    commandLine("docker", "build", "-t", "$imageName:latest", "-f", "${project.projectDir}/docker/server.Dockerfile", "${project.projectDir}")
+    commandLine("docker", "build", "-t", "$imageName:$titanVersion", "-f", "${project.projectDir}/docker/server.Dockerfile", "${project.projectDir}")
     mustRunAfter(tasks.named("shadowJar"))
 }
 

--- a/server/src/scripts/get-userland
+++ b/server/src/scripts/get-userland
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright The Titan Project Contributors.
 #
@@ -18,5 +18,5 @@ download_url=$(get_asset_url zfs-$zfs_version-userland.tar.gz)
 [[ -z $download_url ]] && log_error "failed to find asset zfs-$zfs_version-userland.tar.gz"
 
 curl -fssL $download_url > /var/tmp/userland.tar.gz
-cd / && tar -xvzf /var/tmp/userland.tar.gz
+cd / && tar --skip-old-files -xvzf /var/tmp/userland.tar.gz
 rm /var/tmp/userland.tar.gz

--- a/server/src/scripts/kubernetesOperation
+++ b/server/src/scripts/kubernetesOperation
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright The Titan Project Contributors.
 #

--- a/server/src/scripts/launch
+++ b/server/src/scripts/launch
@@ -86,7 +86,7 @@ uname=$(uname -r)
 if [[ $uname == *"linuxkit"* ]]; then
     echo "Installing ZFS for Docker Desktop ($uname)"
     tag="${uname%%-*}"
-    docker run --rm --privileged titandata/docker-desktop-zfs-kernel:$tag
+    docker run --rm --privileged titandata/docker-desktop-zfs-kernel:$tag-$(get_zfs_build_version)
 fi
 
 #

--- a/server/src/scripts/run
+++ b/server/src/scripts/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright The Titan Project Contributors.
 #

--- a/server/src/scripts/teardown
+++ b/server/src/scripts/teardown
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright The Titan Project Contributors.
 #

--- a/server/src/scripts/titan.sh
+++ b/server/src/scripts/titan.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright The Titan Project Contributors.
 #

--- a/server/src/scripts/util.sh
+++ b/server/src/scripts/util.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Copyright The Titan Project Contributors.
 #

--- a/server/src/scripts/zfs.sh
+++ b/server/src/scripts/zfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright The Titan Project Contributors.
 #
@@ -13,7 +13,7 @@ min_zfs_version=2.0.0
 # Return the tag in the ZFS repository we should be using to build ZFS binaries.
 #
 function get_zfs_build_version() {
-  echo "2.0.6"
+  echo "2.1.5"
 }
 
 #


### PR DESCRIPTION
ZFS build version updated to 2.1.5 while the min zfs version remains at 2.0.0. E2E testing indicates compatibility because no other code needed to be updated between any 2.0 releases and 2.1.5. 

The underlying docker image for titan server has been update to be ubuntu:focal (20.04). This is the same version used by the nightly zfs-releases job to keep github actions runner up to date. There are some issues when compiling with ubuntu:22.04 because it ships with a newer version of openssl, so staying on ubuntu:20.04 for now as it also runs on 22.04. 